### PR TITLE
Fix announcement banner width

### DIFF
--- a/theme/custom.css
+++ b/theme/custom.css
@@ -94,14 +94,12 @@
 }
 
 .announcement-stripe {
+    width: auto;
     background-color: #5e1118;
     font-weight: bold;
     color: rgba(255, 255, 255, 0.8);
     padding: 10px;
-    position: fixed;
     text-align: center;
-    margin: 0 auto;
-    width: 100%;
     z-index: 1000;
     top: 0;
     left: 0;
@@ -118,9 +116,7 @@
 }
 
 /* Add padding to the page wrapper to prevent content from being hidden behind the fixed banner */
-.page-wrapper {
-    padding-top: 40px;
-}
+
 
 /* Footer styles */
 #page-footer {

--- a/theme/toc/pagetoc.css
+++ b/theme/toc/pagetoc.css
@@ -6,7 +6,7 @@
 */
 
 :root {
-    --sidebar-width: 270px; /* or whatever width you want */
+    --sidebar-width: 270px;
     --sidebar-resize-indicator-width: 0px;
     --toc-width: 270px;
     --center-content-toc-shift: calc(-1 * var(--toc-width) / 2);

--- a/theme/toc/pagetoc.css
+++ b/theme/toc/pagetoc.css
@@ -6,6 +6,8 @@
 */
 
 :root {
+    --sidebar-width: 270px; /* or whatever width you want */
+    --sidebar-resize-indicator-width: 0px;
     --toc-width: 270px;
     --center-content-toc-shift: calc(-1 * var(--toc-width) / 2);
     --toc-bg-h1: rgba(114, 137, 218, 0.05);

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -298,3 +298,8 @@ Consensys
 Blockthreat
 Vishing
 Matta
+mattaereal
+touchpoint
+unencrypted
+uncollateralized
+preprocessor


### PR DESCRIPTION
The banner below is how it has looked like for me for a while now, and well I figured we should fix this before the announcement of Frameworks.
<br>
<img width="1508" alt="Screenshot page" src="https://github.com/user-attachments/assets/5cc20ec4-2966-4476-bef3-2538d5c880a5" />
<br>
I've changed the width to auto, and fixed a subtle little rendering issue that was causing there to be 30px of space between the sidebar and the content. It now looks like this on iphone 11, ipad, and desktop.
<br>
<img width="480" alt="Screenshot iphone" src="https://github.com/user-attachments/assets/e4781114-e596-42d8-a300-658beb43ba7f" />
<br>
<img width="999" alt="Screenshot ipad" src="https://github.com/user-attachments/assets/777259b9-da59-45f9-b9d6-aca106a897d5" />
<br>
<img width="1512" alt="Screenshot desktop" src="https://github.com/user-attachments/assets/9ada259f-43a2-4271-82d9-937e62a43fcb" />