### PR TITLE
feat: updating linting, devcontainer, and local development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,39 @@
+# Base debian build with VS Code devcontainer base
+FROM mcr.microsoft.com/vscode/devcontainers/base:debian
+
+# Update packages and install only essential dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    pkg-config \
+    libssl-dev \
+    aspell \
+    aspell-en \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Switch to vscode user
+USER vscode
+
+# Install Rust and Cargo for vscode user
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/home/vscode/.cargo/bin:${PATH}"
+
+# Install mdBook and mdbook-admonish
+RUN /home/vscode/.cargo/bin/cargo install mdbook mdbook-admonish
+
+# Install just command runner
+RUN /home/vscode/.cargo/bin/cargo install just
+
+# Copy markdownlint-cli2 from its Docker image (need root for this)
+USER root
+COPY --from=davidanson/markdownlint-cli2:latest /usr/local/bin/markdownlint-cli2 /usr/local/bin/markdownlint-cli2
+RUN chmod +x /usr/local/bin/markdownlint-cli2
+
+# Switch back to vscode user
+USER vscode
+
+# Set working directory
+WORKDIR /workspace
+
+# Ensure cargo is in PATH for vscode user
+RUN echo 'export PATH="/home/vscode/.cargo/bin:$PATH"' >> /home/vscode/.bashrc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+{
+    "name": "Security Frameworks DevContainer",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "features": {},
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "yzhang.markdown-all-in-one",
+                "rust-lang.rust-analyzer",
+                "tamasfe.even-better-toml"
+            ],
+            "settings": {
+                "terminal.integrated.defaultProfile.linux": "bash",
+                "terminal.integrated.profiles.linux": {
+                    "bash": {
+                        "path": "/bin/bash"
+                    }
+                }
+            }
+        }
+    },
+    "forwardPorts": [
+        3000
+    ],
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
+    "workspaceFolder": "/workspace",
+    "postCreateCommand": "echo 'DevContainer ready! Run \"just serve\" to start the mdBook server.'"
+}

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,17 +12,7 @@ Thank you for contributing to the Security Frameworks! Before you open a PR, mak
 <!--
 ℹ️ Checking for typos locally
 1. Install [aspell](https://www.gnu.org/software/aspell/) for your platform.
-2. Navigate to the project root and run:
-```
- for f in **/*.md ; do echo $f ; aspell --lang=en_US --mode=markdown --home-dir=. --personal=wordlist.txt --ignore-case=true --camel-case list  < $f | sort | uniq -c ; done
-```
-
-ℹ️ Fixing typos
-1. Fix typos: Open the relevant files and fix any identified typos.
-2. Update wordlist: If a flagged word is actually a project-specific term add it to `wordlist.txt` in the project root.
-   Each word should be listed on a separate line.
- * 🚧 Remember:
-    * When adding new words it must NOT have any spaces or special characters within or around it.
-    * \`wordlist\` is NOT case sensitive.
-    * Use backticks to quote code variables so as to not bloat the \`wordlist\`.
+2. Install [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2)
+3. Install [just](https://github.com/casey/just)
+4. Run `just lint`
 -->

--- a/.github/workflows/md-lint.yaml
+++ b/.github/workflows/md-lint.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: DavidAnson/markdownlint-cli2-action@v15
+    - uses: DavidAnson/markdownlint-cli2-action@v20
       continue-on-error: true
       with:
         globs: |

--- a/README.md
+++ b/README.md
@@ -4,12 +4,18 @@ Official repository to the Security Frameworks by SEAL. This repository contains
 
 If you want to know more about the frameworks or take a peek at the live book go to the following branches: [Main](frameworks.securityalliance.org), [Development](frameworks.securityalliance.dev).
 
+# Prerequisites
+
+- [Rust/cargo](https://www.rust-lang.org/tools/install) (For building/serving mdBook)
+- [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) (For linting markdown files)
+- [GNU Aspell](https://sourceforge.net/projects/aspell/) (For spell checking)
+- [just](https://github.com/casey/just) (For running commands)
+
 ## Quick installation and local setup
 
 1. `gh repo clone security-alliance/frameworks`
 2. `git checkout develop`
-3. `cargo install mdbook mdbook-admonish`
-4. `./serve.sh`
+3. `just serve`
 
 ## Collaboration
 
@@ -38,8 +44,9 @@ Before contributing, check if there's a [Steward](https://frameworks.securityall
 The naming convention is `fw_framework_name`, for example `fw_opsec`, `fw_community_mgmt`. Ideally, you'll fork these framework-specific branches, as they typically have more updated information than what's available in the develop branch.
 
 After making your changes:
-1. Submit a PR to the framework-specific branch and let the steward know
-2. After reviews, a PR can be submitted from the framework branch to the develop branch
+1. Run the linting command `just lint`
+2. Submit a PR to the framework-specific branch and let the steward know
+3. After reviews, a PR can be submitted from the framework branch to the develop branch
 
 If there's no specific branch created, that framework is still "headless," which means you can become its steward! See more in the [Stewards](src/contribute/stewards.md) section.
 
@@ -72,7 +79,7 @@ tags:
 
 8. If adding significant content, add attribution using the contributors system (see [using-contributors.md](src/config/using-contributors.md)).
 9. Make sure your changes don't break anything by testing it in the local setup:
-   `./serve.sh`
+   `just serve`
 10. Commit your changes:
     `git add .`
 11. Commit the changes with a descriptive message:
@@ -92,5 +99,3 @@ Editors merge PRs and push suggestions to the main branch which will be reflecte
 2. `git fetch origin develop`
 3. `git merge origin/develop`
 4. Manually merge files, solve conflicts and add a description.
-
-- Using the `serve.sh` script instead of mdBook `serve` command is needed to be able to see properly the local deployment.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,20 @@
+# Default recipe to display help information
+default:
+    @just --list
+
+# Install dependencies
+install:
+    cargo install mdbook mdbook-admonish
+
+# Serve the book locally with hot reload
+serve: install
+    mdbook serve
+
+# Run all linting checks
+lint:
+    @echo "Running spell check..."
+    @for f in **/*.md ; do echo $f ; aspell --lang=en_US --mode=markdown --home-dir=. --personal=wordlist.txt --ignore-case=true --camel-case list  < $f | sort | uniq -c ; done
+    @echo "Spell check complete!"
+    @echo ""
+    @echo "Running markdownlint..."
+    markdownlint-cli2 ./src/*.md

--- a/serve.sh
+++ b/serve.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-if ! test -e theme/index.hbs; then
-    echo "Run serve.sh inside root folder."
-    exit 1
-fi
-
-# Run mdbook serve
-mdbook serve

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -4,7 +4,7 @@
 - [How to Navigate the Website](./intro/how-to-navigate-the-website.md)
 - [Overview of Each Framework](./intro/overview-of-each-framework.md)
 
-# Frameworks
+## Frameworks
 
 - [Community Management](./community-management/README.md)
   - [Discord](./community-management/discord.md)
@@ -27,19 +27,19 @@
   - [While Traveling](./opsec/travel/README.md)
     - [Guide](./opsec/travel/guide.md)
     - [TL;DR](./opsec/travel/tldr.md)
-  - [Governance & Program Management]()
-  - [Control Domains]()
-  - [Lifecycle]()
-  - [Monitoring & Detection]()
-  - [Incident Response & Recovery]()
-  - [Continuous Improvement & Metrics]()
-  - [Integration & Mapping to Other Frameworks]()
-  - [Appendices]()
+  - [Governance & Program Management](./opsec/governance-program-management.md)
+  - [Control Domains](./opsec/control-domains.md)
+  - [Lifecycle](./opsec/lifecycle.md)
+  - [Monitoring & Detection](./opsec/monitoring-detection.md)
+  - [Incident Response & Recovery](./opsec/incident-response-recovery.md)
+  - [Continuous Improvement & Metrics](./opsec/continuous-improvement-metrics.md)
+  - [Integration & Mapping to Other Frameworks](./opsec/integration-mapping.md)
+  - [Appendices](./opsec/appendices.md)
 - [Wallet Security](./wallet-security/README.md)
   - [Custodial vs Non-Custodial](./wallet-security/custodial-vs-non-custodial.md)
   - [Cold vs Hot Wallet](./wallet-security/cold-vs-hot-wallet.md)
   - [Wallets For Beginners & Small Balances](./wallet-security/for-beginners-&-small-balances.md)
-  - [Wallets For Intermediates & Medium Funds ](./wallet-security/intermediates-&-medium-funds.md)
+  - [Wallets For Intermediates & Medium Funds](./wallet-security/intermediates-&-medium-funds.md)
   - [Multisig Wallets For Advanced Users & High Funds](./wallet-security/secure-multisig-best-practices.md)
   - [Account Abstraction Wallets](./wallet-security/account-abstraction.md)
   - [Signing & Verification](./wallet-security/signing-verification.md)
@@ -145,8 +145,7 @@
   - [Partition Encryption](./encryption/partition-encryption.md)
   - [Volume Encryption](./encryption/volume-encryption.md)
 
-
-# About this
+## About this
 
 - [What It Is](./intro/what-is-it.md)
 - [What It Isn't](./intro/what-it-isnt.md)
@@ -154,12 +153,12 @@
   - [Contributors](./contribute/contributors.md)
   - [Stewards](./contribute/stewards.md)
 
-# Practical Guides
+## Practical Guides
 
 <!-- - Step-by-step implementation — can be omitted
 - Case studies — an idea -->
 
-# Additional Resources
+## Additional Resources
 
 <!-- - Tools and software recommendations
 - Further reading and references -->

--- a/src/contribute/contributing.md
+++ b/src/contribute/contributing.md
@@ -36,7 +36,7 @@ To understand how to contribute, follow this process:
 
 ### Local Development with mdBook
 
-If you want to locally experiment with mdBook, you can run `./serve.sh` which will automatically run mdBook when installed, serving the project for local viewing.
+If you want to locally experiment with mdBook, you can run `just serve` which will automatically run mdBook when installed, serving the project for local viewing.
 
 ### Handling the Summary
 


### PR DESCRIPTION
## Frameworks PR Checklist

We should be able to lint locally so we don't have to wait for github to give us errors.

I ran into some git hell so I just make a new PR, sorry about that. This is a continuation from: https://github.com/security-alliance/frameworks/pull/171

- [x] Added documentation for running the linting locally
- [x] If you need feedback for your content from wider community, share the PR in our Discord
- [x] Review changes to ensure there are no typos, see instructions below

BTW, in a larger PR, we should change `src/*.md` to `src/**/*.md`.

Right now we are _only_ linting `SUMMARY.md`