### PR TITLE
fix: CONTRIBUTING.md + contributing.mdx

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,7 +231,7 @@ Example of a category with multiple pages:
   collapsed: false,
   dev: true,                // Indicates this category is in development
   items: [
-    { text: 'Overview', link: '/monitoring/README', dev: true },  // Example page
+    { text: 'Overview', link: '/monitoring/README', dev: true },  // Indicates this page is in development
     { text: 'Guidelines', link: '/monitoring/guidelines', dev: true },
     { text: 'Thresholds', link: '/monitoring/thresholds', dev: true },
   ]
@@ -240,6 +240,30 @@ Example of a category with multiple pages:
 ```
 
 This ensures that new content appears correctly in the site’s navigation for readers on the `.dev` site while staying hidden from the stable `.org` site until ready.
+
+### 4. Error Checking
+
+Before pushing changes, always make sure your build works without errors:
+
+- Run 
+    ```bash
+    npx just build
+    ```
+    or
+    ```bash
+    npm run docs:build
+    ```
+- Preview the updated content locally with:
+    ```bash
+    npm run docs:preview
+    ```
+    or
+    ```bash
+    npx just preview
+    ```
+    (The preview runs at port `4173` by default.)
+    
+This helps catch build or formatting issues early so reviewers see clean contributions.
 
 ## Style guide
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ All contributions should follow this workflow:
 8. Don't forget to add yourself to the YAML header of the file you're modifying, given that is the way we provide attribution. You should also create your profile inside the contributors list, at `docs/config/contributors.json`.
 9. Periodically, reviewed content from `develop` is merged into `main` for the stable site.
 
-If you’re interested in a framework that doesn’t currently have an active steward, you can **become one yourself**. See the [Stewards guide](/docs/pages/contribute/stewards) for details on responsibilities and how to get started.
+If you’re interested in a framework that doesn’t currently have an active steward, you can **become one yourself**. See the [Stewards guide](/docs/pages/contribute/stewards.mdx) for details on responsibilities and how to get started.
 
 **⚠️ Please sign and verify all commits.** (If you have unsigned commits, follow the “Fixing Unsigned Commits” section below to update them)
 
@@ -136,16 +136,12 @@ If you accidentally made unsigned commits in your fork, you’ll need to rewrite
 git rebase -i HEAD~N
 ```
 
----
-
 ## 2. Mark commits to fix
 
 In the editor that opens:
 
 - Change `pick` → `edit` for each unsigned commit.
 - Save and exit.
-
----
 
 ## 3. Re-sign each commit
 
@@ -158,8 +154,6 @@ git rebase --continue
 
 Repeat until all commits are re-signed.
 
----
-
 ## 4. Push your changes
 
 Since history was rewritten, you need to **force-push**:
@@ -167,8 +161,6 @@ Since history was rewritten, you need to **force-push**:
 ```bash
 git push --force
 ```
-
----
 
 ## 5. Verify
 
@@ -227,11 +219,11 @@ Example of a category with multiple pages:
 
 ```tsx
 {
-  text: 'Monitoring',       // Category name visible in the sidebar
+  text: 'Monitoring', // Category name visible in the sidebar
   collapsed: false,
-  dev: true,                // Indicates this category is in development
+  dev: true, // Indicates this category is in development
   items: [
-    { text: 'Overview', link: '/monitoring/README', dev: true },  // Indicates this page is in development
+    { text: 'Overview', link: '/monitoring/README', dev: true }, // Indicates this page is in development
     { text: 'Guidelines', link: '/monitoring/guidelines', dev: true },
     { text: 'Thresholds', link: '/monitoring/thresholds', dev: true },
   ]
@@ -245,24 +237,9 @@ This ensures that new content appears correctly in the site’s navigation for r
 
 Before pushing changes, always make sure your build works without errors:
 
-- Run 
-    ```bash
-    npx just build
-    ```
-    or
-    ```bash
-    npm run docs:build
-    ```
-- Preview the updated content locally with:
-    ```bash
-    npm run docs:preview
-    ```
-    or
-    ```bash
-    npx just preview
-    ```
-    (The preview runs at port `4173` by default.)
-    
+- Run `npx just build` or `npm run docs:build`
+- Preview the updated content locally at port `4173` with: `npx just preview` or `npm run docs:preview`
+
 This helps catch build or formatting issues early so reviewers see clean contributions.
 
 ## Style guide
@@ -322,7 +299,7 @@ pie title What Voldemort doesn't have?
 
 Pages with minimal content which need more work to cover the topic need to include a notice:
 
-> ⚠️ This article is a [stub](https://en.wikipedia.org/wiki/Wikipedia:Stub), help the framework by [contributing](/contribute/contributing) and expanding it.
+> ⚠️ This article is a [stub](https://en.wikipedia.org/wiki/Wikipedia:Stub), help the framework by [contributing](/docs/pages/contribute/contributing.mdx) and expanding it.
 
 ## Anything else?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,7 @@ All contributions should follow this workflow:
 8. Don't forget to add yourself to the YAML header of the file you're modifying, given that is the way we provide attribution. You should also create your profile inside the contributors list, at `docs/config/contributors.json`.
 9. Periodically, reviewed content from `develop` is merged into `main` for the stable site.
 
-If you’re interested in a framework that doesn’t currently have an active steward, you can **become one yourself**. See the [Stewards guide](/docs/pages/contribute
-/stewards) for details on responsibilities and how to get started.
+If you’re interested in a framework that doesn’t currently have an active steward, you can **become one yourself**. See the [Stewards guide](/docs/pages/contribute/stewards) for details on responsibilities and how to get started.
 
 **⚠️ Please sign and verify all commits.** (If you have unsigned commits, follow the “Fixing Unsigned Commits” section below to update them)
 
@@ -120,6 +119,7 @@ If you prefer to install dependencies locally on your machine:
     ```bash
     npx just serve
     ```
+5. Once the server is running, access the site at port ```5173```
 
 **(Optional) Authenticate with GitHub CLI**: The GitHub CLI (`gh`) is already preinstalled in the devcontainer. You can authenticate by running `gh auth login` in the terminal, making it easy to interact with GitHub directly from your development environment.
 

--- a/docs/pages/contribute/contributing.mdx
+++ b/docs/pages/contribute/contributing.mdx
@@ -38,7 +38,7 @@ When contributing, **please submit your Pull Requests to the development branch*
 
 ## Ways to contribute
 
-1. **Check for a framework-specific branch**: First, check if there's a [Steward](./stewards) for the specific framework you're interested in, and reach out. We usually have separate branches pre-develop for frameworks with stewards. Their naming convention is `fw_framework_name`, for example `fw_opsec`, `fw_community_mgmt` - the naming should be intuitive. For more information about stewards and their responsibilities, see the [Stewards](./stewards) section.
+1. **Check for a framework-specific branch**: First, check if there's a [Steward](/contribute/stewards) for the specific framework you're interested in, and reach out. We usually have separate branches pre-develop for frameworks with stewards. Their naming convention is `fw_framework_name`, for example `fw_opsec`, `fw_community_mgmt` - the naming should be intuitive. For more information about stewards and their responsibilities, see the [Stewards](/contribute/stewards) section.
 
 ### 1. Quick edits
 
@@ -60,7 +60,7 @@ All contributions should follow this workflow:
 8. Don't forget to add yourself to the YAML header of the file you're modifying, given that is the way we provide attribution. You should also create your profile inside the contributors list, at `docs/config/contributors.json`.
 9. Periodically, reviewed content from `develop` is merged into `main` for the stable site.
 
-If you’re interested in a framework that doesn’t currently have an active steward, you can **become one yourself**. See the [Stewards guide](/docs/pages/contribute/stewards) for details on responsibilities and how to get started.
+If you’re interested in a framework that doesn’t currently have an active steward, you can **become one yourself**. See the [Stewards guide](/contribute/stewards) for details on responsibilities and how to get started.
 
 **⚠️ Please sign and verify all commits.** (If you have unsigned commits, follow the “Fixing Unsigned Commits” section below to update them)
 
@@ -145,16 +145,12 @@ If you accidentally made unsigned commits in your fork, you’ll need to rewrite
 git rebase -i HEAD~N
 ```
 
----
-
 ## 2. Mark commits to fix
 
 In the editor that opens:
 
 - Change `pick` → `edit` for each unsigned commit.
 - Save and exit.
-
----
 
 ## 3. Re-sign each commit
 
@@ -167,8 +163,6 @@ git rebase --continue
 
 Repeat until all commits are re-signed.
 
----
-
 ## 4. Push your changes
 
 Since history was rewritten, you need to **force-push**:
@@ -176,8 +170,6 @@ Since history was rewritten, you need to **force-push**:
 ```bash
 git push --force
 ```
-
----
 
 ## 5. Verify
 
@@ -236,11 +228,11 @@ Example of a category with multiple pages:
 
 ```tsx
 {
-  text: 'Monitoring',       // Category name visible in the sidebar
+  text: 'Monitoring', // Category name visible in the sidebar
   collapsed: false,
-  dev: true,                // Indicates this category is in development
+  dev: true, // Indicates this category is in development
   items: [
-    { text: 'Overview', link: '/monitoring/README', dev: true },  // Indicates this page is in development
+    { text: 'Overview', link: '/monitoring/README', dev: true }, // Indicates this page is in development
     { text: 'Guidelines', link: '/monitoring/guidelines', dev: true },
     { text: 'Thresholds', link: '/monitoring/thresholds', dev: true },
   ]
@@ -254,24 +246,9 @@ This ensures that new content appears correctly in the site’s navigation for r
 
 Before pushing changes, always make sure your build works without errors:
 
-- Run 
-    ```bash
-    npx just build
-    ```
-    or
-    ```bash
-    npm run docs:build
-    ```
-- Preview the updated content locally with:
-    ```bash
-    npm run docs:preview
-    ```
-    or
-    ```bash
-    npx just preview
-    ```
-    (The preview runs at port `4173` by default.)
-    
+- Run `npx just build` or `npm run docs:build`
+- Preview the updated content locally at port `4173` with: `npx just preview` or `npm run docs:preview`
+
 This helps catch build or formatting issues early so reviewers see clean contributions.
 
 ## Style guide

--- a/docs/pages/contribute/contributing.mdx
+++ b/docs/pages/contribute/contributing.mdx
@@ -240,7 +240,7 @@ Example of a category with multiple pages:
   collapsed: false,
   dev: true,                // Indicates this category is in development
   items: [
-    { text: 'Overview', link: '/monitoring/README', dev: true },  // Example page
+    { text: 'Overview', link: '/monitoring/README', dev: true },  // Indicates this page is in development
     { text: 'Guidelines', link: '/monitoring/guidelines', dev: true },
     { text: 'Thresholds', link: '/monitoring/thresholds', dev: true },
   ]
@@ -249,6 +249,30 @@ Example of a category with multiple pages:
 ```
 
 This ensures that new content appears correctly in the site’s navigation for readers on the `.dev` site while staying hidden from the stable `.org` site until ready.
+
+### 4. Error Checking
+
+Before pushing changes, always make sure your build works without errors:
+
+- Run 
+    ```bash
+    npx just build
+    ```
+    or
+    ```bash
+    npm run docs:build
+    ```
+- Preview the updated content locally with:
+    ```bash
+    npm run docs:preview
+    ```
+    or
+    ```bash
+    npx just preview
+    ```
+    (The preview runs at port `4173` by default.)
+    
+This helps catch build or formatting issues early so reviewers see clean contributions.
 
 ## Style guide
 

--- a/docs/pages/contribute/contributing.mdx
+++ b/docs/pages/contribute/contributing.mdx
@@ -60,8 +60,7 @@ All contributions should follow this workflow:
 8. Don't forget to add yourself to the YAML header of the file you're modifying, given that is the way we provide attribution. You should also create your profile inside the contributors list, at `docs/config/contributors.json`.
 9. Periodically, reviewed content from `develop` is merged into `main` for the stable site.
 
-If you’re interested in a framework that doesn’t currently have an active steward, you can **become one yourself**. See the [Stewards guide](/docs/pages/contribute
-/stewards) for details on responsibilities and how to get started.
+If you’re interested in a framework that doesn’t currently have an active steward, you can **become one yourself**. See the [Stewards guide](/docs/pages/contribute/stewards) for details on responsibilities and how to get started.
 
 **⚠️ Please sign and verify all commits.** (If you have unsigned commits, follow the “Fixing Unsigned Commits” section below to update them)
 
@@ -129,6 +128,7 @@ If you prefer to install dependencies locally on your machine:
     ```bash
     npx just serve
     ```
+5. Once the server is running, access the site at port ```5173```
 
 **(Optional) Authenticate with GitHub CLI**: The GitHub CLI (`gh`) is already preinstalled in the devcontainer. You can authenticate by running `gh auth login` in the terminal, making it easy to interact with GitHub directly from your development environment.
 

--- a/docs/pages/contribute/contributing.mdx
+++ b/docs/pages/contribute/contributing.mdx
@@ -38,7 +38,7 @@ When contributing, **please submit your Pull Requests to the development branch*
 
 ## Ways to contribute
 
-1. **Check for a framework-specific branch**: First, check if there's a [Steward](/contribute/stewards) for the specific framework you're interested in, and reach out. We usually have separate branches pre-develop for frameworks with stewards. Their naming convention is `fw_framework_name`, for example `fw_opsec`, `fw_community_mgmt` - the naming should be intuitive. For more information about stewards and their responsibilities, see the [Stewards](/contribute/stewards) section.
+There are several ways to contribute, depending on your preference and the scope of your changes. First, check existing PRs or branches to make sure your work has not been previously ****submitted**.**
 
 ### 1. Quick edits
 


### PR DESCRIPTION
## Frameworks PR Checklist

- Fixed broken link paths so they work both locally and on the website
- Adjusted indentation, corrected typos and synced the two contributing files
- Added a new section to guide contributors on how to test builds and preview their changes before pushing (including commands and ports for local run and preview)

- [ ] Describe your changes, substitute this text with the information
- [ ] If you are touching an existing piece of content, tag current contributors from the attribution list
- [ ] If there is a steward for that framework, ask the steward to review it
- [ ] If you're modifying the general outline, make sure to update it in the `vocs.config.ts` adding the `dev: true` parameter
- [ ] If you need feedback for your content from the wider community, share the PR in our Discord
- [ ] Review changes to ensure there are no typos, see instructions below

<!--
ℹ️ Checking for typos locally
1. Install [aspell](https://www.gnu.org/software/aspell/) for your platform.
2. Install [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2)
3. Install [just](https://github.com/casey/just)
4. Run `npx just lint`
-->
