### PR TITLE
fix: remove duplicate framework from sidebar

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -345,16 +345,6 @@ const config = {
           ]
         },
         {
-          text: 'Monitoring',
-          collapsed: false,
-          dev: true,
-          items: [
-            { text: 'Overview', link: '/monitoring/overview', dev: true },
-            { text: 'Guidelines', link: '/monitoring/guidelines', dev: true },
-            { text: 'Thresholds', link: '/monitoring/thresholds', dev: true },
-          ]
-        },
-        {
           text: 'Encryption',
           collapsed: false,
           dev: true,


### PR DESCRIPTION
## Frameworks PR Checklist

Noticed that the Monitoring frameworks was written twice in the sidebar

- [ ] Describe your changes, substitute this text with the information
- [ ] If you are touching an existing piece of content, tag current contributors from the attribution list
- [ ] If there is a steward for that framework, ask the steward to review it
- [ ] If you're modifying the general outline, make sure to update it in the `vocs.config.ts` adding the `dev: true` parameter
- [ ] If you need feedback for your content from the wider community, share the PR in our Discord
- [ ] Review changes to ensure there are no typos, see instructions below

<!--
ℹ️ Checking for typos locally
1. Install [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2)
2. Install [just](https://github.com/casey/just)
3. Run `npx just lint`
-->
