### PR TITLE
fix: update safe mobile app references and titles

### DIFF
--- a/docs/pages/multisig-for-protocols/backup-signing-and-infrastructure.mdx
+++ b/docs/pages/multisig-for-protocols/backup-signing-and-infrastructure.mdx
@@ -50,11 +50,11 @@ Note: Local/alternative UIs may not be actively maintained. Treat them as emerge
 
 ### Mobile (Safe)
 
-**Safe Android App**
+**Safe Mobile Apps**
 
-- GitHub: https://github.com/safe-global/safe-android
-- App Store: https://apps.apple.com/us/app/safe-wallet/id1515759131
-- Play Store: https://play.google.com/store/apps/details?id=io.gnosis.safe
+- GitHub: https://github.com/safe-global/safe-wallet-monorepo/tree/dev/apps/mobile
+- App Store: https://apps.apple.com/us/app/safe-mobile/id6748754793
+- Play Store: https://play.google.com/store/apps/details?id=global.safe.mobileapp
 
 ## RPC Backup Options
 


### PR DESCRIPTION
The doc was pointing to the old discontinued Safe{Wallet} application & not the current Safe{Mobile}.


## Frameworks PR Checklist

Thank you for contributing to the Security Frameworks! Before you open a PR, make sure to read [information for contributors](https://frameworks.securityalliance.dev/contribute/contributing) and take a look at the following checklist:

- [ ] Describe your changes, substitute this text with the information
- [ ] If you are touching an existing piece of content, tag current contributors from the attribution list
- [ ] If there is a steward for that framework, ask the steward to review it
- [ ] If you're modifying the general outline, make sure to update it in the `vocs.config.ts` adding the `dev: true` parameter
- [ ] If you need feedback for your content from the wider community, share the PR in our Discord
- [ ] Review changes to ensure there are no typos, see instructions below

<!--
ℹ️ Checking for typos locally
1. Install [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2)
2. Install [just](https://github.com/casey/just)
3. Run `npx just lint`
-->
