### PR TITLE
making the vite deadlinks error just a warning

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -15,6 +15,7 @@ const config = {
   ogImageUrl: {
     '/': 'https://frameworks-static.s3.us-east-2.amazonaws.com/images/logo/frameworks-full.png'
   },
+  checkDeadlinks: "warn" as const,
   sidebar: [
     {
       text: 'Introduction',


### PR DESCRIPTION
## Frameworks PR Checklist

Found out vocs makes the deadlinks checking customizable. 
I made it so its always a warning, and not just on dev as, imo, we dont want that when we do the monthly merge on main, the build fails and we have to rush to make it build. 

I think we can have it as a warning per default and just oversee the contributors build logs before merging the PRs or us periodically checking and resolving the warnings

- [ ] Describe your changes, substitute this text with the information
- [ ] If you are touching an existing piece of content, tag current contributors from the attribution list
- [ ] If there is a steward for that framework, ask the steward to review it
- [ ] If you're modifying the general outline, make sure to update it in the `vocs.config.ts` adding the `dev: true` parameter
- [ ] If you need feedback for your content from the wider community, share the PR in our Discord
- [ ] Review changes to ensure there are no typos, see instructions below

<!--
ℹ️ Checking for typos locally
1. Install [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2)
2. Install [just](https://github.com/casey/just)
3. Run `npx just lint`
-->
