### PR TITLE
Add Isaac and Dickson as stewards

### DIFF
--- a/docs/pages/config/contributors.json
+++ b/docs/pages/config/contributors.json
@@ -141,7 +141,7 @@
     "website": "https://skylock.xyz/",
     "company": "SEAL",
     "job_title": "Safe Harbor",
-    "description": "Safe Harbor contributor & Steward of SEAL Certs"
+    "description": "Steward of Safe Harbor & Steward of SEAL Certs"
   },
   "blackbigswan": {
     "slug": "blackbigswan",


### PR DESCRIPTION
- Changed roles for Dickson Wu and Isaac Patka from "contributor" to "steward".
- Enhanced descriptions to reflect their stewardship responsibilities, providing clearer attribution in documentation.

## Frameworks PR Checklist

Thank you for contributing to the Security Frameworks! Before you open a PR, make sure to read [information for contributors](https://frameworks.securityalliance.dev/contribute/contributing) and take a look at the following checklist:

- [x] Describe your changes, substitute this text with the information
- [ ] If you are touching an existing piece of content, tag current contributors from the attribution list
- [ ] If there is a steward for that framework, ask the steward to review it
- [ ] If you're modifying the general outline, make sure to update it in the `vocs.config.ts` adding the `dev: true` parameter
- [ ] If you need feedback for your content from the wider community, share the PR in our Discord
- [x] Review changes to ensure there are no typos, see instructions below

<!--
ℹ️ Checking for typos locally
1. Install [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2)
2. Install [just](https://github.com/casey/just)
3. Run `npx just lint`
-->
