### PR TITLE
adding custom 404 that doesn't redirect

### DIFF
--- a/public/404.css
+++ b/public/404.css
@@ -2,30 +2,30 @@
 
 /* CSS Variables */
 :root {
-    --vocs-404-color_background: rgba(255 255 255 / 100%);
-    --vocs-404-color_text: #4c4c4c;
-    --vocs-404-color_heading: #202020;
-    --vocs-404-color_border: #ececec;
-    --vocs-404-color_textAccent: #0588f0;
-    --vocs-404-color_textAccentHover: #0d74ce;
-    --vocs-404-space_8: 0.5rem;
-    --vocs-404-space_24: 1.5rem;
-    --vocs-404-fontSize_root: 16px;
-    --vocs-404-fontSize_h1: 2rem;
-    --vocs-404-fontFamily_default: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
-    --vocs-404-fontWeight_medium: 400;
-    --vocs-404-fontWeight_semibold: 500;
-    --vocs-404-lineHeight_paragraph: 1.75em;
-    --vocs-404-lineHeight_heading: 1.5em;
+    --404-color_background: rgba(255 255 255 / 100%);
+    --404-color_text: #4c4c4c;
+    --404-color_heading: #202020;
+    --404-color_border: #ececec;
+    --404-color_textAccent: #0588f0;
+    --404-color_textAccentHover: #0d74ce;
+    --404-space_8: 0.5rem;
+    --404-space_24: 1.5rem;
+    --404-fontSize_root: 16px;
+    --404-fontSize_h1: 2rem;
+    --404-fontFamily_default: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+    --404-fontWeight_medium: 400;
+    --404-fontWeight_semibold: 500;
+    --404-lineHeight_paragraph: 1.75em;
+    --404-lineHeight_heading: 1.5em;
   }
   
   :root.dark {
-    --vocs-404-color_background: #121113;
-    --vocs-404-color_text: rgba(255, 255, 255, 0.8);
-    --vocs-404-color_heading: rgba(255 255 255 / 100%);
-    --vocs-404-color_border: #2b292d;
-    --vocs-404-color_textAccent: #3b9eff;
-    --vocs-404-color_textAccentHover: #0090ff;
+    --404-color_background: #121113;
+    --404-color_text: rgba(255, 255, 255, 0.8);
+    --404-color_heading: rgba(255 255 255 / 100%);
+    --404-color_border: #2b292d;
+    --404-color_textAccent: #3b9eff;
+    --404-color_textAccentHover: #0090ff;
   }
   
   /* Base Reset */
@@ -45,12 +45,12 @@
   }
   
   body {
-    font-family: var(--vocs-404-fontFamily_default);
-    font-size: var(--vocs-404-fontSize_root);
-    line-height: var(--vocs-404-lineHeight_paragraph);
-    font-weight: var(--vocs-404-fontWeight_regular);
-    background-color: var(--vocs-404-color_background);
-    color: var(--vocs-404-color_text);
+    font-family: var(--404-fontFamily_default);
+    font-size: var(--404-fontSize_root);
+    line-height: var(--404-lineHeight_paragraph);
+    font-weight: var(--404-fontWeight_medium);
+    background-color: var(--404-color_background);
+    color: var(--404-color_text);
     -webkit-text-size-adjust: 100%;
     text-rendering: optimizeLegibility;
   }
@@ -60,7 +60,7 @@
     color: inherit;
     border-top-width: 1px;
     border-top-style: solid;
-    border-top-color: var(--vocs-404-color_border);
+    border-top-color: var(--404-color_border);
   }
   
   h1,
@@ -85,30 +85,30 @@
   
   /* Component Styles */
   .vocs_H1 {
-    font-size: var(--vocs-404-fontSize_h1);
+    font-size: var(--404-fontSize_h1);
     letter-spacing: -0.02em;
-    line-height: var(--vocs-404-lineHeight_heading);
-    color: var(--vocs-404-color_heading);
-    font-weight: var(--vocs-404-fontWeight_semibold);
+    line-height: var(--404-lineHeight_heading);
+    color: var(--404-color_heading);
+    font-weight: var(--404-fontWeight_semibold);
   }
   
   .vocs_Paragraph {
-    line-height: var(--vocs-404-lineHeight_paragraph);
+    line-height: var(--404-lineHeight_paragraph);
     letter-spacing: 0.005em;
-    color: var(--vocs-404-color_text);
-    margin-bottom: var(--vocs-404-space_24);
+    color: var(--404-color_text);
+    margin-bottom: var(--404-space_24);
   }
   
   .vocs_Link {
-    color: var(--vocs-404-color_textAccent);
-    font-weight: var(--vocs-404-fontWeight_medium);
-    text-underline-offset: var(--vocs-404-space_8);
+    color: var(--404-color_textAccent);
+    font-weight: var(--404-fontWeight_medium);
+    text-underline-offset: var(--404-space_8);
     text-decoration: underline;
     transition: color 0.1s;
   }
   
   .vocs_Link:hover {
-    color: var(--vocs-404-color_textAccentHover);
+    color: var(--404-color_textAccentHover);
   }
   
   .vocs_NotFound_root {
@@ -121,7 +121,7 @@
   }
   
   .vocs_NotFound_divider {
-    border-color: var(--vocs-404-color_border);
+    border-color: var(--404-color_border);
     width: 50%;
   }
   

--- a/public/404.html
+++ b/public/404.html
@@ -10,11 +10,11 @@
 <body>
   <div class="vocs_NotFound_root">
     <h1 class="vocs_H1">Page Not Found</h1>
-    <div style="height: var(--vocs-404-space_24);"></div>
+    <div style="height: var(--404-space_24);"></div>
     <hr class="vocs_NotFound_divider" />
-    <div style="height: var(--vocs-404-space_24);"></div>
+    <div style="height: var(--404-space_24);"></div>
     <p class="vocs_Paragraph">The page you were looking for could not be found.</p>
-    <div style="height: var(--vocs-404-space_8);"></div>
+    <div style="height: var(--404-space_8);"></div>
     <a href="/" class="vocs_Link">Go to Home Page</a>
   </div>
 </body>


### PR DESCRIPTION
## Frameworks PR Checklist

Despite being a [vocs open issue](https://github.com/wevm/vocs/issues/315), i've found a way to create a custom 404 that works for both Vercel and CF and that does not redirect (as it overrides the vocs default one).
This closes #306 

- [ ] Describe your changes, substitute this text with the information
- [ ] If you are touching an existing piece of content, tag current contributors from the attribution list
- [ ] If there is a steward for that framework, ask the steward to review it
- [ ] If you're modifying the general outline, make sure to update it in the `vocs.config.ts` adding the `dev: true` parameter
- [ ] If you need feedback for your content from the wider community, share the PR in our Discord
- [ ] Review changes to ensure there are no typos, see instructions below

<!--
ℹ️ Checking for typos locally
1. Install [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2)
2. Install [just](https://github.com/casey/just)
3. Run `npx just lint`
-->
