### PR TITLE
Add branch-aware robots.txt

### DIFF
--- a/functions/robots.txt.ts
+++ b/functions/robots.txt.ts
@@ -2,7 +2,8 @@ export function onRequest(context: { env: { CF_PAGES_BRANCH?: string; }; }) {
   const branch = context.env.CF_PAGES_BRANCH;
   const isMain = branch === 'main';
 
-  const header = `# As a condition of accessing this website, you agree to abide by the following
+  const body = isMain
+    ? `# As a condition of accessing this website, you agree to abide by the following
 # content signals:
 
 # (a) If a content-signal = yes, you may collect content for the corresponding
@@ -26,10 +27,8 @@ export function onRequest(context: { env: { CF_PAGES_BRANCH?: string; }; }) {
 # ANY RESTRICTIONS EXPRESSED VIA CONTENT SIGNALS ARE EXPRESS RESERVATIONS OF
 # RIGHTS UNDER ARTICLE 4 OF THE EUROPEAN UNION DIRECTIVE 2019/790 ON COPYRIGHT
 # AND RELATED RIGHTS IN THE DIGITAL SINGLE MARKET.
-`;
 
-const rules = isMain
-? `User-agent: *
+User-agent: *
 Allow: /
 
 User-agent: Amazonbot
@@ -56,13 +55,9 @@ Disallow: /
 User-agent: meta-externalagent
 Disallow: /
 `
-: `User-agent: *
+    : `User-agent: *
 Disallow: /
 `;
-
-  // Build the robots.txt content
-  const body = `${header}
-${rules}`.trim();
 
   return new Response(body + '\n', {
     headers: {


### PR DESCRIPTION
## Frameworks PR Checklist

Found a way to add a branch-aware robots.txt using Cloudflare Functions, so the file is generated at build time by Cloudflare.
For the main branch, the robots.txt is the same as the one used on securityalliance.org (https://securityalliance.org/robots.txt), while for all other branches it is simply: User-Agent: * Disallow: /

- [ ] Describe your changes, substitute this text with the information
- [ ] If you are touching an existing piece of content, tag current contributors from the attribution list
- [ ] If there is a steward for that framework, ask the steward to review it
- [ ] If you're modifying the general outline, make sure to update it in the `vocs.config.ts` adding the `dev: true` parameter
- [ ] If you need feedback for your content from the wider community, share the PR in our Discord
- [ ] Review changes to ensure there are no typos, see instructions below

<!--
ℹ️ Checking for typos locally
1. Install [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2)
2. Install [just](https://github.com/casey/just)
3. Run `npx just lint`
-->
