### PR TITLE
fix md-linter path in the github workflow

### DIFF
--- a/.github/workflows/md-lint.yaml
+++ b/.github/workflows/md-lint.yaml
@@ -14,4 +14,4 @@ jobs:
       continue-on-error: true
       with:
         globs: |
-          src/**/*.md
+          docs/**/*.mdx


### PR DESCRIPTION
## Frameworks PR Checklist

Fixed the path of the linter in the github workflow

- [ ] Describe your changes, substitute this text with the information
- [ ] If you are touching an existing piece of content, tag current contributors from the attribution list
- [ ] If there is a steward for that framework, ask the steward to review it
- [ ] If you're modifying the general outline, make sure to update it in the `vocs.config.ts` adding the `dev: true` parameter
- [ ] If you need feedback for your content from the wider community, share the PR in our Discord
- [ ] Review changes to ensure there are no typos, see instructions below

<!--
ℹ️ Checking for typos locally
1. Install [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2)
2. Install [just](https://github.com/casey/just)
3. Run `npx just lint`
-->
