### PR TITLE
[multisig] independent transaction verification requirement

### DIFF
--- a/docs/pages/certs/sfc-multisig-ops.mdx
+++ b/docs/pages/certs/sfc-multisig-ops.mdx
@@ -88,20 +88,20 @@ cert:
     description: Do you maintain audit trails and retention for transaction reviews, approvals,
       execution, and post-execution confirmation?
     title: Audit Trails and Retention
-  - id: ms-4.1.3b
+  - id: ms-4.1.4
     description: Do you require each signer to independently verify transaction details through 
       a separate interface or data source before signing, rather than relying solely on the 
       initiator's representation?
     title: Independent Transaction Verification Requirement
-  - id: ms-4.1.4
+  - id: ms-4.1.5
     description: Do you maintain a policy defining enhanced controls for high-risk transactions
       (emergency actions, large transfers, protocol configuration changes)?
     title: Policy for High-Risk Transactions
-  - id: ms-4.1.5
+  - id: ms-4.1.6
     description: Do you maintain documented standards for multisig technology and tools, and
       a formal evaluation process for adopting new ones?
     title: Multisig Standards and Evaluation
-  - id: ms-4.1.6
+  - id: ms-4.1.7
     description: Do you maintain documented backup infrastructure for multisig operations (alternate
       signing interfaces, RPC/explorers, failover procedures), and test their use?
     title: Backup Infrastructure for Multisig


### PR DESCRIPTION
Adds a new check requiring each multisig signer to independently verify transaction details through a separate interface before signing.

Why this matters: Many multisig compromises succeed because signers trust what an initiator tells them, without independently confirming the actual on-chain transaction. A compromised frontend, supply chain attack, or social engineering can display legitimate-looking data while the underlying transaction is malicious. 