### PR TITLE
Fix/twitter preview image (it gets cropped when linking)

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -13,7 +13,7 @@ const config = {
   logoUrl: 'https://frameworks-static.s3.us-east-2.amazonaws.com/images/logo/frameworks-full.svg',
   iconUrl: 'https://frameworks-static.s3.us-east-2.amazonaws.com/images/logo/favicon.svg',
   ogImageUrl: {
-    '/': 'https://frameworks-static.s3.us-east-2.amazonaws.com/images/logo/frameworks-full-cropped.svg'
+    '/': 'https://frameworks-static.s3.us-east-2.amazonaws.com/images/logo/frameworks-full-cropped.png'
   },
   checkDeadlinks: "warn" as const,
   sidebar: [


### PR DESCRIPTION
## Frameworks PR Checklist

i've noted the preview image is being cut by twitter -> 
<img width="300" alt="Screenshot 2026-01-26 at 16 06 42" src="https://github.com/user-attachments/assets/bf8cb440-11ff-44a1-8d13-3b72885d3cae" />

Basically twitter is not able to resize images like other socials (and our image is almost 6k pixels) and it wants a precise format. So i resized it and uploaded to our bucket.


- [ ] Describe your changes, substitute this text with the information
- [ ] If you are touching an existing piece of content, tag current contributors from the attribution list
- [ ] If there is a steward for that framework, ask the steward to review it
- [ ] If you're modifying the general outline, make sure to update it in the `vocs.config.ts` adding the `dev: true` parameter
- [ ] If you need feedback for your content from the wider community, share the PR in our Discord
- [ ] Review changes to ensure there are no typos, see instructions below

<!--
ℹ️ Checking for typos locally
1. Install [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2)
2. Install [just](https://github.com/casey/just)
3. Run `npx just lint`
-->
