### PR TITLE
Making the searchbar indexer not run in local builds

### DIFF
--- a/utils/searchbar-indexing.js
+++ b/utils/searchbar-indexing.js
@@ -134,6 +134,16 @@ function extractSectionsFromMdx(raw) {
 }
 
 async function main() {
+  // Only run this script in CI/deployment environments (Vercel or Cloudflare Pages)
+  // Skip during local builds
+  const isVercel = !!process.env.VERCEL;
+  const isCloudflarePages = !!process.env.CF_PAGES;
+
+  if (!isVercel && !isCloudflarePages) {
+    console.log('Skipping search index generation: not running in a deployment environment (Vercel or Cloudflare Pages)');
+    return;
+  }
+
   // Determine where the built search index exists (try Cloudflare Pages dist, Vercel output, docs/dist)
   // Try these directories in order; pick the first that contains the index
   const candidateDirs = [cfPagesDistVocsDir, vercelVocsDir, vercelPath0DistVocsDir, distVocsDir];


### PR DESCRIPTION
## Frameworks PR Checklist

I noted that the script we have to create the searchbar index was creating it also in local builds, so i made it make a simple check to make it run only on CF and Vercel builds

- [ ] Describe your changes, substitute this text with the information
- [ ] If you are touching an existing piece of content, tag current contributors from the attribution list
- [ ] If there is a steward for that framework, ask the steward to review it
- [ ] If you're modifying the general outline, make sure to update it in the `vocs.config.ts` adding the `dev: true` parameter
- [ ] If you need feedback for your content from the wider community, share the PR in our Discord
- [ ] Review changes to ensure there are no typos, see instructions below

<!--
ℹ️ Checking for typos locally
1. Install [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2)
2. Install [just](https://github.com/casey/just)
3. Run `npx just lint`
-->
