### PR TITLE
fix: restore Tailwind usage for Certs components after vocs upgrade

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@source "../components";
 
 details .vocs_Paragraph {
     margin-bottom: var(--vocs-space_24);


### PR DESCRIPTION
## Frameworks PR Checklist

Found out that the reason Certs checklists are breaking on develop (e.g. -> https://frameworks.securityalliance.dev/certs/sfc-devops-infrastructure) is because with the upgrade of vocs, tailwind doesn't autodetect content sources anymore and needs explicit direction. 
So all fixed by adding `@source "../components"` to the styles.css -> https://frameworks-git-fix-cert-styling-securityalliance.vercel.app/certs/sfc-devops-infrastructure

Closes #343

- [ ] Describe your changes, substitute this text with the information
- [ ] If you are touching an existing piece of content, tag current contributors from the attribution list
- [ ] If there is a steward for that framework, ask the steward to review it
- [ ] If you're modifying the general outline, make sure to update it in the `vocs.config.ts` adding the `dev: true` parameter
- [ ] If you need feedback for your content from the wider community, share the PR in our Discord
- [ ] Review changes to ensure there are no typos, see instructions below

<!--
ℹ️ Checking for typos locally
1. Install [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2)
2. Install [just](https://github.com/casey/just)
3. Run `npx just lint`
-->
