### PR TITLE
Fix: pnpm commands failing silently due to misconfigured dependency settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,15 +25,9 @@
   "author": "",
   "license": "ISC",
   "pnpm": {
-    "trustedDependencies": [
+    "onlyBuiltDependencies": [
       "esbuild",
       "just-install"
-    ],
-    "ignoredBuiltDependencies": [
-      "just-install"
-    ],
-    "onlyBuiltDependencies": [
-      "esbuild"
     ]
   },
   "packageManager": "pnpm@10.15.0",


### PR DESCRIPTION
## Frameworks PR Checklist

Fixed `pnpm exec just ...` commands (`pnpm exec just build` || `pnpm exec just serve`) failing silently due to misconfigured pnpm dependency settings.

This PR:
- Removes the `trustedDependencies` configuration as it's deprecated in pnpm 10.x
- Fixes a contradictory config where `just-install` was listed in both `trustedDependencies` AND `ignoredBuiltDependencies` - the ignore took precedence and `just-install` was not being installed

For the reason above, i've removed `just-install` from `ignoredBuiltDependencies` and added it to `onlyBuiltDependencies ` (together with `esbuild` that was already there) so it can actually be installed and the `pnpm exec just ...` commands can work

- [ ] Describe your changes, substitute this text with the information
- [ ] If you are touching an existing piece of content, tag current contributors from the attribution list
- [ ] If there is a steward for that framework, ask the steward to review it
- [ ] If you're modifying the general outline, make sure to update it in the `vocs.config.ts` adding the `dev: true` parameter
- [ ] If you need feedback for your content from the wider community, share the PR in our Discord
- [ ] Review changes to ensure there are no typos, see instructions below

<!--
ℹ️ Checking for typos locally
1. Install [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2)
2. Install [just](https://github.com/casey/just)
3. Run `npx just lint`
-->
