### PR TITLE
Fix double title suffix by adding titleTemplate config

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -16,6 +16,7 @@ const config = {
     dismissable: false
   },
   title: 'Security Frameworks by SEAL',
+  titleTemplate: '%s',
   description: 'Comprehensive security framework documentation for Web3 projects and blockchain security best practices.',
   logoUrl: 'https://frameworks-static.s3.us-east-2.amazonaws.com/images/logo/frameworks-full.svg',
   iconUrl: 'https://frameworks-static.s3.us-east-2.amazonaws.com/images/logo/favicon.svg',


### PR DESCRIPTION


## Frameworks PR Checklist

Thank you for contributing to the Security Frameworks! Before you open a PR, make sure to read [information for contributors](https://frameworks.securityalliance.dev/contribute/contributing) and take a look at the following checklist:

- [x] Vocs was appending " – Security Frameworks by SEAL" to page titles that already included " | Security Alliance" or " | SEAL" suffixes.

Adding `titleTemplate: '%s'` tells Vocs to use the frontmatter title as-is without appending the site title.

Fixes #357
