### PR TITLE
docs: add project-level CLAUDE.md for AI-assisted contributions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,8 @@ package-lock.json
 pnpm-lock.yaml
 .pnpm-store/
 
-# Claude Code configuration
-CLAUDE.md
+# Claude Code personal overrides (use CLAUDE.local.md)
+# CLAUDE.md is tracked — see the project-level file
 
 # Build folder
 **/dist/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,56 @@
+# CLAUDE.md — SEAL Security Frameworks
+
+## Project
+
+MDX documentation site built with [Vocs](https://vocs.dev) (Vite + React). Content lives in `docs/pages/`, components in `components/`.
+
+## Build & Verify
+
+```bash
+pnpm install
+pnpm run docs:build    # full build — MUST pass before pushing
+pnpm run docs:dev      # local preview at localhost:5173
+npx cspell "docs/**/*.mdx"  # spellcheck
+```
+
+Build pipeline: generate-tags → generate-indexes → mermaid-wrapper → generate-printables → generate-cert-data → vocs build. All steps must succeed.
+
+## Content
+
+- **Template:** every MDX page must follow `docs/pages/config/template.mdx`
+- **Frontmatter (required):** `title`, `description` (140-160 chars, SEO-focused), `tags`, `contributors`
+- **Valid tags:** Security Specialist · Operations & Strategy · Community & Marketing · HR · Engineer/Developer · SEAL/Initiative · Certifications · SFC
+- **Imports:** match component import path depth to file location (`../` count matters)
+- **Key Takeaway:** `> 🔑 **Key Takeaway**:` format, max 40 words, immediately after the H1 heading
+- **Close every page** with `</TagProvider>` then `<ContributeFooter />`
+- **Links:** use relative `.mdx` links for cross-references within the repo
+
+## Writing Style
+
+- Practitioner voice — no fluff, no marketing language
+- Specific and actionable: tool names, setting paths, concrete steps
+- Tables, checklists, and code blocks over prose where possible
+- Cross-reference existing pages to avoid duplication
+- Match the tone and depth of neighboring pages in the same section
+
+## Certifications (SFC)
+
+Cert pages use YAML frontmatter with a `cert:` array defining sections and controls. Each control needs `id`, `title`, `description`, and optional `baselines`. See any `sfc-*.mdx` file for the schema.
+
+Cert contributions require stricter review — see `docs/pages/certs/contributions.mdx`.
+
+## Git
+
+- **Target branch:** `develop` (not `main`)
+- New content pages: add `dev: true` in the sidebar entry in `vocs.config.ts`
+- One logical change per commit, imperative mood messages
+
+## Quality Checklist
+
+Before pushing, verify:
+
+- [ ] `pnpm run docs:build` passes cleanly
+- [ ] All URLs and cross-references resolve
+- [ ] Frontmatter matches template (title, description, tags, contributors)
+- [ ] No content duplication — link to existing pages instead
+- [ ] Spellcheck passes or new terms added to cspell config


### PR DESCRIPTION
## Summary

Adds a tracked `CLAUDE.md` with project conventions for LLM-based coding tools (Claude Code, GitHub Copilot, Cursor, etc.).

## Why

AI coding tools are increasingly used for open-source contributions. Claude Code and similar tools read a `CLAUDE.md` at the repo root to understand project conventions before making changes. Without one, AI contributors may:

- Skip the build step and push broken code
- Miss frontmatter requirements or the template structure
- Target `main` instead of `develop`
- Produce content that doesn't match the project's writing style

This file encodes what a human contributor would learn from reading the contributing guide, but in a format optimized for AI tools.

## What's in it

- **Build & verify** — commands to run before pushing (`pnpm run docs:build`)
- **Content conventions** — template, frontmatter schema, valid tags, component imports
- **Writing style** — practitioner voice, actionable, no fluff
- **Certifications** — cert frontmatter schema reference
- **Git workflow** — target `develop`, `dev: true` for new pages
- **Quality checklist** — build, links, frontmatter, dedup, spellcheck

## .gitignore change

`CLAUDE.md` was previously gitignored (so contributors could have personal ones). This PR tracks it as a shared project resource. Contributors can still use `CLAUDE.local.md` for personal overrides.

## Disclosure

This contribution was authored with AI assistance.