### PR TITLE
Fix: vocs.config path in index generator + added more in depth escapes for ts syntax

### DIFF
--- a/utils/generate-folder-indexes.js
+++ b/utils/generate-folder-indexes.js
@@ -179,6 +179,7 @@ function detectCurrentBranch() {
 function resolveCurrentBranch() {
   const candidates = [
     process.env.CF_PAGES_BRANCH,
+    process.env.VERCEL_GIT_COMMIT_REF,
     process.env.BRANCH,
     process.env.GITHUB_REF_NAME,
   ];
@@ -246,11 +247,16 @@ function loadSidebarConfig(branchName) {
   const previousCF = Object.prototype.hasOwnProperty.call(process.env, 'CF_PAGES_BRANCH')
     ? process.env.CF_PAGES_BRANCH
     : undefined;
+  const previousVercel = Object.prototype.hasOwnProperty.call(process.env, 'VERCEL_GIT_COMMIT_REF')
+    ? process.env.VERCEL_GIT_COMMIT_REF
+    : undefined;
 
   if (branchName) {
     process.env.CF_PAGES_BRANCH = branchName;
+    process.env.VERCEL_GIT_COMMIT_REF = branchName;
   } else {
     delete process.env.CF_PAGES_BRANCH;
+    delete process.env.VERCEL_GIT_COMMIT_REF;
   }
 
   try {
@@ -263,6 +269,11 @@ function loadSidebarConfig(branchName) {
       delete process.env.CF_PAGES_BRANCH;
     } else {
       process.env.CF_PAGES_BRANCH = previousCF;
+    }
+    if (previousVercel === undefined) {
+      delete process.env.VERCEL_GIT_COMMIT_REF;
+    } else {
+      process.env.VERCEL_GIT_COMMIT_REF = previousVercel;
     }
   }
 }


### PR DESCRIPTION
Reviewing PRs i've noted a misspelled vocs.config path in the index generator script and fixed it + as in this PR -> #383 we have added more params to the config file, i added more escapes to the indexer so it doesnt fail

## Frameworks PR Checklist

Thank you for contributing to the Security Frameworks! Before you open a PR, make sure to read [information for contributors](https://frameworks.securityalliance.dev/contribute/contributing) and take a look at the following checklist:

- [ ] Describe your changes, substitute this text with the information
- [ ] If you are touching an existing piece of content, tag current contributors from the attribution list
- [ ] If there is a steward for that framework, ask the steward to review it
- [ ] If you're modifying the general outline, make sure to update it in the `vocs.config.tsx` adding the `dev: true` parameter
- [ ] If you need feedback for your content from the wider community, share the PR in our Discord
- [ ] Review changes to ensure there are no typos, see instructions below

<!--
ℹ️ Checking for typos locally
1. Install [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2)
2. Install [just](https://github.com/casey/just)
3. Run `npx just lint`
-->
