### PR TITLE
DevSecOps: move sandboxing/isolation guidance out of AI Security (#398)

### DIFF
--- a/docs/pages/devsecops/overview.mdx
+++ b/docs/pages/devsecops/overview.mdx
@@ -39,13 +39,14 @@ Some of the key areas to consider are:
 
 ## What’s inside DevSecOps
 
-- [Sandboxing & Isolation](/devsecops/sandboxing-and-isolation): Canonical guidance for containment patterns across CI/CD and automation workflows.
-- [Execution Sandboxing](/devsecops/execution-sandboxing): Core runtime isolation controls to limit blast radius and privilege abuse.
-- [Execution Sandboxing: A Practical Guide](/devsecops/execution-sandboxing-practical-guide): Implementation playbook for runners, untrusted PRs, secrets, and egress.
-- [Capability-Based Isolation](/devsecops/capability-based-isolation): Replace broad privileges with explicit, auditable capability grants.
-- [Network & Resource Isolation](/devsecops/network-and-resource-isolation): Enforce deny-by-default networking and strict CPU/memory/resource boundaries.
-- [Sandboxing for Tool Execution](/devsecops/sandboxing-for-tool-execution): Secure high-risk tool invocation with constrained runtime and auditable effects.
-- [Sandboxing & Policy Enforcement](/devsecops/sandboxing-and-policy-enforcement): Combine sandbox boundaries with policy-as-code for defense in depth.
+- **Isolation & Sandboxing**
+  - [Sandboxing & Isolation](/devsecops/sandboxing-and-isolation): Canonical guidance for containment patterns across CI/CD and automation workflows.
+  - [Execution Sandboxing](/devsecops/execution-sandboxing): Core runtime isolation controls to limit blast radius and privilege abuse.
+  - [Execution Sandboxing: A Practical Guide](/devsecops/execution-sandboxing-practical-guide): Implementation playbook for runners, untrusted PRs, secrets, and egress.
+  - [Capability-Based Isolation](/devsecops/capability-based-isolation): Replace broad privileges with explicit, auditable capability grants.
+  - [Network & Resource Isolation](/devsecops/network-and-resource-isolation): Enforce deny-by-default networking and strict CPU/memory/resource boundaries.
+  - [Sandboxing for Tool Execution](/devsecops/sandboxing-for-tool-execution): Secure high-risk tool invocation with constrained runtime and auditable effects.
+  - [Sandboxing & Policy Enforcement](/devsecops/sandboxing-and-policy-enforcement): Combine sandbox boundaries with policy-as-code for defense in depth.
 - [Securing CI/CD Pipelines](/devsecops/continuous-integration-continuous-deployment): Build safer pipelines with testing, scanning, deterministic builds, and access controls.
 - [Repository Hardening](/devsecops/repository-hardening): Protect repos with branch policies, signed commits, and hardened automation settings.
 - [Security Testing](/devsecops/security-testing): Shift-left with SAST, DAST, IAST, and fuzzing to catch issues early.

--- a/utils/fetched-tags.json
+++ b/utils/fetched-tags.json
@@ -159,20 +159,7 @@
     "/community-management/twitter": [
       "Community & Marketing"
     ],
-    "/devsecops/ai-execution-sandboxing-practical-guide": [
-      "Engineer/Developer",
-      "Security Specialist",
-      "Operations & Strategy",
-      "Devops",
-      "SRE"
-    ],
-    "/devsecops/ai-execution-sandboxing": [
-      "Engineer/Developer",
-      "Security Specialist",
-      "Operations & Strategy",
-      "Devops"
-    ],
-    "/devsecops/capability-based-isolation-for-ai-agents": [
+    "/devsecops/capability-based-isolation": [
       "Engineer/Developer",
       "Security Specialist",
       "Operations & Strategy"
@@ -188,12 +175,25 @@
       "Devops",
       "SRE"
     ],
+    "/devsecops/execution-sandboxing-practical-guide": [
+      "Engineer/Developer",
+      "Security Specialist",
+      "Operations & Strategy",
+      "Devops",
+      "SRE"
+    ],
+    "/devsecops/execution-sandboxing": [
+      "Engineer/Developer",
+      "Security Specialist",
+      "Operations & Strategy",
+      "Devops"
+    ],
     "/devsecops/integrated-development-environments": [
       "Engineer/Developer",
       "Security Specialist",
       "Devops"
     ],
-    "/devsecops/network-and-resource-isolation-in-ai-sandboxes": [
+    "/devsecops/network-and-resource-isolation": [
       "Engineer/Developer",
       "Security Specialist",
       "Operations & Strategy",
@@ -217,13 +217,13 @@
       "Operations & Strategy",
       "Devops"
     ],
-    "/devsecops/sandboxing-as-a-complement-to-execution-path-enforcement": [
+    "/devsecops/sandboxing-and-policy-enforcement": [
       "Engineer/Developer",
       "Security Specialist",
       "Operations & Strategy",
       "Devops"
     ],
-    "/devsecops/sandboxing-for-tool-and-execution-calls": [
+    "/devsecops/sandboxing-for-tool-execution": [
       "Engineer/Developer",
       "Security Specialist",
       "Operations & Strategy",
@@ -1118,6 +1118,7 @@
     "DPRK IT Workers": "dprk-it-workers",
     "Governance": "governance",
     "DevSecOps": "devsecops",
+    "Isolation & Sandboxing": "devsecops",
     "Privacy": "privacy",
     "Supply Chain": "supply-chain",
     "Security Automation": "security-automation",

--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -300,13 +300,19 @@ const config = {
           dev: true,
           items: [
             { text: 'Overview', link: '/devsecops/overview', dev: true },
-            { text: 'Sandboxing & Isolation', link: '/devsecops/sandboxing-and-isolation', dev: true },
-            { text: 'Execution Sandboxing', link: '/devsecops/execution-sandboxing', dev: true },
-            { text: 'Capability-Based Isolation', link: '/devsecops/capability-based-isolation', dev: true },
-            { text: 'Sandboxing for Tool Execution', link: '/devsecops/sandboxing-for-tool-execution', dev: true },
-            { text: 'Network & Resource Isolation', link: '/devsecops/network-and-resource-isolation', dev: true },
-            { text: 'Sandboxing & Policy Enforcement', link: '/devsecops/sandboxing-and-policy-enforcement', dev: true },
-            { text: 'Execution Sandboxing: A Practical Guide', link: '/devsecops/execution-sandboxing-practical-guide', dev: true },
+            {
+              text: 'Isolation & Sandboxing',
+              collapsed: false,
+              items: [
+                { text: 'Sandboxing & Isolation', link: '/devsecops/sandboxing-and-isolation', dev: true },
+                { text: 'Execution Sandboxing', link: '/devsecops/execution-sandboxing', dev: true },
+                { text: 'Capability-Based Isolation', link: '/devsecops/capability-based-isolation', dev: true },
+                { text: 'Sandboxing for Tool Execution', link: '/devsecops/sandboxing-for-tool-execution', dev: true },
+                { text: 'Network & Resource Isolation', link: '/devsecops/network-and-resource-isolation', dev: true },
+                { text: 'Sandboxing & Policy Enforcement', link: '/devsecops/sandboxing-and-policy-enforcement', dev: true },
+                { text: 'Execution Sandboxing: A Practical Guide', link: '/devsecops/execution-sandboxing-practical-guide', dev: true },
+              ]
+            },
             { text: 'Code Signing', link: '/devsecops/code-signing', dev: true },
             { text: 'Continuous Integration and Deployment', link: '/devsecops/continuous-integration-continuous-deployment', dev: true },
             { text: 'Integrated Development Environments', link: '/devsecops/integrated-development-environments', dev: true },


### PR DESCRIPTION
Implements #398 by relocating general sandboxing + isolation guidance from the AI Security section into DevSecOps, where it belongs for CI/CD, build systems, automation, and developer tooling.

What this PR does

• Moves and renames sandboxing/isolation documentation pages into docs/pages/devsecops/
• Removes AI-specific framing so the guidance reads as broadly applicable DevSecOps best practice
• Updates navigation/indexes/tag generation so the new pages are discoverable in DevSecOps
• Cleans up old/moved stubs in the AI Security section to avoid duplicated guidance

Why

Sandboxing and isolation are core DevSecOps controls (CI runners, PR builds, preview environments, automation with side effects). Keeping the material under AI Security made it harder to find and implicitly scoped it too narrowly.

Notes for reviewers

• The intent is content relocation + normalization, not changing the security stance.
• Pages remain focused on practical controls: blast-radius reduction, least privilege, egress controls, and operational footguns.

Closes #398.