### PR TITLE
Chore: Bump vocs to fix sidebar sections not opening on internal links

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@types/react-dom": "^19.2.3",
     "cspell": "^9.4.0",
     "tailwindcss": "4.0.7",
-    "vocs": "^1.2.1"
+    "vocs": "1.2.2"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ importers:
         specifier: 4.0.7
         version: 4.0.7
       vocs:
-        specifier: ^1.2.1
-        version: 1.2.1(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.1(react@19.2.1))(react-router-dom@7.12.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)(rollup@4.59.0)(typescript@5.9.3)
+        specifier: 1.2.2
+        version: 1.2.2(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.1(react@19.2.1))(react-router-dom@7.12.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)(rollup@4.59.0)(typescript@5.9.3)
 
 packages:
 
@@ -4090,8 +4090,8 @@ packages:
       yaml:
         optional: true
 
-  vocs@1.2.1:
-    resolution: {integrity: sha512-rQ5aoD68+UJQeJ9G/nPcqcwhbBpMFZnHJ9ZkIsRHaeqBdiA4S86ufplJRKxmX56XZLEpY+wlU+TGz8Qsxtb8Sw==}
+  vocs@1.2.2:
+    resolution: {integrity: sha512-i5NSKOJQZUkKagQuzGy/g5Sr28bnn5JnwDAN637aPJ/KOwCFepq7d3rUV3YBAxwA4SVh22SwD57IrmgtD3yvDw==}
     engines: {node: '>=22'}
     hasBin: true
     peerDependencies:
@@ -8830,7 +8830,7 @@ snapshots:
       lightningcss: 1.30.2
       yaml: 2.8.2
 
-  vocs@1.2.1(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.1(react@19.2.1))(react-router-dom@7.12.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)(rollup@4.59.0)(typescript@5.9.3):
+  vocs@1.2.2(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.1(react@19.2.1))(react-router-dom@7.12.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)(rollup@4.59.0)(typescript@5.9.3):
     dependencies:
       '@floating-ui/react': 0.27.16(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@hono/node-server': 1.19.6(hono@4.12.3)


### PR DESCRIPTION
This was a known issue of vocs. Specs:

- When sidebar sections are collapsed by default, clicking an internal link to a page in a different section would load the page correctly but the sidebar section would stay closed and you couldn't tell where you landed in the docs.
- Easy to reproduce: go to https://frameworks.securityalliance.dev/intro/overview-of-each-framework and click any of the framework links. The page opens but the sidebar doesn't follow along.
- The issue was fixed in [wevm/vocs#353](https://github.com/wevm/vocs/pull/353), so -> bumped vocs from 1.2.1 to 1.2.2 which includes this fix.

All good here -> https://chore-bump-vocs.frameworks-573.pages.dev/intro/overview-of-each-framework

## Frameworks PR Checklist

Thank you for contributing to the Security Frameworks! Before you open a PR, make sure to read [information for contributors](https://frameworks.securityalliance.dev/contribute/contributing) and take a look at the following checklist:

- [ ] Describe your changes, substitute this text with the information
- [ ] If you are touching an existing piece of content, tag current contributors from the attribution list
- [ ] If there is a steward for that framework, ask the steward to review it
- [ ] If you're modifying the general outline, make sure to update it in the `vocs.config.tsx` adding the `dev: true` parameter
- [ ] If you need feedback for your content from the wider community, share the PR in our Discord
- [ ] Review changes to ensure there are no typos, see instructions below

<!--
ℹ️ Checking for typos locally
1. Install [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2)
2. Install [just](https://github.com/casey/just)
3. Run `npx just lint`
-->
