### PR TITLE
Add TxScope — Solana multisig pre-signing threat scanner

### DIFF
--- a/docs/pages/monitoring/tools.mdx
+++ b/docs/pages/monitoring/tools.mdx
@@ -105,6 +105,18 @@ serverless functions that run on Tenderly's infrastructure). The CLI and SDKs ar
 - **Website:** [tenderly.co](https://tenderly.co)
 - **GitHub:** [Tenderly](https://github.com/Tenderly) (CLI, SDKs, framework plugins)
 
+### TxScope
+
+Pre-signing transaction threat scanner for Solana multisigs. Monitors Squads Protocol vaults for pending proposals,
+simulates each transaction against mainnet via Helius RPC, and generates plain-language threat reports before any
+signer approves. Detection modules cover durable nonces, authority and admin transfers, withdrawal guard
+manipulation, known attack pattern matching, instruction-level trace and decode, proposer history and anomaly
+detection, and risk scoring (0–100). Free for on-demand scans; paid tiers for continuous monitoring with Telegram
+and Slack alerts.
+
+- **Chains:** Solana
+- **Website:** [txscope.com](https://txscope.com)
+
 ## Reliability Considerations
 
 Your monitoring system is only effective if it is itself reliable. Before committing to a tooling setup, evaluate

--- a/docs/pages/wallet-security/tools-and-resources.mdx
+++ b/docs/pages/wallet-security/tools-and-resources.mdx
@@ -84,6 +84,10 @@ Implement continuous monitoring to detect unauthorized or suspicious activity on
   - Connect to Telegram for notifications
   - Monitor for suspicious delegateCall transactions
 
+### Solana Multisig Monitoring
+
+- **[TxScope](https://txscope.com)**: Pre-signing threat scanner for Solana Squads multisigs. Simulates pending proposals against mainnet state and generates plain-language threat reports with risk scoring, durable nonce detection, authority transfer alerts, and known attack pattern matching.
+
 ### Network Security
 
 For dedicated signing machines, implement network-level protections:


### PR DESCRIPTION
## Summary

Adds TxScope to the monitoring tools and wallet security tools pages as a Solana-native 
pre-signing transaction threat scanner for Squads Protocol multisigs.

This addresses the non-EVM tooling gap noted in the current tools page — TxScope is 
purpose-built for Solana and serves the "external transaction monitor" role described 
in the multisig operations framework (SFC-MS-6.1.3, SFC-TRO-6.1.1).

## What TxScope does

- Monitors Squads Protocol vaults for pending proposals
- Simulates transactions against Solana mainnet via Helius RPC
- Generates plain-language threat reports before signers approve
- Detects: durable nonces, authority transfers, withdrawal guard manipulation, known attack patterns, proposer anomalies
- Instruction-level trace and decode with CPI depth
- Risk scoring (0–100) for automated alerting thresholds
- Free on-demand scans; paid tiers for continuous monitoring with Telegram/Slack alerts

## Relevance

- Solana-native tooling addressing the EVM gap in the current tools page
- Aligns with SFC-MS-6.1.3 (Multisig Monitoring and Alerts) and SFC-TRO-6.1.1 (Monitoring and Threat Awareness)
- Demonstrated against the Drift Protocol $285M exploit — public case study reports available at [txscope.com](https://txscope.com)

## Changes

- `docs/pages/monitoring/tools.mdx` — added TxScope under Commercial / Hosted section
- `docs/pages/wallet-security/tools-and-resources.mdx` — added TxScope under Monitoring & Alerting > Solana Multisig Monitoring

Website: https://txscope.com