### PR TITLE
content: clarify phishing awareness guidance on account claims and channel scope

### DIFF
--- a/docs/pages/community-management/overview.mdx
+++ b/docs/pages/community-management/overview.mdx
@@ -54,8 +54,11 @@ platform-specific recommendations in more depth.
 - Educate members on recognizing and reporting phishing attempts.
 - Clearly communicate to community members that your team will never send the first direct message to them. This is
   important because attackers often impersonate team members and initiate direct messages to trick users into believing
-  they are legitimate, thereby gaining their trust and potentially compromising their security.
-- Publicly define all official communication channels used by your organization.
+  they are legitimate, thereby gaining their trust and potentially compromising their security.  
+  However, statements such as “will never DM first” or labels like “Official,” “Support,” or platform status indicators (e.g., premium badges) must not be treated as proof of legitimacy.
+- Publicly define all official communication channels and clearly state which platforms are not used.  
+If a platform is unsupported, declare this alongside official links (e.g., “We do not operate a Telegram community”).  
+Where possible, reserve common impersonation handles and maintain placeholder accounts that redirect users to official channels.  
 
 Refer to the [**Security Awareness framework**](/awareness/overview) to learn more about social engineering techniques
 and security training best practices.


### PR DESCRIPTION
## Summary

* clarify that labels such as “Official”, “Support”, “will never DM first”, and platform status indicators are not proof of legitimacy
* recommend verifying identities only through links listed on the organization’s official website
* clarify that teams should explicitly state which platforms are not used, not only which channels are official

Closes #443

## Validation

* reviewed wording for tone and consistency with existing content
* verified changes are limited to `docs/pages/community-management/overview.mdx`