### PR TITLE
fix: normalize ContributeFooter route before GitHub link

### DIFF
--- a/components/footer/ContributeFooter.tsx
+++ b/components/footer/ContributeFooter.tsx
@@ -13,9 +13,7 @@ export function ContributeFooter({
   const [currentPath, setCurrentPath] = useState<string>("");
 
   useEffect(() => {
-    const sanitizedPath = window.location.pathname
-      .replace(/\/+$/, "")
-      .replace(/^\/+/, "");
+    const sanitizedPath = window.location.pathname.replace(/^\/+|\/+$/g, "");
     const filePath = sanitizedPath ? `${sanitizedPath}.mdx` : "";
     
     setCurrentPath(filePath);

--- a/components/footer/ContributeFooter.tsx
+++ b/components/footer/ContributeFooter.tsx
@@ -13,8 +13,10 @@ export function ContributeFooter({
   const [currentPath, setCurrentPath] = useState<string>("");
 
   useEffect(() => {
-    const pathname = window.location.pathname;
-    const filePath = `${pathname.slice(1)}.mdx`;
+    const sanitizedPath = window.location.pathname
+      .replace(/\/+$/, "")
+      .replace(/^\/+/, "");
+    const filePath = sanitizedPath ? `${sanitizedPath}.mdx` : "";
     
     setCurrentPath(filePath);
   }, []);
@@ -44,4 +46,3 @@ export function ContributeFooter({
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
Fixes `ContributeFooter.tsx` URL generation to handle trailing slashes in `window.location.pathname`.

### Problem
Routes like `/intro/introduction/` were being transformed into `intro/introduction/.mdx`, producing invalid GitHub links (for example `.../intro/introduction/.mdx`).

### Change
- Normalize path from `window.location.pathname` by trimming leading and trailing `/`.
- Avoid generating a path for `/` home route.
- Result is correct: `/intro/introduction/` -> `intro/introduction.mdx`.

### Validation
- Manual path normalization check via quick Node verification for common routes.

## Frameworks PR Checklist
- [x] Describe your changes
- [ ] If you are touching an existing piece of content, tag current contributors from the attribution list
- [ ] If there is a steward for that framework, ask the steward to review it
- [ ] If you're modifying the general outline, make sure to update it in `vocs.config.ts` adding the `dev: true` parameter
- [x] If you need feedback for your content from the wider community, share the PR in our Discord
- [x] Review changes to ensure there are no typos

### Files
- `components/footer/ContributeFooter.tsx`
