### PR TITLE
Chore: Refreshing stewardship page

### DIFF
--- a/docs/pages/contribute/index.mdx
+++ b/docs/pages/contribute/index.mdx
@@ -13,4 +13,4 @@ title: "Contribute"
 
 - [Contributing Guide](/contribute/contributing)
 - [Spotlight Zone](/contribute/spotlight-zone)
-- [Becoming a Framework Steward](/contribute/stewards)
+- [Framework Stewardship](/contribute/stewards)

--- a/docs/pages/contribute/stewards.mdx
+++ b/docs/pages/contribute/stewards.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Becoming a Framework Steward | Security Alliance"
-description: "Become a SEAL Framework Steward: champion and caretake a security framework. Rally collaborators, manage contributions, advocate for adoption, and shape Web3 security standards."
+title: "Framework Stewardship | Security Alliance"
+description: "Learn what it means to be a Security Frameworks steward: how the role is earned, what it involves, and how to get started."
 ---
 import { ContributeFooter, TagFilter, TagProvider } from '../../../components'
 
@@ -11,94 +11,113 @@ import { ContributeFooter, TagFilter, TagProvider } from '../../../components'
 
 ## What is a Framework Steward?
 
-A framework steward is the champion and caretaker for an individual security framework (most frameworks
-here -> [https://frameworks.securityalliance.org](https://frameworks.securityalliance.org) are currently
-available for adoption). This role goes beyond casual contribution.
-It's about taking ownership and helping guide the framework's development through community engagement.
+A framework steward is the resident expert for one (or more) of the security domains covered by the
+[Security Frameworks](https://frameworks.securityalliance.org). The role is a natural extension
+of contribution: stewards are people who have demonstrated genuine depth in a specific area,
+through the content they've written or reviewed, and who SEAL trusts to maintain the quality and
+direction of that domain going forward.
 
-## The Steward's Role
+It is a technical role, but also a community one. Stewards bring a sense of ownership to their
+domain, and being embedded in the contributor community often leads to finding and connecting
+with people who care deeply about the same problems.
 
-A framework steward is a project management role, responsible for:
+## Why become a steward?
 
-- **Rallying collaborators**: Recruit contributors who share your passion for specific security challenges
-- **Managing contributions**: Help triage [GitHub issues](https://github.com/security-alliance/frameworks/issues) and
-    coordinate improvements
-- **Advocating for adoption**: Work with SEAL to promote your framework within your networks and the broader Web3
-    community
-- **Creating content**: Work with SEAL to write blog posts, host workshops, or share best practices related to your
-    framework
-- **Representing the community**: Be a voice for practitioners who use and rely on these standards
+Because what gets written here is what practitioners across Web3 will actually read and rely on.
+When you become a steward, your approval is required before anything merges into your framework.
+That is real influence over what the community considers best practice, not in a symbolic way, but
+in a direct, technical one.
 
-The core SEAL team will support you throughout this journey, helping you focus on specific challenges rather than
-drowning in administrative tasks.
+Beyond that: the people you will meet are worth it. The stewards community is small and
+deliberately kept that way. These are security professionals who care enough about the ecosystem
+to put time into building something that matters.
 
-## Why Become a Steward?
+And finally, your work here compounds. The Security Frameworks are a living resource that
+practitioners, teams, and organizations will keep coming back to. The depth you bring to your
+framework keeps getting read long after the initial contribution.
 
-### Recognition and Growth
+## How the role is earned
 
-- **Earn achievement badges**: Receive public recognition with roles like Security Framework Ambassador or DAO
-    Safeguards Steward
-- **Build your reputation**: Establish yourself as a thought leader in Web3 security
-- **Develop new skills**: Gain experience in open-source governance, technical writing, and community building
+Most stewards got here because they genuinely cared about a topic and wrote something useful.
+The role is a recognition of that, not a prerequisite for it.
 
-### Tangible Benefits
+There is no application form. The typical path looks like this:
 
-- **Access exclusive events**: Receive tickets to security conferences and invite-only Security Alliance gatherings
-- **Showcase your expertise**: Get featured through SEAL's official channels, including our
-    [blog](https://www.securityalliance.org/news) and [social media](https://twitter.com/_SEAL_Org)
-- **Connect with peers**: Build relationships with other security professionals who share your interests
+1. A contributor writes or reviews content for a specific framework, either independently or
+   as part of a broader effort.
+2. We notice the quality and depth of that work, or the contributor reaches out expressing
+   interest in a more active role.
+3. If there is mutual trust and the fit is clear, we designate them as steward: they are
+   added to the [contributors database](https://github.com/security-alliance/frameworks/blob/develop/docs/pages/config/contributors.json) with the `Framework-Steward` badge, and they get their
+   own entry in the [Spotlight Zone](/contribute/spotlight-zone), the public-facing recognition
+   page where stewards are listed alongside the frameworks they own.
 
-### Lasting Impact
+If you are interested, the most direct path is to start contributing to the framework you care
+about. You can also reach out on [Discord](https://discord.gg/securityalliance) if you want to
+discuss it first.
 
-- **Shape industry standards**: Help develop frameworks that could become foundational to Web3 security
-- **Prevent security incidents**: Your work will directly contribute to a safer ecosystem
-- **Leave a legacy**: Carve your name into the DNA of Web3 security practices for years to come
+## Responsibilities
 
-## Stewardship in Action: What It Looks Like
+Once designated as steward for a framework, your responsibilities are focused:
 
-### Time Commitment
+- **Review incoming contributions**: When a pull request touches your framework, you will be
+  tagged as a required reviewer. The PR will not be merged without your approval. You become the
+  quality and accuracy gate for your domain.
+- **Help grow the framework**: The Security Frameworks are a work in progress, and many domains
+  still have room to grow. If you know people with the right expertise, bring them in, whether as
+  contributors to your framework or to the project more broadly. The goal is to make these
+  frameworks as broad and battle-tested as possible, and stewards are well-positioned to make
+  that happen.
+- **Advise on structural decisions**: When changes that affect the organization or direction of
+  the repo are being considered, stewards are consulted as domain experts. Your input carries
+  weight on decisions that touch your framework.
 
-Being a steward doesn't mean giving up your day job. We're looking for contributors who can dedicate approximately 3
-hours per week to their framework. This might include:
+## What this looks like in practice
 
-- Reviewing [pull requests](https://github.com/security-alliance/frameworks/pulls) and GitHub issues
-- Participating in sporadic steward meetings
-- Creating occasional content or presentations
-- Engaging with the community on [Discord](https://discord.gg/securityalliance)
+**On GitHub**: You are tagged as a required reviewer on any PR that touches your framework.
+Nothing merges without your sign-off.
 
-### Support Structure
+**On Discord**: Our [Discord server](https://discord.gg/securityalliance) has a dedicated
+stewards channel. You will be added to it and pinged when a relevant PR comes in, when we
+want your perspective on something, or when you want to share something more privately before
+it goes to the broader community. It is also where you will meet the other stewards, a small
+group of people who are genuinely invested in Web3 security and often worth knowing.
 
-You won't be working alone. You will have:
+**On the Spotlight Zone**: Your stewardship is publicly recognized on the
+[Spotlight Zone](/contribute/spotlight-zone) page, where your profile appears alongside
+the framework you own.
 
-- Access to a dedicated channel on our [Discord server](https://discord.gg/securityalliance)
-- Coordination calls with the SEAL team as needed
-- Documentation templates and contribution guidelines
-- Access to technical advisors when needed
+## Open frameworks
 
-## How to Apply
+The following frameworks are currently looking for a steward. If any of these match your
+expertise, this is a good place to start:
 
-Ready to become a framework steward? Here's how to get started:
+- Awareness
+- DevSecOps
+- DPRK IT Workers
+- Encryption
+- External Security Reviews
+- Front-End & Web App Security
+- Governance
+- IAM
+- Infrastructure
+- Multisig for Protocols
+- Privacy
+- Secure Software Development
+- Security Automation
+- Supply Chain
+- Threat Modeling
+- Treasury Operations
+- User & Team Security
+- Vulnerability Disclosure
 
-1. Review the proposed frameworks at [frameworks.securityalliance.org](https://frameworks.securityalliance.org) and
-    identify which one aligns with your expertise and interests.
-2. Join our [steward candidates Telegram channel](https://t.me/+Yd9OpSt1UvcyMjU5) and introduce yourself to let us know
-    which Framework you want to adopt.
+If none of these match your expertise but you see a gap that isn't covered anywhere on the site,
+that is worth something too. A new framework can start small, a single page or a rough outline,
+and grow from there through iteration. If you have a topic in mind, reach out on
+[Discord](https://discord.gg/securityalliance) and we can figure out together whether it makes
+sense to build it out.
 
-We're looking for diverse perspectives and experiences, and you don't need to have decades of experience. Passion,
-dedication, and a willingness to learn are just as important.
-
-## Join Us in Building a Safer Web3
-
-The "Adopt a Framework" campaign isn't just about improving documentation. You'll be part of a movement where security
-becomes a shared responsibility across the Web3 ecosystem.
-
-By becoming a steward, you're taking an active role in preventing the next major hack, protecting user funds, and
-ensuring that innovation can continue without compromising safety.
-
-We're just getting started, and we need your expertise.
-
-Have questions about the stewardship program or ideas for improving it? You can use the [potential stewards Telegram
-channel](https://t.me/+Yd9OpSt1UvcyMjU5) for that too! 🙂
+Otherwise, start contributing to whichever framework fits your background. Either way works.
 
 ---
 


### PR DESCRIPTION
Rewrote the stewardship page to reflect how the role actually works: corrected the responsibilities, replaced the Telegram application flow with the description of how stewardship is earned through contribution, added practical mechanics (GitHub, Discord, Spotlight Zone)and listed open frameworks.

## Frameworks PR Checklist

Thank you for contributing to the Security Frameworks! Before you open a PR, make sure to read [information for contributors](https://frameworks.securityalliance.dev/contribute/contributing) and take a look at the following checklist:

- [ ] Describe your changes, substitute this text with the information
- [ ] If you are touching an existing piece of content, tag current contributors from the attribution list
- [ ] If there is a steward for that framework, ask the steward to review it
- [ ] If you're modifying the general outline, make sure to update it in the `vocs.config.ts` adding the `dev: true` parameter
- [ ] If you need feedback for your content from the wider community, share the PR in our Discord
- [ ] Review changes to ensure there are no typos; see instructions below.

<!--
ℹ️ Checking for typos locally
1. Install [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2)
2. Install [just](https://github.com/casey/just)
3. Run `npx just lint`
-->
