### PR TITLE
fix: remediate PR #461 attribution and review findings

### DIFF
--- a/docs/pages/devsecops/code-signing.mdx
+++ b/docs/pages/devsecops/code-signing.mdx
@@ -7,9 +7,9 @@ tags:
   - DevOps
 contributors:
   - role: wrote
-    users: [frameworks-volunteer]
+    users: [mattaereal]
   - role: reviewed
-    users: []
+    users: [scode2277]
 ---
 
 import { TagList, AttributionList, TagProvider, TagFilter, ContributeFooter } from '../../../components'
@@ -193,7 +193,7 @@ A signature is meaningless if the verifying party cannot obtain the correct
 public key.
 
 - Upload your public key to GitHub (Settings > SSH and GPG keys) and to a
-  public keyserver (keys.openpgp.org, keys.mailvelope.com).
+  public keyserver (keys.openpgp.org, keyserver.ubuntu.com).
 - Use the same key across all platforms so that the identity is consistent.
 - In CI, pin trusted public key fingerprints in the pipeline configuration.
   Reject signatures from unknown keys.

--- a/docs/pages/devsecops/continuous-integration-continuous-deployment.mdx
+++ b/docs/pages/devsecops/continuous-integration-continuous-deployment.mdx
@@ -8,9 +8,9 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [frameworks-volunteer]
+    users: [mattaereal]
   - role: reviewed
-    users: []
+    users: [scode2277]
 ---
 
 import { TagList, AttributionList, TagProvider, TagFilter, ContributeFooter } from '../../../components'
@@ -336,7 +336,7 @@ to CI/CD pipeline security.
 - [SLSA Specification v1.0](https://slsa.dev/spec/v1.0/)
 - [NIST SP 800-218, Secure Software Development Framework](https://csrc.nist.gov/pubs/sp/800/218/final)
 - [GitHub Docs: Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
-- [CISA: Securing the Software Supply Chain for Developers](https://www.cisa.gov/sbom)
+- [CISA: Software Bill of Materials](https://www.cisa.gov/sbom)
 - [OWASP CI/CD Security Guide](https://owasp.org/www-project-devsecops-guideline/latest/03-CI-CD/)
 
 ---

--- a/docs/pages/devsecops/repository-hardening.mdx
+++ b/docs/pages/devsecops/repository-hardening.mdx
@@ -7,9 +7,9 @@ tags:
   - DevOps
 contributors:
   - role: wrote
-    users: [frameworks-volunteer]
+    users: [mattaereal]
   - role: reviewed
-    users: []
+    users: [scode2277]
 ---
 
 import { TagList, AttributionList, TagProvider, TagFilter, ContributeFooter } from '../../../components'

--- a/docs/pages/devsecops/security-testing.mdx
+++ b/docs/pages/devsecops/security-testing.mdx
@@ -8,9 +8,9 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [frameworks-volunteer]
+    users: [mattaereal]
   - role: reviewed
-    users: []
+    users: [scode2277]
 ---
 
 import { TagList, AttributionList, TagProvider, TagFilter, ContributeFooter } from '../../../components'
@@ -161,6 +161,8 @@ rules:
     severity: ERROR
     languages: [javascript, python, solidity]
 
+  # NOTE: This is a simplified example. In production, use a more specific
+  # pattern that matches actual sensitive variables, not any spread argument.
   - id: sensitive-data-logging
     pattern: console.log(...$SENSITIVE)
     message: Do not log sensitive data in production.
@@ -188,7 +190,7 @@ ignore alerts, real findings get missed.
 # nosemgrep: hardcoded-private-key
 # Reason: Test fixtures only — not real keys.
 # Ticket: SEC-1234, suppress until test fixture refactored.
-# Expiry: 2025-06-01
+# Expiry: 2027-06-01
 ```
 
 Every suppression should include: the finding ID, why it is a false positive,


### PR DESCRIPTION
## Summary

Remediates frontmatter attribution and minor issues from #461.

### Changes
- Updates contributors frontmatter in 4 DevSecOps pages:
  - author: mattaereal
  - reviewer: scode2277
- Replaces discontinued keys.mailvelope.com with keyserver.ubuntu.com
- Fixes CISA link text to match URL (Software Bill of Materials)
- Updates expired nosemgrep example date to 2027-06-01
- Adds note about simplified Semgrep rule example

Closes review observations from #461.