### PR TITLE
docs(devsecops): expand IDE extension verification guidance

### DIFF
--- a/docs/pages/devsecops/integrated-development-environments.mdx
+++ b/docs/pages/devsecops/integrated-development-environments.mdx
@@ -5,6 +5,9 @@ tags:
   - Engineer/Developer
   - Security Specialist
   - DevOps
+contributors:
+  - role: wrote
+    users: [mattaereal, fredriksvantes, ElliotFriedman]
 ---
 
 import { TagList, AttributionList, TagProvider, TagFilter, ContributeFooter } from '../../../components'
@@ -20,8 +23,17 @@ import { TagList, AttributionList, TagProvider, TagFilter, ContributeFooter } fr
 Integrated Development Environments (IDEs) are essential tools for developers, but they also need to be secured.
 Consider implementing the following best practices:
 
-1. Ensure IDEs are configured securely, with plugins and extensions only installed from trusted sources. Some IDEs have
-  features that allow for automated execution of files in folders. Use restricted mode if you don't fully trust a project.
+1. Install plugins and extensions only from trusted sources, and verify each one through multiple independent channels
+  before installing:
+    - Confirm the publisher matches the expected organization — typosquats and lookalike publishers are common.
+    - Cross-reference the extension's source repository on GitHub; skim recent commits, open issues, and any security
+      advisories.
+    - Check install counts and verified-publisher badges, and prefer signed / officially-published releases over
+      sideloaded builds.
+
+    Due diligence on extensions is typically low, which is precisely why threat actors target this vector: a single
+    malicious or compromised extension can exfiltrate source, secrets, and session tokens across every project on the
+    machine. Use restricted mode if you don't fully trust a project.
 2. Keep IDEs and their plugins/extensions up-to-date to protect against vulnerabilities.
 3. Integrate static code analysis tools within the IDE to catch security issues early in the development process.
 4. Configure IDEs to follow the principle of least privilege, limiting access to sensitive information and systems.


### PR DESCRIPTION
Item 1 of the IDE hardening list said extensions should come from "trusted sources" without defining what verification looks like. This PR expands it into a multi-channel check (publisher match, GitHub source repo cross-reference, install counts / verified-publisher badges / signed releases) and adds a threat-model line on why extensions are a high-yield target.

Also adds a contributors frontmatter acknowledging historical authors (mattaereal, fredriksvantes) alongside the new contribution.