### PR TITLE
fix: include hidden files in preview build artifact

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -41,5 +41,6 @@ jobs:
         with:
           name: preview-build
           path: docs/dist
+          include-hidden-files: true
           if-no-files-found: error
           retention-days: 1


### PR DESCRIPTION
## Summary

The Vocs search index lives in `docs/dist/.vocs/` (a hidden directory starting with a dot). The `actions/upload-artifact@v4` action **excludes hidden files by default**, so the `.vocs` directory was never included in the preview build artifact. When this artifact was deployed to Cloudflare Pages, the search index was missing, causing `fetch("/.vocs/search-index-<hash>.json")` to return 404 and the native search (`/`) to show no results.

On production (Cloudflare Pages direct build), this works because Cloudflare Pages builds and serves all files including hidden ones. The bug only affects preview deployments built via GitHub Actions.

**Fix:** Add `include-hidden-files: true` to the upload-artifact step in the preview build workflow.

Closes #469
