### PR TITLE
fix: add Web3-specific standards to Integration overview

### DIFF
--- a/docs/pages/opsec/integration/overview.mdx
+++ b/docs/pages/opsec/integration/overview.mdx
@@ -1,11 +1,16 @@
 ---
 title: "OpSec Integration | Security Alliance"
-description: "Integrate OpSec with DevSecOps, privacy frameworks, and governance. Map controls to ISO 27001, NIST, CIS Controls, OWASP, and SOC 2 standards for unified Web3 security approach."
+description: "Integrate OpSec with DevSecOps, privacy frameworks, and governance. Map controls to ISO 27001, NIST, CIS Controls, OWASP, SOC 2, MITRE AADAPT, OWASP SCWE, EEA EthTrust, and OWASP Smart Contract Top 10 standards for unified Web3 security approach."
 tags:
   - Security Specialist
   - Operations & Strategy
   - DevOps
   - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: [scode2277]
 ---
 
 import { TagList, AttributionList, TagProvider, TagFilter, ContributeFooter } from '../../../../components'
@@ -138,11 +143,15 @@ Aligning operational security practices with established security standards and 
 
 ### Web3-Specific Standards
 
-1. **Blockchain Security Framework**: Emerging standards for blockchain security
-2. **Smart Contract Security Standard**: Best practices for contract security
-3. **OWASP for Smart Contracts**: Adapting web security principles to contracts
-4. **Token Security Standards**: Security standards for token implementations
-5. **Cross-Chain Security Standards**: Emerging standards for cross-chain security
+1. **MITRE AADAPT** — [Adversarial Tactics, Techniques, and Procedures for Digital Asset Systems](https://aadapt.mitre.org/). Modeled after MITRE ATT&CK, AADAPT catalogs real-world adversary behavior targeting blockchain and digital-asset infrastructure. It provides a structured taxonomy of tactics, techniques, and sub-techniques that helps security teams understand attacker workflows, map detections, and prioritize defenses. Use AADAPT to align OpSec threat modeling with the latest Web3 TTPs.
+
+2. **OWASP Smart Contract Weakness Enumeration (SCWE)** — [OWASP SCWE](https://scs.owasp.org/SCWE/). A smart-contract-specific weakness enumeration inspired by CWE. SCWE supersedes the now-outdated SWC Registry, covering all 36 SWC entries plus additional weakness classes identified since. Reference SCWE when classifying vulnerabilities found during audits, penetration tests, or formal verification to maintain a consistent, community-maintained taxonomy.
+
+3. **OWASP Smart Contract Top 10** — [Smart Contract Top 10](https://owasp.org/www-project-smart-contract-top-10/). An awareness standard under the OWASP Top 10 initiative that highlights the ten most critical smart contract vulnerability categories, ranked and updated yearly. Use it as a risk-prioritization checklist during design reviews and audit scoping to ensure the most impactful weaknesses receive attention first.
+
+4. **EEA EthTrust Security Levels v3** — [EthTrust SL v3](https://entethalliance.org/specs/ethtrust-sl/). Defines certification requirements and three assurance levels (S, M, Q) for audited smart contracts. Level S requires formal verification and comprehensive testing; Level M requires thorough manual review; Level Q covers quick-scan assessments. Map OpSec audit procedures to the appropriate EthTrust level to communicate assurance rigor to stakeholders and regulators.
+
+5. **Cross-Chain Security Standards**: Emerging standards for cross-chain bridge and messaging protocol security, where bridge exploits remain a dominant attack vector.
 
 ## Creating a Unified Security Approach
 

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -362,3 +362,6 @@ viem
 wagmi
 NCSC
 Intune
+AADAPT
+SCWE
+EthTrust


### PR DESCRIPTION
## Summary

Replaces the generic "Web3-Specific Standards" entries in the Integration overview page with concrete, well-documented standards as requested in #176:

1. **MITRE AADAPT** — Adversarial tactics and techniques for digital asset systems, modeled after MITRE ATT&CK
2. **OWASP SCWE** — Smart contract weakness enumeration that supersedes the outdated SWC Registry
3. **OWASP Smart Contract Top 10** — Yearly-updated awareness standard for top smart contract vulnerability categories
4. **EEA EthTrust Security Levels v3** — Certification requirements with three assurance levels (S, M, Q) for audited smart contracts

Also adds `contributors` frontmatter (mattaereal/scode2277) and updates the page description and cspell wordlist (AADAPT, SCWE, EthTrust).

Closes #176
