### PR TITLE
fix: add early-stage standards section, omit unlinkable entries

### DIFF
--- a/docs/pages/opsec/integration/overview.mdx
+++ b/docs/pages/opsec/integration/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "OpSec Integration | Security Alliance"
-description: "Integrate OpSec with DevSecOps, privacy frameworks, and governance. Map controls to ISO 27001, NIST, CIS Controls, OWASP, SOC 2, MITRE AADAPT, OWASP SCWE, EEA EthTrust, and OWASP Smart Contract Top 10 standards for unified Web3 security approach."
+description: "Integrate OpSec with DevSecOps, privacy frameworks, and governance. Map controls to ISO 27001, NIST, CIS Controls, OWASP, SOC 2, MITRE AADAPT, OWASP SCWE, EEA EthTrust, OWASP Smart Contract Top 10, and CCSS standards for unified Web3 security approach."
 tags:
   - Security Specialist
   - Operations & Strategy
@@ -151,7 +151,11 @@ Aligning operational security practices with established security standards and 
 
 4. **EEA EthTrust Security Levels v3** — [EthTrust SL v3](https://entethalliance.org/specs/ethtrust-sl/). Defines certification requirements and three assurance levels (S, M, Q) for audited smart contracts. Level S requires formal verification and comprehensive testing; Level M requires thorough manual review; Level Q covers quick-scan assessments. Map OpSec audit procedures to the appropriate EthTrust level to communicate assurance rigor to stakeholders and regulators.
 
-5. **Cross-Chain Security Standards**: Emerging standards for cross-chain bridge and messaging protocol security, where bridge exploits remain a dominant attack vector.
+### Early-Stage & Emerging Standards
+
+The following initiatives are still under active development. They are listed here for awareness, but their specifications may change significantly. Always refer to the linked resources for the latest status.
+
+1. **CryptoCurrency Security Standard (CCSS)** — [C4 CCSS](https://cryptoconsortium.org/ccss/). An open standard developed by the CryptoCurrency Certification Consortium (C4) that defines security requirements for systems that handle cryptocurrencies. CCSS covers key management, wallet generation, and transaction signing at three levels of increasing rigor. While primarily aimed at custodial and exchange infrastructure, its control categories can inform OpSec practices for any organization handling digital assets.
 
 ## Creating a Unified Security Approach
 

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -365,3 +365,4 @@ Intune
 AADAPT
 SCWE
 EthTrust
+CCSS


### PR DESCRIPTION
## Summary

Addresses feedback from @mattaereal on PR #475:

1. **Removed "Cross-Chain Security Standards"** from the main Web3-Specific Standards list -- no citable standard or link exists for this. Per the feedback: if you can't link it, don't include it.

2. **Added "Early-Stage & Emerging Standards" subsection** with a clear disclaimer that these initiatives are under active development and may change. Only includes entries with verified, working links to the actual initiative.

3. **Added CCSS (CryptoCurrency Security Standard)** by C4 -- a real, citable standard with a live page at https://cryptoconsortium.org/ccss/. Covers key management, wallet generation, and transaction signing at three levels of rigor.

The three previously deleted placeholder names ("Blockchain Security Framework", "Smart Contract Security Standard", "Token Security Standards") remain omitted -- none map to real, citable initiatives with working links.

Closes #176 (together with #475)
