### PR TITLE
ci: bump GitHub Actions to Node.js 24 runtime

### DIFF
--- a/.github/workflows/md-lint.yaml
+++ b/.github/workflows/md-lint.yaml
@@ -9,8 +9,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: DavidAnson/markdownlint-cli2-action@v20
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd # v23.2.0
       continue-on-error: true
       with:
         globs: |

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -14,16 +14,16 @@ jobs:
     name: Build Preview Site
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: pnpm
@@ -37,7 +37,7 @@ jobs:
           CF_PAGES_BRANCH: ${{ github.head_ref }}
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: preview-build
           path: docs/dist

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -27,7 +27,7 @@ jobs:
       url: ${{ steps.cloudflare-preview-deploy.outputs.alias || steps.cloudflare-preview-deploy.outputs.url }}
     steps:
       - name: Download build artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         id: preview-build-artifact
         with:
           name: preview-build

--- a/.github/workflows/s3-upload.yml
+++ b/.github/workflows/s3-upload.yml
@@ -37,7 +37,7 @@ jobs:
       # Step 0: Verify user permissions
       - name: Verify user permissions
         id: check-permissions
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const allowed = ['admin', 'maintain', 'triage'];
@@ -61,7 +61,7 @@ jobs:
 
       # Step 1: Acknowledge the command by adding a reaction
       - name: React to command
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             // Add an "eyes" emoji reaction to the comment to show we're processing
@@ -75,7 +75,7 @@ jobs:
       # Step 2: Extract GitHub image URLs from the comment
       - name: Extract GitHub image URLs
         id: extract-urls
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const comment = context.payload.comment.body;
@@ -193,24 +193,24 @@ jobs:
 
       # Step 4: Checkout repository
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # Step 5: Setup Node.js and pnpm
       - name: Setup Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "20"
 
       # Step 6: Install pnpm
       - name: Setup pnpm
-        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
         with:
           version: 10.15.0
           run_install: false
 
       # Step 7: Cache pnpm dependencies
       - name: Cache pnpm dependencies
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: pnpm-cache
         with:
           path: |
@@ -228,7 +228,7 @@ jobs:
 
       # Step 9: Write URLs to a temp file for the processing script
       - name: Write URLs to file
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');
@@ -248,7 +248,7 @@ jobs:
 
       # Step 9b: Configure AWS credentials using OIDC (just-in-time before upload)
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}
@@ -296,7 +296,7 @@ jobs:
 
       # Step 11: Comment results back to PR and check for failures
       - name: Comment results and check failures
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           RESULTS_FILE_PATH: ${{ env.RESULTS_FILE_PATH }}
         with:

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -17,7 +17,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 2
@@ -50,7 +50,7 @@ jobs:
 
       - name: Comment on pull request
         if: env.TYPOS != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/vocs-config-reminder.yml
+++ b/.github/workflows/vocs-config-reminder.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check for added, renamed, or removed documentation files
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             // Sanitize filenames


### PR DESCRIPTION
## Summary

Upgrades all GitHub Actions in workflow files from **node20** to **node24** runtimes to resolve the upcoming deprecation warnings (node20 actions will be forced to node24 starting June 2, 2026, and removed September 16, 2026).

## Actions upgraded

- `actions/checkout` v4 → v6.0.2
- `actions/setup-node` v4 → v6.4.0
- `actions/upload-artifact` v4 → v7.0.1
- `actions/download-artifact` v4 → v8.0.1
- `pnpm/action-setup` v4 → v6.0.5
- `actions/github-script` v7 → v9.0.0
- `actions/cache` v4 → v5.0.5
- `aws-actions/configure-aws-credentials` v4 → v6.1.1
- `DavidAnson/markdownlint-cli2-action` v20 → v23.2.0

## Not upgraded

- `AdrianGonz97/refined-cf-pages-action` remains at **v1.3.0** — the latest upstream release still runs on node20 and no node24 release is available yet.

## Verification

All bumped versions were verified via GitHub raw `action.yml` to confirm `runs.using: node24`.