### PR TITLE
fix(security): add overrides for uuid and tmp advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
       "lodash-es": ">=4.18.1",
       "yaml": ">=2.8.4",
       "fast-xml-parser": ">=5.7.0",
-      "hono": ">=4.12.18"
+      "hono": ">=4.12.18",
+      "uuid": ">=11.1.1",
+      "tmp": ">=0.2.6"
     }
   },
   "packageManager": "pnpm@10.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,8 @@ overrides:
   yaml: '>=2.8.4'
   fast-xml-parser: '>=5.7.0'
   hono: '>=4.12.18'
+  uuid: '>=11.1.1'
+  tmp: '>=0.2.6'
 
 importers:
 
@@ -54,7 +56,7 @@ importers:
         specifier: ^0.34.5
         version: 0.34.5
       uuid:
-        specifier: ^14.0.0
+        specifier: '>=11.1.1'
         version: 14.0.0
     devDependencies:
       '@types/react':
@@ -4537,8 +4539,8 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
-  tmp@0.2.5:
-    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+  tmp@0.2.6:
+    resolution: {integrity: sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==}
     engines: {node: '>=14.14'}
 
   toidentifier@1.0.1:
@@ -4671,11 +4673,6 @@ packages:
 
   uuid@14.0.0:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
-    hasBin: true
-
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vary@1.1.2:
@@ -8122,9 +8119,9 @@ snapshots:
       jszip: 3.10.1
       readable-stream: 3.6.2
       saxes: 5.0.1
-      tmp: 0.2.5
+      tmp: 0.2.6
       unzipper: 0.10.14
-      uuid: 8.3.2
+      uuid: 14.0.0
 
   execa@5.1.1:
     dependencies:
@@ -10043,7 +10040,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
-  tmp@0.2.5: {}
+  tmp@0.2.6: {}
 
   toidentifier@1.0.1: {}
 
@@ -10190,8 +10187,6 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@14.0.0: {}
-
-  uuid@8.3.2: {}
 
   vary@1.1.2: {}
 


### PR DESCRIPTION
## Summary

Corrects the overbroad overrides from PR #503. `pnpm audit` on develop shows only **2 open advisories** (not 71). The remaining 69 were already resolved by recent Dependabot group bumps (e.g. #491, #502).

### Changes

Adds only the two overrides actually needed:

- **uuid >=11.1.1** (GHSA-w5hq-g745-h8pq) — transitive dep `exceljs>uuid@8.3.2`
- **tmp >=0.2.6** (GHSA-ph9p-34f9-6g65) — transitive dep `exceljs>tmp@0.2.5` (path traversal)

### What was removed from #503

The 11 unnecessary overrides that were added in #503 (`@hono/node-server`, `flatted`, `smol-toml`, `brace-expansion`, `picomatch`, `dompurify`, `vite`, `follow-redirects`, `axios`, `postcss`, `mermaid`) and version bumps to existing overrides (`yaml`, `hono`) are dropped — those advisories are already resolved on develop.

Closes open dependabot alerts.

Supersedes #503
