### PR TITLE
fix: run spell-check with pinned cspell version

### DIFF
--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -22,13 +22,25 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 2
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
       - name: Find and check typos in mdx files
         id: find_typos
         run: |
           echo "Checking for typos..."
           set -o pipefail
           # Run cspell and capture output, but don't fail yet
-          output=$(npx cspell lint "docs/pages/**/*.mdx" --no-progress --no-summary || true)
+          output=$(pnpm exec cspell lint "docs/pages/**/*.mdx" --no-progress --no-summary || true)
 
           if [[ -n "$output" ]]; then
             echo "Typos found, formatting output..."

--- a/justfile
+++ b/justfile
@@ -21,7 +21,7 @@ preview: install
 # Run all linting checks
 lint:
     @echo "Running spell check..."
-    find ./docs/pages -name "*.mdx" -print0 | xargs -0 npx cspell
+    find ./docs/pages -name "*.mdx" -print0 | xargs -0 pnpm exec cspell
     @echo "Spell check complete!"
     @echo ""
     @echo "Running markdownlint..."


### PR DESCRIPTION
Spell-check workflow used `npx cspell`, which fetched the latest cspell from npm at runtime instead of the version pinned in `package.json`/`pnpm-lock.yaml`.
- Added `pnpm/action-setup` + `actions/setup-node` (Node 22) and a `pnpm install` step, then switched to `pnpm exec cspell`.
- Updated the `justfile` `lint` to use `pnpm exec cspell` so local runs match CI.

## Frameworks PR Checklist

Thank you for contributing to the Security Frameworks! Before you open a PR, make sure to read [information for contributors](https://frameworks.securityalliance.dev/contribute/contributing) and take a look at the following checklist:

- [ ] Describe your changes, substitute this text with the information
- [ ] If you are touching an existing piece of content, tag current contributors from the attribution list
- [ ] If there is a steward for that framework, ask the steward to review it
- [ ] If you're modifying the general outline, make sure to update it in the `vocs.config.ts` adding the `dev: true` parameter
- [ ] If you need feedback for your content from the wider community, share the PR in our Discord
- [ ] Review changes to ensure there are no typos; see instructions below.

<!--
ℹ️ Checking for typos locally
1. Install [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2)
2. Install [just](https://github.com/casey/just)
3. Run `npx just lint`
-->
