### PR TITLE
chore: improve dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,12 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "UTC"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     target-branch: "develop"
     groups:
-      npm_and_yarn:
+      pnpm-deps:
         patterns:
           - "*"
         update-types:
@@ -22,16 +24,24 @@ updates:
       - "dependencies"
 
   - package-ecosystem: "github-actions"
-    directory: "/.github/workflows"
+    directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
       time: "09:00"
       timezone: "UTC"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 3
     target-branch: "develop"
+    groups:
+      actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     commit-message:
       prefix: "chore(gha)"
     labels:
       - "dependencies"
-      - "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -68,9 +68,6 @@ updates:
 
     cooldown:
       default-days: 7
-      semver-patch-days: 7
-      semver-minor-days: 14
-      semver-major-days: 30
 
     open-pull-requests-limit: 3
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,47 +1,101 @@
 version: 2
+
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+
     schedule:
       interval: "weekly"
       day: "monday"
       time: "09:00"
       timezone: "UTC"
+
+    target-branch: "develop"
+
+    # Normal version updates only.
+    # Security updates are not delayed by cooldown.
     cooldown:
       default-days: 7
+      semver-patch-days: 7
+      semver-minor-days: 14
+      semver-major-days: 30
+
     open-pull-requests-limit: 5
-    target-branch: "develop"
+
+    # Conservative npm behavior:
+    # do not rewrite package.json ranges unless needed.
+    versioning-strategy: "increase-if-necessary"
+
     groups:
-      pnpm-deps:
+      pnpm-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+
+      pnpm-minor:
+        applies-to: "version-updates"
         patterns:
           - "*"
         update-types:
           - "minor"
-          - "patch"
+
+    # Block routine major updates.
+    # Handle majors manually / intentionally.
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+
     commit-message:
       prefix: "chore(deps)"
+
     labels:
       - "dependencies"
+      - "npm"
 
   - package-ecosystem: "github-actions"
     directory: "/"
+
     schedule:
       interval: "weekly"
       day: "monday"
       time: "09:00"
       timezone: "UTC"
+
+    target-branch: "develop"
+
     cooldown:
       default-days: 7
+      semver-patch-days: 7
+      semver-minor-days: 14
+      semver-major-days: 30
+
     open-pull-requests-limit: 3
-    target-branch: "develop"
+
     groups:
-      actions:
+      actions-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+
+      actions-minor:
+        applies-to: "version-updates"
         patterns:
           - "*"
         update-types:
           - "minor"
-          - "patch"
+
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+
     commit-message:
       prefix: "chore(gha)"
+
     labels:
       - "dependencies"


### PR DESCRIPTION
This PR improves the dependabot setup with these changes:

- Fix `github-actions` block directory from `/.github/workflows` to `/` (correct value per GitHub docs)
- Add `cooldown: default-days: 7` to both blocks to avoid auto-PRs on freshly published versions
- Add grouping to `github-actions` block (was missing)
- Rename group `npm_and_yarn` to `pnpm-deps` to reflect the actual package manager in use
- Remove `github-actions` label from labels block

## Frameworks PR Checklist

Thank you for contributing to the Security Frameworks! Before you open a PR, make sure to read [information for contributors](https://frameworks.securityalliance.dev/contribute/contributing) and take a look at the following checklist:

- [ ] Describe your changes, substitute this text with the information
- [ ] If you are touching an existing piece of content, tag current contributors from the attribution list
- [ ] If there is a steward for that framework, ask the steward to review it
- [ ] If you're modifying the general outline, make sure to update it in the `vocs.config.ts` adding the `dev: true` parameter
- [ ] If you need feedback for your content from the wider community, share the PR in our Discord
- [ ] Review changes to ensure there are no typos; see instructions below.

<!--
ℹ️ Checking for typos locally
1. Install [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2)
2. Install [just](https://github.com/casey/just)
3. Run `npx just lint`
-->
