### PR TITLE
certs: expand the contributions guide

### DIFF
--- a/docs/pages/certs/contributions.mdx
+++ b/docs/pages/certs/contributions.mdx
@@ -37,7 +37,11 @@ The section structure within each certification category is fixed; new controls 
 - **Submit a pull request** to this repo. See the general [Contributing guide](/contribute/contributing) for setup, branching, commit signing, and attribution.
 - **For larger ideas** (a new certification category, or restructuring), open an issue with the `certifications` tag first so we can align before any code is written.
 
-Feedback from auditors running real engagements is especially valuable. If a control or baseline doesn't hold up in practice, tell us, and a PR is even better.
+Feedback from auditors running real engagements is especially valuable. If a control or baseline doesn't hold up in practice, please tell us; a PR is even better.
+
+Reach out directly through:
+- Email: [certs@securityalliance.org](mailto:certs@securityalliance.org)
+- Discord: [Security Alliance server](http://discord.gg/securityalliance)
 
 ## Versioning and Releases
 

--- a/docs/pages/certs/contributions.mdx
+++ b/docs/pages/certs/contributions.mdx
@@ -1,9 +1,13 @@
 ---
 title: "Contributing to SEAL Certifications | Security Alliance"
-description: "Contribute to SEAL Certifications: suggest improvements, propose new certifications, or become a SEAL-approved auditor."
+description: "Contribute to SEAL Certifications: improve controls, add controls, or propose new certification categories. The frameworks repo is the source of truth, and changes ship in named releases."
 tags:
   - SEAL/Initiative
   - Certifications
+  - SFC
+contributors:
+  - role: wrote
+    users: [isaac]
 ---
 
 import { TagList, AttributionList, TagProvider, TagFilter, ContributeFooter } from '../../../components'
@@ -11,21 +15,35 @@ import { TagList, AttributionList, TagProvider, TagFilter, ContributeFooter } fr
 <TagProvider>
 <TagFilter />
 
-# Contributions
+# Contributing to SEAL Certifications
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Like the rest of Frameworks, SEAL Certifications are open-source and accept contributions from the community.  However,
-due to the nature of Certifications, contributions are subject to more stringent review and approval processes managed
-by Isaac, the initiative lead, and the other Certifications maintainers.
+Like the rest of Frameworks, SEAL Certifications is open-source and welcomes community contributions. Because the certification carries more weight than general docs, changes go through a more stringent review, and final decisions are made by the SEAL Certifications initiative lead.
 
-- If you have suggestions for improving existing Certifications, or ideas for a new Certification, please open an issue
-  in the frameworks repo with the `certifications` tag. We welcome feedback and ideas from the community!
-- If you're a protocol interested in having your project certified, you can reach out to us through our [protocol
-  interest form](https://securityalliance.typeform.com/CertsWaitlist).
-- If you're a security firm interested in becoming a SEAL-approved auditor, please reach out through our [interest form](https://securityalliance.typeform.com/CertsAuditor).
+**This repository is the source of truth for all certification controls.** The controls for each certification category (Multisig Ops, Treasury Ops, Incident Response, and so on) live in the `cert:` block at the top of its page, for example [`sfc-multisig-ops.mdx`](/certs/sfc-multisig-ops). To change what the certification requires, change it here.
 
-For more information on contributing to SEAL Certifications, or the rest of Frameworks, please see the [Contributing Guide](/contribute/contributing).
+## What You Can Contribute
+
+- **Improve a control**: clarify wording, or fix and refine baselines.
+- **Add a control** to an existing certification category.
+- **Propose a new certification category**: open an issue first (see below) so we can discuss scope before it's built out.
+
+The section structure within each certification category is fixed; new controls are added within the existing sections.
+
+## How to Contribute
+
+- **Submit a pull request** to this repo. See the general [Contributing guide](/contribute/contributing) for setup, branching, commit signing, and attribution.
+- **For larger ideas** (a new certification category, or restructuring), open an issue with the `certifications` tag first so we can align before any code is written.
+
+Feedback from auditors running real engagements is especially valuable. If a control or baseline doesn't hold up in practice, tell us, and a PR is even better.
+
+## Versioning and Releases
+
+- Each certification category page carries a **`version`** in its header.
+- **Control IDs** (such as `ms-2.1.2`) are kept stable across revisions wherever possible. When a control is renumbered, it's called out in the changelog so anyone tracking controls can re-map cleanly.
+- Changes are batched into periodic **named releases** and recorded in the [changelog](/certs/changelog), which summarizes what changed, when, and why.
+- Releases are named after **seal species**, advancing alphabetically (Baikal, Bearded, Crabeater, Elephant, and so on), so a given state of the framework can be referred to by name as well as by version.
 
 </TagProvider>


### PR DESCRIPTION
Expands the thin `certs/contributions.mdx` into a lightweight guide for contributing to the certifications.

### What it documents
- **This repo is the source of truth** for controls; each cert's controls live in the `cert:` block of its page.
- What you can contribute: improve a control, add a control to an existing cert, or propose a new cert (issue first).
- **Categories are fixed**; new controls are added within existing categories.
- Final decisions rest with the **SEAL Certifications initiative lead**.
- Lightweight release process: stable control IDs (renumbers called out for workbook re-mapping), changes batched into **named releases** tracked in the changelog. Releases are named after **seal species**, alphabetically (Baikal, Bearded, Crabeater, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)