### PR TITLE
chore: rewrite searchbar indexer for Vocs v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "docs:dev": "pnpm run generate-tags && pnpm run generate-indexes && vocs dev --host 0.0.0.0 --port 5173",
     "docs:build": "pnpm run generate-tags && pnpm run generate-indexes && pnpm run generate-printables && pnpm run generate-cert-data && vocs build",
-    "postdocs:build": "node utils/sitemap-generator.cjs && node utils/generate-llms.cjs",
+    "postdocs:build": "node utils/sitemap-generator.cjs && node utils/generate-llms.cjs && node utils/searchbar-indexing.cjs",
     "docs:preview": "vocs preview",
     "generate-tags": "node utils/tags-fetcher.cjs",
     "generate-indexes": "node utils/generate-folder-indexes.cjs",

--- a/utils/searchbar-indexing.cjs
+++ b/utils/searchbar-indexing.cjs
@@ -1,318 +1,186 @@
 /*
-  Purpose
-  - Temporary patch for a known Vocs issue where their search indexer skips MDX files
-    containing ESM imports or React components. This is a known open issue on Vocs’ GitHub.
-  - Until Vocs releases an official fix, this script ensures those pages are properly indexed.
-
-  What it does
-  - Builds a MiniSearch index **only** from the files listed in the sidebar (i.e., the ones
-    we explicitly want indexed).
-  - Respects branch-based filtering: on main branch, excludes pages marked with dev: true
-    (matching the sidebar filtering logic in vocs.config.ts).
-  - Parses MDX files as plain text, extracting headings and content.
-  - Generates a clean search index that includes all pages — even those with imports.
-  - After the build, it overwrites Vocs' generated `search-index-<hash>.json`
-    with our patched version in the appropriate Cloudflare Pages output directory.
-
-  High-level flow
-  1) Check branch via CF_PAGES_BRANCH (main vs develop/other).
-  2) Locate the generated search index file by scanning common output paths:
-     - dist/.vocs                             (Cloudflare Pages build output)
-     - docs/dist/.vocs                        (local build output)
-  3) Parse vocs.config.ts sidebar to collect allowed routes (excluding dev: true on main).
-  4) Walk docs/pages and extract sections using markdown headings (#, ##, etc.).
-  5) Filter to only allowed routes and build a MiniSearch index (code tags stripped).
-  6) Overwrite the found `search-index-<hash>.json` and mirror it across other .vocs dirs.
+  Post-processes Vocs v2's search index to match the curated nav and the develop/production split.
+  Vocs v2 indexes every built route (including off-sidebar/stale pages, folder-index duplicates, and
+  `dev: true` pages), so we load its index and discard the sections that should not be searchable:
+    - Allowlist to sidebar routes (vocs.config.ts). On main, also drop `dev: true` routes.
+    - On main, drop sections whose heading is wrapped in <DevOnly> (components/dev-only/DevOnly.tsx
+      renders null on main, but Vocs still indexes the raw MDX text).
+  The filtered index is written back to the SAME dist/public/assets/search-index-<hash>.json (its
+  hashed name is baked into the built client). We post-process rather than re-index because the
+  Vocs v1 indexer skipped MDX with imports/components; v2 indexes correctly.
 */
 
 const fs = require('fs');
 const path = require('path');
-const matter = require('gray-matter');
 const MiniSearch = require('minisearch');
 
 const workspaceRoot = process.cwd();
-const pagesDir = path.join(workspaceRoot, 'docs', 'pages');
-const distVocsDir = path.join(workspaceRoot, 'docs', 'dist', '.vocs');
-const cfPagesDistVocsDir = path.join(workspaceRoot, 'dist', '.vocs');
-const cfPagesStaticDir = path.join(workspaceRoot, 'dist');
+const assetsDir = path.join(workspaceRoot, 'dist', 'public', 'assets');
 const vocsConfigPath = path.join(workspaceRoot, 'vocs.config.ts');
+const pagesDir = path.join(workspaceRoot, 'docs', 'pages');
 
-function walkFiles(dir, out = []) {
-  // Recursively collect .mdx files
+// Must match Vocs' own index options (node_modules/vocs/dist/internal/search.client.js)
+// so MiniSearch.loadJSON can rehydrate the index Vocs serialized.
+const searchFields = ['category', 'subtitle', 'text', 'title', 'titles'];
+const storeFields = ['category', 'href', 'searchPriority', 'subtitle', 'text', 'title', 'titles', 'type'];
+
+// Walk the sidebar, collecting every link. `dev: true` is inherited from ancestor groups,
+// mirroring collectDevLinks()/filterDevItems() in vocs.config.ts so the two stay in sync.
+function collectLinks(items, parentIsDev, all, dev) {
+  for (const item of items) {
+    const isDev = Boolean(item.dev) || parentIsDev;
+    if (item.link) {
+      all.add(item.link);
+      if (isDev) dev.add(item.link);
+    }
+    if (Array.isArray(item.items)) collectLinks(item.items, isDev, all, dev);
+  }
+}
+
+// Extract the `sidebar: [ ... ]` array literal from vocs.config.ts and evaluate it.
+// The sidebar is pure data (text/link/dev/collapsed/items), so it evaluates as plain JS.
+// Bracket-matching (rather than line-by-line regex) preserves nesting, which is what lets us
+// inherit `dev: true` from a parent group down to its children.
+function readSidebarLinks() {
+  const source = fs.readFileSync(vocsConfigPath, 'utf8');
+
+  const keyIdx = source.indexOf('sidebar:');
+  if (keyIdx === -1) throw new Error('Could not find `sidebar:` in vocs.config.ts');
+  const startIdx = source.indexOf('[', keyIdx);
+  if (startIdx === -1) throw new Error('Could not find start of sidebar array in vocs.config.ts');
+
+  let depth = 0;
+  let quote = null;
+  let endIdx = -1;
+  for (let i = startIdx; i < source.length; i++) {
+    const ch = source[i];
+    const prev = source[i - 1];
+    if (quote) {
+      if (ch === quote && prev !== '\\') quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') {
+      quote = ch;
+    } else if (ch === '[') {
+      depth++;
+    } else if (ch === ']') {
+      depth--;
+      if (depth === 0) {
+        endIdx = i;
+        break;
+      }
+    }
+  }
+  if (endIdx === -1) throw new Error('Could not find end of sidebar array in vocs.config.ts');
+
+  // eslint-disable-next-line no-new-func -- evaluating our own config's data-only sidebar
+  const sidebar = new Function(`return (${source.slice(startIdx, endIdx + 1)});`)();
+  const all = new Set();
+  const dev = new Set();
+  collectLinks(sidebar, false, all, dev);
+  return { all, dev };
+}
+
+function findIndexFile() {
+  if (!fs.existsSync(assetsDir)) return undefined;
+  const match = fs
+    .readdirSync(assetsDir)
+    .filter((f) => /^search-index-.*\.json$/i.test(f))
+    .sort()[0];
+  return match ? path.join(assetsDir, match) : undefined;
+}
+
+function walkMdx(dir, out = []) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const p = path.join(dir, entry.name);
-    if (entry.isDirectory()) walkFiles(p, out);
+    if (entry.isDirectory()) walkMdx(p, out);
     else if (/\.mdx$/i.test(entry.name)) out.push(p);
   }
   return out;
 }
 
-function slugify(input) {
-  // Minimal slug generator for anchor fragments derived from headings
-  return String(input)
-    .trim()
-    .toLowerCase()
-    .replace(/&/g, 'and')
-    .replace(/[^a-z0-9\s\-]/g, '')
-    .replace(/\s+/g, '-')
-    .replace(/\-+/g, '-')
-    .replace(/^\-|\-$/g, '');
-}
-
-function removeFences(str) {
-  // Remove fenced code blocks’ opening lines to avoid dense token noise
-  return str.replace(/^```.*$/gm, '').replace(/^~~~.*$/gm, '');
-}
-
-function normalizeSlashes(p) {
-  return p.split(path.sep).join('/');
-}
-
-function computeHref(filePath) {
-  // Map docs/pages/<path>.mdx to /<path> (index.md[x] collapses to directory route)
-  const relFromPages = normalizeSlashes(path.relative(pagesDir, filePath));
-  const withoutExt = relFromPages.replace(/\.mdx$/i, '');
-  const noIndex = withoutExt.replace(/\/index$/i, '');
+// Map docs/pages/<path>.mdx to its route (/<path>, with index files collapsing to the directory),
+// matching the hrefs Vocs stores in the index.
+function fileToRoute(file) {
+  const rel = path.relative(pagesDir, file).split(path.sep).join('/');
+  const noExt = rel.replace(/\.mdx$/i, '');
+  const noIndex = noExt.replace(/(^|\/)index$/i, '');
   return `/${noIndex}`;
 }
 
-function extractSectionsFromMdx(raw) {
-  // Parse frontmatter, then split content into sections by ATX headings
-  const { content } = matter(raw);
-  const lines = content.split(/\r?\n/);
-
-  const sections = [];
-  let current = null;
-  let parentTitles = [];
-
-  for (const line of lines) {
-    const m = /^(#{1,6})\s+(.*)$/.exec(line);
-    if (m) {
-      // Emit previously collected section before starting a new heading
-      if (current) sections.push(current);
-
-      const level = m[1].length;
-      const title = m[2].trim();
-      const anchor = slugify(title);
-
-      const titles = parentTitles.slice(0, level - 1);
-      titles[level - 1] = title;
-      parentTitles = titles.slice();
-
-      current = {
-        level,
-        title,
-        anchor,
-        titles: titles.slice(0, -1),
-        chunks: [],
-      };
-    } else {
-      if (!current) continue; // ignore text until first heading
-      current.chunks.push(line);
+// Collect "<route>\n<heading text>" keys for every ATX heading wrapped in a <DevOnly> block.
+// Vocs indexes one section per heading and stores the heading text as `title`, so a section is
+// uniquely identified within a page by (route, title). Only whole headings placed inside <DevOnly>
+// are handled (the way the component is used); text wrapped under a heading defined outside the
+// block stays in that heading's section and is not removed.
+function collectDevOnlyHeadingKeys() {
+  const keys = new Set();
+  for (const file of walkMdx(pagesDir)) {
+    const raw = fs.readFileSync(file, 'utf8');
+    if (!raw.includes('<DevOnly')) continue;
+    const route = fileToRoute(file);
+    const blockRe = /<DevOnly\b[^>]*>([\s\S]*?)<\/DevOnly>/g;
+    let block;
+    while ((block = blockRe.exec(raw))) {
+      for (const line of block[1].split(/\r?\n/)) {
+        const heading = /^#{1,6}\s+(.*\S)\s*$/.exec(line);
+        if (heading) keys.add(`${route}\n${heading[1].trim()}`);
+      }
     }
   }
-
-  if (current) sections.push(current);
-
-  return sections.map((s, idx) => {
-    const text = removeFences(s.chunks.join('\n'))
-      .replace(/<[^>]*>/g, '')
-      .trim();
-    return {
-      anchor: s.anchor,
-      title: s.title,
-      titles: s.titles,
-      isPage: idx === 0,
-      text,
-    };
-  });
+  return keys;
 }
 
-async function main() {
-  // Only run this script in CI/deployment environments (Cloudflare Pages or GitHub Actions)
-  // Skip during local builds
-  const isCloudflarePages = !!process.env.CF_PAGES;
-  const isCI = !!process.env.CI;
+function main() {
+  const isMainBranch = process.env.CF_PAGES_BRANCH === 'main';
 
-  if (!isCloudflarePages && !isCI) {
-    console.log('Skipping search index generation: not running in a deployment environment (Cloudflare Pages or CI)');
+  const indexFile = findIndexFile();
+  if (!indexFile) {
+    // Do not fail the build: surface it loudly but let the deploy proceed.
+    console.error(`Search index: WARNING - no search-index-*.json found in ${assetsDir}; index was NOT filtered.`);
     return;
   }
 
-  // Determine where the built search index exists (try Cloudflare Pages dist, docs/dist)
-  // Try these directories in order; pick the first that contains the index
-  const candidateDirs = [cfPagesDistVocsDir, distVocsDir];
+  const { all, dev } = readSidebarLinks();
+  // develop/preview: allow every sidebar link. main: drop dev links from the allowlist.
+  const allowed = isMainBranch ? new Set([...all].filter((link) => !dev.has(link))) : all;
+  console.log(
+    `Search index: ${isMainBranch ? 'main (production)' : 'develop/preview'} branch, ` +
+      `${allowed.size} allowed routes (${all.size} sidebar links, ${dev.size} dev).`,
+  );
 
-  let baseDirForIndex = undefined;
-  let fileName = undefined;
+  // On main, also strip individual sections whose heading lives inside a <DevOnly> block.
+  const devOnlyHeadings = isMainBranch ? collectDevOnlyHeadingKeys() : new Set();
+  if (isMainBranch) console.log(`Search index: ${devOnlyHeadings.size} <DevOnly> headings to strip.`);
 
-  for (const dir of candidateDirs) {
-    try {
-      if (!fs.existsSync(dir)) {
-        console.log(`Listing skipped (not found): ${dir}`);
-        continue;
-      }
-      const items = fs.readdirSync(dir);
-      console.log(`Listing ${dir}:`, items);
-      const candidates = items.filter((f) => /^search-index-.*\.json$/i.test(f)).sort();
-      if (candidates.length > 0) {
-        baseDirForIndex = dir;
-        fileName = candidates[0];
-        break;
-      }
-    } catch (e) {
-      console.log(`Listing failed for ${dir}: ${e.message}`);
-    }
+  const raw = JSON.parse(fs.readFileSync(indexFile, 'utf8'));
+
+  // Keep only sections whose clean route (storedFields.href without #anchor) is allowed, and
+  // (on main) drop sections whose heading was wrapped in <DevOnly>. Discard by the original
+  // document id (documentIds[internalId]).
+  const idsToDiscard = [];
+  for (const internalId of Object.keys(raw.documentIds)) {
+    const stored = raw.storedFields[internalId] || {};
+    const route = (stored.href || '').split('#')[0];
+    const isDevOnlySection = devOnlyHeadings.has(`${route}\n${stored.title}`);
+    if (!allowed.has(route) || isDevOnlySection) idsToDiscard.push(raw.documentIds[internalId]);
   }
 
-  if (!baseDirForIndex || !fileName) {
-    console.error(`No existing Vocs search index file found in any candidate directory: ${candidateDirs.join(', ')}`);
-    process.exit(1);
+  const before = Object.keys(raw.documentIds).length;
+  if (idsToDiscard.length === 0) {
+    console.log(`Search index: all ${before} sections are on the allowlist, nothing to do.`);
+    return;
   }
 
-  const payloadTargets = [];
-  // Always write back to the discovered base dir first
-  payloadTargets.push(path.join(baseDirForIndex, fileName));
-  // And mirror to common output locations if they exist or can be created
-  if (baseDirForIndex !== distVocsDir) payloadTargets.push(path.join(distVocsDir, fileName));
-  if (baseDirForIndex !== cfPagesDistVocsDir) payloadTargets.push(path.join(cfPagesDistVocsDir, fileName));
+  const index = MiniSearch.loadJSON(JSON.stringify(raw), { fields: searchFields, storeFields });
+  index.discardAll(idsToDiscard);
+  index.vacuum();
 
-  const files = walkFiles(pagesDir);
-  const documents = [];
-
-  for (const file of files) {
-    const raw = fs.readFileSync(file, 'utf8');
-    const sections = extractSectionsFromMdx(raw);
-    if (sections.length === 0) continue;
-
-    const hrefBase = computeHref(file);
-    sections.forEach((section, i) => {
-      const href = `${hrefBase}#${section.anchor}`;
-      const id = `${href}::${i}`; // ensure unique ID even if anchors repeat
-      documents.push({
-        href,
-        html: '',
-        id,
-        isPage: section.isPage,
-        text: section.text,
-        title: section.title,
-        titles: section.titles,
-      });
-    });
-  }
-
-  // Check if we're on main branch (same logic as vocs.config.ts filterDevItems)
-  const isMainBranch = process.env.CF_PAGES_BRANCH === 'main';
-  console.log(`Branch check: ${isMainBranch ? 'main (filtering dev: true pages)' : 'develop (including all pages)'}`);
-
-  // Derive allowed routes from sidebar config (preferred) or fallback to Cloudflare Pages static output
-  let allowedRoutes = undefined;
-  if (fs.existsSync(vocsConfigPath)) {
-    try {
-      const cfg = fs.readFileSync(vocsConfigPath, 'utf8');
-      
-      // Extract all link and dev pairs by scanning line-by-line
-      // This approach handles nested objects better than complex regex
-      const lines = cfg.split('\n');
-      const routes = new Set();
-      
-      for (let i = 0; i < lines.length; i++) {
-        const line = lines[i];
-        const linkMatch = line.match(/link:\s*(['"])(.*?)\1/);
-        
-        if (linkMatch) {
-          const link = linkMatch[2];
-          
-          // Check for dev: true on the same line or nearby lines (within 3 lines before)
-          let hasDev = false;
-          for (let j = Math.max(0, i - 3); j <= i; j++) {
-            if (lines[j].includes('dev:') && lines[j].includes('true')) {
-              hasDev = true;
-              break;
-            }
-          }
-          
-          // On main branch: skip pages with dev: true
-          // On other branches: include all pages
-          if (isMainBranch && hasDev) {
-            console.log(`  Skipping dev page: ${link}`);
-            continue;
-          }
-          
-          routes.add(link);
-        }
-      }
-      
-      if (routes.size > 0) allowedRoutes = routes;
-    } catch (e) {
-      console.warn('Failed to parse vocs.config.ts:', e.message);
-    }
-  }
-  if (!allowedRoutes) {
-    // Fallback: walk dist/static directory and collect all directories that contain index.html
-    // (This happens when vocs.config.ts parsing fails or yields no routes)
-    const staticDir = fs.existsSync(cfPagesStaticDir) ? cfPagesStaticDir : null;
-    
-    if (staticDir) {
-      const stack = [staticDir];
-      const routes = new Set();
-      while (stack.length) {
-        const dir = stack.pop();
-        const entries = fs.readdirSync(dir, { withFileTypes: true });
-        let hasIndex = false;
-        for (const e of entries) {
-          if (e.isFile() && e.name === 'index.html') hasIndex = true;
-        }
-        if (hasIndex) {
-          const rel = normalizeSlashes(path.relative(staticDir, dir));
-          const route = '/' + rel.replace(/^\/?/, '');
-          routes.add(route === '/.' || route === '/' ? '/' : route);
-        }
-        for (const e of entries) {
-          if (e.isDirectory()) stack.push(path.join(dir, e.name));
-        }
-      }
-      // Remove non-doc routes
-      routes.delete('/');
-      routes.delete('/404');
-      allowedRoutes = routes;
-    }
-  }
-
-  // Filter documents to only include routes present in the sidebar
-  let filteredDocuments = documents;
-  if (allowedRoutes && allowedRoutes.size > 0) {
-    // Keep only sections whose base href (without #anchor) is in the allowed set
-    filteredDocuments = documents.filter((d) => allowedRoutes.has(d.href.split('#')[0]));
-    console.log(`Filtering to sidebar/static routes: ${filteredDocuments.length} of ${documents.length} sections`);
-  } else {
-    console.log(`No sidebar filtering applied; indexing all ${documents.length} sections`);
-  }
-
-  // Build the MiniSearch index with the same structure Vocs expects
-  const mini = new MiniSearch({
-    fields: ['title', 'titles', 'text'], // Fields to index for search
-    storeFields: ['href', 'html', 'isPage', 'text', 'title', 'titles'], // Fields to store in results
-  });
-
-  await mini.addAllAsync(filteredDocuments);
-  const json = mini.toJSON();
-
-  // Write the regenerated index to all discovered .vocs directories
-  const payload = JSON.stringify(json);
-  for (const target of payloadTargets) {
-    try {
-      fs.mkdirSync(path.dirname(target), { recursive: true });  // Ensure directory exists
-      fs.writeFileSync(target, payload);
-      console.log(`Search index written (${filteredDocuments.length} sections): ${target}`);
-    } catch (err) {
-      // Skip targets that aren't writable
-      console.log(`Skipping ${target}: ${err.code === 'EACCES' ? 'permission denied' : err.message}`);
-    }
-  }
+  fs.writeFileSync(indexFile, JSON.stringify(index.toJSON()), 'utf8');
+  console.log(
+    `Search index: discarded ${idsToDiscard.length} off-allowlist sections, ` +
+      `${index.documentCount} of ${before} remain. Wrote ${path.basename(indexFile)}.`,
+  );
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+main();

--- a/utils/searchbar-indexing.cjs
+++ b/utils/searchbar-indexing.cjs
@@ -183,4 +183,9 @@ function main() {
   );
 }
 
-main();
+try {
+  main();
+} catch (err) {
+  console.error(`Search index: failed to filter index: ${err.message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
In this PR:
- Rewrote `utils/searchbar-indexing.cjs` from a re-indexer into a post-processor over Vocs v2's own search index.
- Re-added it to `postdocs:build` in `package.json`.

Why:
The old script worked around a Vocs v1 bug (its indexer skipped MDX with imports/components). Vocs v2 indexes correctly, but I decided to keep the script because it guarantees that dev files, as well as files not in the sidebar, are not searchable on the `.org` site.

What it does now:
- Instead of rebuilding the index, it takes the one Vocs v2 already correctly generates and filters it in place.
- Removes files we don't want indexed, like pages that are not in the sidebar or config pages.
- Removes the `dev: true` files, so the `.org` stays clean.
- Also removes the `DevOnly`-wrapped headings from the index of the `Overview of Each Framework` page.