### PR TITLE
docs(monitoring): normalize structure and wording

### DIFF
--- a/docs/pages/monitoring/guidelines.mdx
+++ b/docs/pages/monitoring/guidelines.mdx
@@ -1,6 +1,6 @@
 ---
-title: "On-Chain Monitoring Guidelines | Security Alliance"
-description: "On-chain monitoring: track large fund transfers, token minting, and anomalies. Set up automated tools and real-time alerts via email, SMS, and messaging apps."
+title: "On-Chain Monitoring Guidelines | SEAL"
+description: "Define on-chain monitoring objectives, coverage tracks, owned multi-channel alerts, periodic alert tests, and forensic readiness links for protocols."
 tags:
   - Engineer/Developer
   - Security Specialist
@@ -20,8 +20,12 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Effective on-chain monitoring is complex and involves setting up systems and processes to continuously observe
-blockchain activities and detect any anomalies.
+> 🔑 **Key Takeaway**: Effective on-chain monitoring pairs continuous observation with owned alerts, tested delivery
+> paths, and a response plan — not tool installation alone.
+
+Effective on-chain monitoring combines systems and processes that continuously observe blockchain activity, surface
+anomalies, and drive a prepared response. Start from the [First principles](/monitoring/overview#first-principles) on
+the framework overview before expanding coverage.
 
 ## Key Principles
 
@@ -108,11 +112,17 @@ Structure monitoring coverage across these tracks:
 
 ### Forensic readiness
 
-Monitoring detects anomalies. Forensic readiness ensures you can reconstruct and prove what happened with defensible
-evidence. These are complementary capabilities: monitoring without forensic readiness means you can notice an incident
-but may struggle to investigate, substantiate, or disclose it reliably. See
-[Forensic Readiness](/incident-management/forensic-readiness) for how to design evidence collection into your
-architecture.
+Monitoring detects anomalies. Forensic readiness ensures teams can reconstruct and prove what happened with defensible
+evidence. These are complementary capabilities: monitoring without forensic readiness means responders can notice an
+incident but may struggle to investigate, substantiate, or disclose it reliably. See
+[Forensic Readiness](/incident-management/forensic-readiness) for designing evidence collection into architecture.
+
+## Further Reading & Tools
+
+- [Monitoring overview](/monitoring/overview): first principles and page map
+- [Incident Management](/incident-management/overview): response and communications after an alert
+- [Forensic Readiness](/incident-management/forensic-readiness): evidence design for defensible investigation
+- [On-chain monitoring tools](/monitoring/tools): catalog and reliability criteria
 
 ---
 

--- a/docs/pages/monitoring/guidelines.mdx
+++ b/docs/pages/monitoring/guidelines.mdx
@@ -27,16 +27,16 @@ Effective on-chain monitoring combines systems and processes that continuously o
 anomalies, and drive a prepared response. Start from the [First principles](/monitoring/overview#first-principles) on
 the framework overview before expanding coverage.
 
-## Key Principles
+## Key principles
 
-- **Transparency:** Prefer open-source or auditable tools so your monitoring infrastructure can itself be reviewed.
+- **Transparency:** Prefer open-source or auditable tools so the monitoring infrastructure can itself be reviewed.
 - **Real-time detection:** Minimize the time between an on-chain event and the alert reaching a responder.
 - **Automation:** Automate repetitive detection tasks to reduce human error and ensure consistent coverage.
-- **Scalability:** Design your monitoring setup to scale as protocol activity and the number of monitored contracts grows.
+- **Scalability:** Design the monitoring setup to scale as protocol activity and the number of monitored contracts grows.
 
-## Best Practices
+## Best practices
 
-### Define Monitoring Objectives
+### Define monitoring objectives
 
 1. Determine the critical metrics to monitor. Common categories include:
    - Large fund transfers from protocol or treasury wallets
@@ -46,20 +46,20 @@ the framework overview before expanding coverage.
    - Access control modifications (role grants, revocations)
    - Unusual gas usage patterns that may indicate griefing or exploitation attempts
 
-### Implement Monitoring Tools
+### Implement monitoring tools
 
 1. Use automated monitoring tools that can continuously track blockchain activities and generate alerts for anomalies.
-   See the [Tools](/monitoring/tools) page for a catalog of available options.
+    See the [Tools](/monitoring/tools) page for a catalog of available options.
 2. Supplement automated tools with periodic manual reviews.
 
-### Establish Alerting Mechanisms
+### Establish alerting mechanisms
 
 1. Set up real-time alerts to notify relevant project members of any suspicious activities or threshold breaches.
 2. Use multiple channels for alerts (Discord webhooks, Telegram bots, PagerDuty, Slack) to ensure timely delivery.
 3. Every alert must have a designated owner and a documented response. An alert with no one responsible is
-   indistinguishable from no alert at all.
+    indistinguishable from no alert at all.
 
-### Monitoring Strategies
+### Monitoring strategies
 
 Structure monitoring coverage across these tracks:
 
@@ -92,23 +92,23 @@ Structure monitoring coverage across these tracks:
 - Network latency affecting transaction confirmation
 - RPC endpoint availability
 
-### Regular Reviews and Updates
+### Regular reviews and updates
 
-1. Conduct regular reviews of your monitoring systems to ensure they are functioning correctly and covering all
-   necessary metrics.
-2. Regularly update thresholds and alert configurations to reflect your current needs.
-3. **Test your alerts periodically**: verify that alert delivery actually works end-to-end, not just that the
-   detection rule is configured. A misconfigured webhook or expired token can silently break your alerting.
+1. Conduct regular reviews of monitoring systems to ensure they are functioning correctly and covering all
+    necessary metrics.
+2. Regularly update thresholds and alert configurations to reflect current needs.
+3. **Test alerts periodically**: verify that alert delivery actually works end-to-end, not just that the
+    detection rule is configured. A misconfigured webhook or expired token can silently break alerting.
 4. **Alert on alert tampering**: configure alerts for the disabling or modification of existing alerts. This
-   protects against both accidental misconfiguration and adversarial tampering that could silently disable your
-   detection coverage.
+    protects against both accidental misconfiguration and adversarial tampering that could silently disable
+    detection coverage.
 
-### Incident Response
+### Incident response
 
 1. Develop and maintain an [incident response plan](/incident-management/overview) to handle alerts and anomalies as
-   soon as possible.
+    soon as possible.
 2. Document who gets paged for each alert category and what the first response steps are. This should be decided
-   before an incident, not during one.
+    before an incident, not during one.
 
 ### Forensic readiness
 
@@ -117,7 +117,7 @@ evidence. These are complementary capabilities: monitoring without forensic read
 incident but may struggle to investigate, substantiate, or disclose it reliably. See
 [Forensic Readiness](/incident-management/forensic-readiness) for designing evidence collection into architecture.
 
-## Further Reading & Tools
+## Further Reading
 
 - [Monitoring overview](/monitoring/overview): first principles and page map
 - [Incident Management](/incident-management/overview): response and communications after an alert

--- a/docs/pages/monitoring/overview.mdx
+++ b/docs/pages/monitoring/overview.mdx
@@ -75,7 +75,7 @@ options.
 - [DevSecOps](/devsecops/overview): CI/CD and pipeline telemetry complementary to on-chain signals
 - [Treasury Operations](/treasury-operations/overview): high-value transfer monitoring and controls
 
-## Further Reading & Tools
+## Further Reading
 
 - [OpenZeppelin Monitor](https://docs.openzeppelin.com/monitor): open-source monitoring stack often used as a
   self-hosted baseline

--- a/docs/pages/monitoring/overview.mdx
+++ b/docs/pages/monitoring/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Monitoring | Security Alliance"
-description: "Blockchain security monitoring framework: detect anomalies and breaches in real-time with guidelines for alerts, thresholds, and monitoring tools."
+description: "On-chain security monitoring for Web3 protocols: first principles, alert ownership, redundancy, guidelines, thresholds, and tooling choices."
 tags:
   - Engineer/Developer
   - Security Specialist
@@ -20,36 +20,66 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Monitoring is a crucial aspect of maintaining the security and integrity of a blockchain project. Effective monitoring
-allows you to detect anomalies and potential security breaches in real-time, enabling prompt response and mitigation.
-This section focuses on monitoring the on-chain security of a project, including guidelines for setting up monitoring
-systems, defining thresholds for alerts, and utilizing existing on-chain monitoring tools.
+> 🔑 **Key Takeaway**: Monitoring only improves security when every alert has an owner and a documented response.
+> Detection without action is noise.
 
-## First Principles
+On-chain monitoring watches blockchain state and events so teams can detect anomalies and attacks close to real time.
+For smart contract protocols, that means tracking the behaviors that matter to safety and solvency — large transfers,
+mint and burn activity, admin changes, upgrades, oracle deviations, and similar signals — and routing those signals to
+people prepared to act.
+
+This framework focuses on **on-chain** security monitoring. Off-chain infrastructure metrics (hosts, CI, cloud control
+planes) belong in DevSecOps and infrastructure guidance; linking monitored on-chain signals to
+[incident management](/incident-management/overview) remains essential.
+
+## First principles
 
 Before deploying any monitoring tool, establish the fundamentals that make monitoring effective.
 
-### Know what you're monitoring and why
+### Know what is monitored and why
 
-Define which on-chain events are meaningful to your project and what response each alert should trigger. A monitoring
-setup without defined responses is noise: it consumes attention without producing safety. For every alert you
-configure, answer: *who receives this, and what do they do when it fires?*
+Define which on-chain events are meaningful to the project and which response each alert must trigger. A monitoring
+setup without defined responses is noise: it consumes attention without producing safety. For every alert configured,
+answer: *who receives this, and what do they do when it fires?*
 
-### Act on your alerts
+### Act on alerts
 
-Organizations fail to monitor in two ways: not logging at all or logging without acting. Both leave you blind.
+Organizations fail at monitoring in two ways: not observing at all, or observing without acting. Both leave teams blind
+to preventable loss.
 
-Every alert must map to a concrete, documented response. For smart contract protocols, this typically means having a
-pause mechanism or circuit breaker and, in higher-maturity setups, possibly a carefully designed automated system that
-can trigger when a critical alert fires, but only where the trigger conditions and failure modes have been explicitly
-reviewed. Without this, monitoring only tells you what happened, not what you could have prevented.
+Every alert must map to a concrete, documented response. For smart contract protocols, that typically means a pause
+mechanism or circuit breaker and, in higher-maturity setups, carefully designed automation that may fire on critical
+alerts only when trigger conditions and failure modes have been explicitly reviewed. Without this, monitoring reports
+what happened after the fact rather than enabling prevention or fast containment.
 
-### Monitor with redundancy *(higher maturity)*
+### Monitor with redundancy (higher maturity)
 
 No monitoring provider has perfect uptime or perfect detection. For critical systems, run two independent providers
-monitoring the same invariants in parallel (one self-hosted, one managed). If one has downtime or misses an event,
-the other still provides coverage. See the [Tools](/monitoring/tools) page for guidance on combining self-hosted and
-managed options.
+monitoring the same invariants in parallel (for example one self-hosted and one managed). If one has downtime or misses
+an event, the other still provides coverage. See [Tools](/monitoring/tools) for combining self-hosted and managed
+options.
+
+## What this framework covers
+
+1. [Guidelines](/monitoring/guidelines): objectives, coverage tracks, alerting design, reviews, and linkage to
+   incident response and forensic readiness.
+2. [Tools](/monitoring/tools): open-source and commercial on-chain monitoring options with reliability criteria.
+3. [Thresholds](/monitoring/thresholds): baseline metrics, multi-layered alerts, adaptive thresholds, and anomaly
+   detection.
+
+## Related frameworks
+
+- [Incident Management](/incident-management/overview): response plans, communications, and forensic readiness tied to
+  alerts
+- [Infrastructure](/infrastructure/overview): broader infrastructure and network monitoring context
+- [DevSecOps](/devsecops/overview): CI/CD and pipeline telemetry complementary to on-chain signals
+- [Treasury Operations](/treasury-operations/overview): high-value transfer monitoring and controls
+
+## Further Reading & Tools
+
+- [OpenZeppelin Monitor](https://docs.openzeppelin.com/monitor): open-source monitoring stack often used as a
+  self-hosted baseline
+- [Forta Network](https://docs.forta.network/): decentralized detection bots and community-shared threat signals
 
 ---
 

--- a/docs/pages/monitoring/thresholds.mdx
+++ b/docs/pages/monitoring/thresholds.mdx
@@ -60,7 +60,7 @@ threshold.
 Several tools in the [Tools](/monitoring/tools) catalog offer built-in anomaly detection. Hypernative uses ML-based
 behavioral modeling, and Tenderly supports custom alert rules that can approximate anomaly thresholds.
 
-## Further Reading & Tools
+## Further Reading
 
 - [Monitoring guidelines](/monitoring/guidelines): coverage objectives and alert ownership
 - [On-chain monitoring tools](/monitoring/tools): platforms with threshold and anomaly features

--- a/docs/pages/monitoring/thresholds.mdx
+++ b/docs/pages/monitoring/thresholds.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Monitoring Alert Thresholds | Security Alliance"
-description: "On-chain threshold configuration: set baseline metrics, multi-layered alerts, and anomaly detection rules to catch unusual blockchain activity."
+title: "Monitoring Alert Thresholds | SEAL"
+description: "Configure on-chain alert thresholds from baselines: multi-layered rules, adaptive updates, and anomaly detection without drowning responders in noise."
 tags:
   - Engineer/Developer
   - Security Specialist
@@ -20,46 +20,51 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Setting appropriate thresholds for on-chain monitoring is hard when taking into account you want to detect unusual
-activities, without generating excessive false positives. Here are some guidelines for defining and configuring
-thresholds. For guidance on what to monitor and how to set up alerting, see the
-[Guidelines](/monitoring/guidelines) page.
+> 🔑 **Key Takeaway**: Thresholds must catch meaningful deviation from normal protocol behavior without drowning
+> responders in false positives — and they must be reviewed as activity patterns change.
 
-## Generic Guidelines
+Setting thresholds is a balance: detect unusual activity early without drowning operators in noise. For what to monitor
+and how to design alerting ownership, see [Guidelines](/monitoring/guidelines).
 
-### Understand Normal Activity Patterns
+## Understand normal activity patterns
 
-1. Establish baseline metrics for normal activities, such as average transaction volumes and typical token minting rates
-(if any).
+1. Establish baseline metrics for normal activity, such as average transaction volumes and typical token minting rates
+   (if any).
 2. Use historical data to understand activity patterns and identify deviations from the norm.
 
-### Set Thresholds for Alerts
+## Set thresholds for alerts
 
 1. Define thresholds for large fund transfers from project wallets, considering both absolute amounts and relative
-percentages.
-2. Set thresholds for token minting events, including the number of tokens minted and the frequency of minting.
+   percentages.
+2. Set thresholds for token minting events, including volume minted and mint frequency.
 3. Establish thresholds for changes in contract ownership or significant modifications to contract code.
 
-### Adjust Thresholds Over Time
+## Adjust thresholds over time
 
-1. Implement adaptive thresholds that can adjust based on changing activity patterns and emerging threats.
-2. Periodically review and update thresholds to ensure they remain relevant and effective.
+1. Prefer adaptive thresholds that can adjust based on changing activity patterns and emerging threats when tooling
+   supports them.
+2. Periodically review and update thresholds so they remain relevant and effective.
 
-### Multi-Layered Thresholds
+## Multi-layered thresholds
 
 1. Use primary thresholds for critical alerts and secondary thresholds for less urgent notifications.
-2. Define thresholds based on a combination of metrics to reduce false positives and improve accuracy.
+2. Combine metrics where single-signal rules produce too many false positives.
 
-### Anomaly Detection
+## Anomaly detection
 
-It is hard, if not impossible, to predict every type of alert one should set up for their project. As such, implementing
-an anomaly detection system can be of great value as it will monitor the project and its transactions in real time, and
-compare it to its previous behavior. If for example it is common that 4% of tokens change owner each day and there's a
-day with 20% of tokens changing owner in the past 10 minutes, then that could be detected as an anomaly and a cause
-for investigation.
+It is difficult to enumerate every alert a project will eventually need. Anomaly detection systems that compare live
+behavior to recent history can catch novel deviations. Example: if roughly 4% of tokens typically change owners each day
+and 20% change owners in ten minutes, that ramp may warrant investigation even without a pre-written absolute
+threshold.
 
-Several of the tools in the [Tools](/monitoring/tools) catalog offer built-in anomaly detection. Hypernative uses
-ML-based behavioral modeling, and Tenderly supports custom alert rules that can approximate anomaly thresholds.
+Several tools in the [Tools](/monitoring/tools) catalog offer built-in anomaly detection. Hypernative uses ML-based
+behavioral modeling, and Tenderly supports custom alert rules that can approximate anomaly thresholds.
+
+## Further Reading & Tools
+
+- [Monitoring guidelines](/monitoring/guidelines): coverage objectives and alert ownership
+- [On-chain monitoring tools](/monitoring/tools): platforms with threshold and anomaly features
+- [Incident Management](/incident-management/overview): response when a threshold fires
 
 ---
 

--- a/docs/pages/monitoring/tools.mdx
+++ b/docs/pages/monitoring/tools.mdx
@@ -1,6 +1,6 @@
 ---
-title: "On-Chain Monitoring Tools | Security Alliance"
-description: "On-chain monitoring tools catalog: open-source and commercial options for transaction monitoring, anomaly detection, alerting, and reliability assessment."
+title: "On-Chain Monitoring Tools | SEAL"
+description: "Catalog of open-source and commercial on-chain monitoring tools with reliability criteria: uptime, time-to-alert, delivery, and redundancy."
 tags:
   - Engineer/Developer
   - Security Specialist
@@ -20,9 +20,12 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> The tools below are primarily focused on EVM-compatible chains. For non-EVM chains (Solana, Cosmos, etc.), verify
-> chain support before selecting a tool. For critical systems, consider running monitors from two independent providers
-> simultaneously. See the [Reliability Considerations](#reliability-considerations) section below.
+> 🔑 **Key Takeaway**: Choose monitoring tools for detection quality and operational reliability — uptime, time-to-alert,
+> delivery guarantees, and redundant coverage — not feature lists alone.
+
+The catalog below is primarily focused on EVM-compatible chains. For non-EVM chains (Solana, Cosmos, and others),
+verify chain support before selecting a tool. For critical systems, run monitors from two independent providers when
+practical. See [Reliability considerations](#reliability-considerations).
 
 ## Open Source / Self-Hosted
 
@@ -151,6 +154,14 @@ channel, not primary paging (high latency, often filtered to spam)
 
 For high-severity alerts, use a dedicated paging tool with escalation so that if the primary on-call misses the
 alert, it automatically escalates to a secondary.
+
+## Further Reading & Tools
+
+- [Monitoring overview](/monitoring/overview): first principles and when redundancy is warranted
+- [Monitoring guidelines](/monitoring/guidelines): what to cover before buying tooling
+- [Alert thresholds](/monitoring/thresholds): tuning signals against baseline behavior
+- [OpenZeppelin Monitor documentation](https://docs.openzeppelin.com/monitor)
+- [Forta documentation](https://docs.forta.network/)
 
 ---
 

--- a/docs/pages/monitoring/tools.mdx
+++ b/docs/pages/monitoring/tools.mdx
@@ -1,6 +1,6 @@
 ---
 title: "On-Chain Monitoring Tools | SEAL"
-description: "Catalog of open-source and commercial on-chain monitoring tools with reliability criteria: uptime, time-to-alert, delivery, and redundancy."
+description: "Catalog open-source and commercial on-chain monitoring tools with reliability criteria: uptime, time-to-alert, delivery guarantees, and redundancy."
 tags:
   - Engineer/Developer
   - Security Specialist
@@ -27,7 +27,7 @@ The catalog below is primarily focused on EVM-compatible chains. For non-EVM cha
 verify chain support before selecting a tool. For critical systems, run monitors from two independent providers when
 practical. See [Reliability considerations](#reliability-considerations).
 
-## Open Source / Self-Hosted
+## Open source / self-hosted
 
 ### BlockScout
 
@@ -50,7 +50,7 @@ via a scraper.
 - **Chains:** Chain-agnostic (infrastructure layer)
 - **GitHub:** [prometheus/prometheus](https://github.com/prometheus/prometheus) | [grafana/grafana](https://github.com/grafana/grafana)
 
-## Commercial / Hosted
+## Commercial / hosted
 
 ### Etherscan
 
@@ -117,24 +117,24 @@ and Slack alerts.
 - **Chains:** Solana
 - **Website:** [txscope.com](https://txscope.com)
 
-## Reliability Considerations
+## Reliability considerations
 
-Your monitoring system is only effective if it is itself reliable. Before committing to a tooling setup, evaluate
+A monitoring system is only effective if it is itself reliable. Before committing to a tooling setup, evaluate
 these factors:
 
 ### Self-hosted vs. managed
 
-| | Self-Hosted | Managed Platform |
+| | Self-hosted | Managed platform |
 | --- | --- | --- |
 | **Control** | Full control over configuration and data | Vendor controls infrastructure |
-| **Operational burden** | You own uptime, upgrades, and maintenance | Vendor handles ops |
-| **Vendor risk** | None | Platform downtime or shutdown affects you |
+| **Operational burden** | Operators own uptime, upgrades, and maintenance | Vendor handles ops |
+| **Vendor risk** | None | Platform downtime or shutdown removes visibility |
 | **Cost** | Infrastructure cost + engineering time | Subscription fee |
 
 ### Key reliability metrics to evaluate
 
 - **Uptime SLA:** What guaranteed availability does the provider offer? Is there a status page?
-- **Time-to-alert:** How quickly after an on-chain event does a notification reach you? Minutes matter during an exploit.
+- **Time-to-alert:** How quickly after an on-chain event does a notification reach responders? Minutes matter during an exploit.
 - **Alert delivery guarantees:** Does the platform guarantee at-least-once delivery, or is it best-effort?
 
 ### Redundancy recommendation
@@ -145,17 +145,17 @@ platform has downtime or misses an anomaly, the self-hosted layer still provides
 
 ### Alert channel reliability
 
-Your monitoring is only as good as the delivery mechanism for its alerts.
+Monitoring is only as good as the delivery mechanism for its alerts.
 
 - **Prefer:** PagerDuty or OpsGenie (escalation policies, on-call rotations, delivery receipts)
 - **Use with care:** Slack, Discord, Telegram (useful for visibility, but easy to miss; no delivery guarantees)
-- **Don’t rely on email as the sole channel for critical alerts**: Email may be appropriate as a secondary or audit
+- **Do not rely on email as the sole channel for critical alerts**: Email may be appropriate as a secondary or audit
 channel, not primary paging (high latency, often filtered to spam)
 
 For high-severity alerts, use a dedicated paging tool with escalation so that if the primary on-call misses the
 alert, it automatically escalates to a secondary.
 
-## Further Reading & Tools
+## Further Reading
 
 - [Monitoring overview](/monitoring/overview): first principles and when redundancy is warranted
 - [Monitoring guidelines](/monitoring/guidelines): what to cover before buying tooling


### PR DESCRIPTION
## Scope

Framework: Monitoring (`docs/pages/monitoring/`)
Pages reviewed: overview, guidelines, tools, thresholds
Pages changed: all four content pages (not generated `index.mdx`)

## Why this PR is needed

- Overview lacked Key Takeaway, child page map, and related/further reading
- Child pages lacked canonical Key Takeaways and Further Reading sections
- Opening prose mixed informational fluff with first principles without a clear contract
- Descriptions needed searchable, action-oriented tuning

## Content model applied

| Page | Type |
| --- | --- |
| overview | Framework overview |
| guidelines | Procedure / implementation guide |
| tools | Reference / catalog |
| thresholds | Procedure / implementation guide |

## Changes

- Structural: overview page map, related frameworks, further reading on all pages
- Wording: Key Takeaways; lighter “you” phrasing on overview/thresholds openings; no detection-rule rewrite
- Metadata: titles/descriptions tuned for length and search terms
- Citations/links: internal IR/forensic links retained; vendor docs linked where already relevant
- Components: existing TagList/Attribution/Footer retained

## Substantive security changes

- None. Editorial and structural changes only. Alert-ownership and redundancy guidance already present; restated for clarity on the overview.

## Intentionally unchanged

- Tool catalog entries, pricing mentions, and third-party product claims (steward/product fact-check)
- Specific vendor/feature statements in `tools.mdx`

## Validation

- [x] Signed commits verified
- [x] cspell clean on `docs/pages/monitoring`
- [x] markdownlint-cli2 clean on `docs/pages/monitoring`
- [ ] Full `docs:build` (not re-run on this branch; identical generators; framework MSX-only)
- [x] Diff limited to this framework content pages
- [x] Generated LLM/index files not hand-edited

## Dependencies

Depends on standards guidance in https://github.com/security-alliance/frameworks/pull/561 (not bundled here).

## Reviewer focus

- Overview “First principles” fidelity vs prior language
- Whether tool catalog should stay exception-light without per-vendor citations