### PR TITLE
docs(encryption): normalize structure and wording

### DIFF
--- a/docs/pages/encryption/cloud-data-encryption.mdx
+++ b/docs/pages/encryption/cloud-data-encryption.mdx
@@ -9,7 +9,7 @@ tags:
   - Cloud
 contributors:
   - role: wrote
-    users: [scode2277]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/encryption/cloud-data-encryption.mdx
+++ b/docs/pages/encryption/cloud-data-encryption.mdx
@@ -1,11 +1,19 @@
 ---
-title: "Cloud Data Encryption | Security Alliance"
-description: "Protect cloud data with AES-256 encryption at rest and TLS 1.2+ in transit. Best practices for AWS KMS, Azure Key Vault, Google Cloud KMS, and bring your own keys (BYOK)."
+title: "Cloud Data Encryption | SEAL"
+description: "Encrypt cloud data at rest and in transit with strong algorithms, provider KMS or BYOK, access controls,
+and MFA on key management paths."
 tags:
   - Engineer/Developer
   - Security Specialist
   - DevOps
   - Cloud
+contributors:
+  - role: wrote
+    users: [scode2277]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -14,6 +22,12 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Cloud data must be encrypted in transit and at rest, with keys controlled through a deliberate KMS
+> or BYOK design — not left on default storage alone.
+
+Cloud storage and managed databases fail open when encryption and key custody are afterthoughts. This page lists
+practical controls for major cloud providers without replacing provider-specific runbooks.
 
 You should consider using the best practices below to ensure that data stored in the cloud
 is protected from unauthorized access:
@@ -67,8 +81,13 @@ keys.**
     - Ensure that all encryption-related software is kept up-to-date with the latest security patches.
     - Monitor for vulnerabilities in encryption libraries and apply patches promptly.
 
-By following these best practices and utilizing the recommended tools, you can significantly enhance the security of
-your data stored in the cloud.
+## Further Reading & Tools
+
+- [Encryption overview](/encryption/overview): framework map and shared concepts
+- [NIST SP 800-175B](https://csrc.nist.gov/publications/detail/sp/800-175b/rev-1/final): guideline for using
+  cryptographic standards in the federal government (useful baseline references)
+- [OWASP Cryptographic Storage Cheat
+  Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html)
 
 ---
 

--- a/docs/pages/encryption/cloud-data-encryption.mdx
+++ b/docs/pages/encryption/cloud-data-encryption.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Cloud Data Encryption | SEAL"
-description: "Encrypt cloud data at rest and in transit with strong algorithms, provider KMS or BYOK, access controls,
-and MFA on key management paths."
+description: "Encrypt cloud data at rest and in transit with strong algorithms, provider KMS or BYOK, access controls, and MFA on key management paths."
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/encryption/cloud-data-encryption.mdx
+++ b/docs/pages/encryption/cloud-data-encryption.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Cloud Data Encryption | SEAL"
-description: "Encrypt cloud data at rest and in transit with strong algorithms, provider KMS or BYOK, access controls, and MFA on key management paths."
+description: "Encrypt cloud data at rest on object stores and disks: KMS custody, bucket defaults, customer-managed keys, server-side encryption, and access separation."
 tags:
   - Engineer/Developer
   - Security Specialist
@@ -31,7 +31,7 @@ practical controls for major cloud providers without replacing provider-specific
 You should consider using the best practices below to ensure that data stored in the cloud
 is protected from unauthorized access:
 
-## Best Practices
+## Best practices
 
 1. **Use strong encryption algorithms.**
    - Example: Use AES-256 for data at rest and TLS 1.2 or higher for data in transit.
@@ -80,7 +80,7 @@ keys.**
     - Ensure that all encryption-related software is kept up-to-date with the latest security patches.
     - Monitor for vulnerabilities in encryption libraries and apply patches promptly.
 
-## Further Reading & Tools
+## Further Reading
 
 - [Encryption overview](/encryption/overview): framework map and shared concepts
 - [NIST SP 800-175B](https://csrc.nist.gov/publications/detail/sp/800-175b/rev-1/final): guideline for using

--- a/docs/pages/encryption/communication-encryption.mdx
+++ b/docs/pages/encryption/communication-encryption.mdx
@@ -1,9 +1,17 @@
 ---
-title: "Securing Communications | Security Alliance"
-description: "Compare secure messaging systems with end-to-end encryption: Signal, Matrix/Element, WhatsApp, Wire vs. non-E2EE platforms like Telegram, Discord, Slack, and Microsoft Teams."
+title: "Securing Communications | SEAL"
+description: "Choose messaging systems with default end-to-end encryption for sensitive operations; compare Signal,
+Matrix, WhatsApp, Wire against non-E2EE defaults."
 tags:
   - Engineer/Developer
   - Security Specialist
+contributors:
+  - role: wrote
+    users: [scode2277]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -12,6 +20,12 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: For sensitive operational communications, prefer messengers with end-to-end encryption enabled by
+> default and a threat model that matches the data shared.
+
+Messaging defaults decide whether compromise of a server or operator yields plaintext. This page compares common tools
+by encryption posture so teams can pick channels that match risk.
 
 Using secure messaging systems is crucial for protecting the privacy and integrity of your communications. Here are some
 popular messaging systems that offer end-to-end encryption and those that do not by default.
@@ -63,7 +77,15 @@ for messages.
    - Does not offer end-to-end encryption for messages.
    - [Microsoft Teams](https://www.microsoft.com/en/microsoft-teams/group-chat-software)
 
-For secure communication, it is recommended to use messaging systems that offer end-to-end encryption by default.
+Prefer messengers that offer end-to-end encryption by default for sensitive operational traffic.
+
+## Further Reading & Tools
+
+- [Encryption overview](/encryption/overview): framework map and shared concepts
+- [NIST SP 800-175B](https://csrc.nist.gov/publications/detail/sp/800-175b/rev-1/final): guideline for using
+  cryptographic standards in the federal government (useful baseline references)
+- [OWASP Cryptographic Storage Cheat
+  Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html)
 
 ---
 

--- a/docs/pages/encryption/communication-encryption.mdx
+++ b/docs/pages/encryption/communication-encryption.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Securing Communications | SEAL"
-description: "Choose messaging systems with default end-to-end encryption for sensitive operations; compare Signal,
-Matrix, WhatsApp, Wire against non-E2EE defaults."
+description: "Choose messaging systems with default end-to-end encryption for sensitive operations; compare Signal, Matrix, WhatsApp, Wire against non-E2EE defaults."
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/encryption/communication-encryption.mdx
+++ b/docs/pages/encryption/communication-encryption.mdx
@@ -29,7 +29,7 @@ by encryption posture so teams can pick channels that match risk.
 Using secure messaging systems is crucial for protecting the privacy and integrity of your communications. Here are some
 popular messaging systems that offer end-to-end encryption and those that do not by default.
 
-## End-to-End Encrypted Messaging Systems
+## End-to-end encrypted messaging systems
 
 1. **Signal**
    - Offers strong end-to-end encryption for messages, voice calls, and video calls.
@@ -51,7 +51,7 @@ popular messaging systems that offer end-to-end encryption and those that do not
    - Open source with a strong focus on privacy.
    - [Wire](https://wire.com/)
 
-## Messaging Systems Without Default End-to-End Encryption
+## Messaging systems without default end-to-end encryption
 
 These messaging systems supposedly provide encryption for data in transit and at rest, but not end-to-end encryption
 for messages.
@@ -78,7 +78,7 @@ for messages.
 
 Prefer messengers that offer end-to-end encryption by default for sensitive operational traffic.
 
-## Further Reading & Tools
+## Further Reading
 
 - [Encryption overview](/encryption/overview): framework map and shared concepts
 - [NIST SP 800-175B](https://csrc.nist.gov/publications/detail/sp/800-175b/rev-1/final): guideline for using

--- a/docs/pages/encryption/communication-encryption.mdx
+++ b/docs/pages/encryption/communication-encryption.mdx
@@ -7,7 +7,7 @@ tags:
   - Security Specialist
 contributors:
   - role: wrote
-    users: [scode2277]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/encryption/database-encryption.mdx
+++ b/docs/pages/encryption/database-encryption.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Database Encryption | SEAL"
-description: "Protect database contents with strong algorithms, column-level encryption for PII, Transparent Data Encryption (TDE), HSM-backed keys, and strict access control."
+description: "Encrypt databases at rest and in use: TDE, column-level crypto, keys held outside the DB host, and performance trade-offs for protocol backends."
 tags:
   - Engineer/Developer
   - Security Specialist
@@ -29,7 +29,7 @@ classes of backup leakage, but application and access control still matter.
 Often, databases contain information that should not be publicly available. In order to protect your database, you may
 consider implementing the following best practices:
 
-## Best Practices
+## Best practices
 
 1. Use strong encryption algorithms to encrypt database files and backups.
 2. Encrypt sensitive columns within the database, such as those containing personally identifiable information (PII).
@@ -38,7 +38,7 @@ consider implementing the following best practices:
 case.
 5. Enforce strict access controls to prevent unauthorized access to encrypted data.
 
-## Further Reading & Tools
+## Further Reading
 
 - [Encryption overview](/encryption/overview): framework map and shared concepts
 - [NIST SP 800-175B](https://csrc.nist.gov/publications/detail/sp/800-175b/rev-1/final): guideline for using

--- a/docs/pages/encryption/database-encryption.mdx
+++ b/docs/pages/encryption/database-encryption.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Database Encryption | SEAL"
-description: "Protect database contents with strong algorithms, column-level encryption for PII, Transparent Data
-Encryption (TDE), HSM-backed keys, and strict access control."
+description: "Protect database contents with strong algorithms, column-level encryption for PII, Transparent Data Encryption (TDE), HSM-backed keys, and strict access control."
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/encryption/database-encryption.mdx
+++ b/docs/pages/encryption/database-encryption.mdx
@@ -7,7 +7,7 @@ tags:
   - Security Specialist
 contributors:
   - role: wrote
-    users: [scode2277]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/encryption/database-encryption.mdx
+++ b/docs/pages/encryption/database-encryption.mdx
@@ -1,9 +1,17 @@
 ---
-title: "Database Encryption | Security Alliance"
-description: "Protect database contents with strong encryption algorithms, encrypted sensitive columns for PII, Transparent Data Encryption (TDE), HSM key management, and strict access controls."
+title: "Database Encryption | SEAL"
+description: "Protect database contents with strong algorithms, column-level encryption for PII, Transparent Data
+Encryption (TDE), HSM-backed keys, and strict access control."
 tags:
   - Engineer/Developer
   - Security Specialist
+contributors:
+  - role: wrote
+    users: [scode2277]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -12,6 +20,12 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Databases that hold PII or secrets need encryption of files/backups and sensitive columns, plus
+> key management and access control — TDE alone is not a complete design.
+
+Databases often concentrate regulated and high-value data. Encryption reduces the impact of storage theft and some
+classes of backup leakage, but application and access control still matter.
 
 Often, databases contain information that should not be publicly available. In order to protect your database, you may
 consider implementing the following best practices:
@@ -24,6 +38,14 @@ consider implementing the following best practices:
 4. Implement robust key management practices, including the use of HSMs and regular key rotation depending on your use
 case.
 5. Enforce strict access controls to prevent unauthorized access to encrypted data.
+
+## Further Reading & Tools
+
+- [Encryption overview](/encryption/overview): framework map and shared concepts
+- [NIST SP 800-175B](https://csrc.nist.gov/publications/detail/sp/800-175b/rev-1/final): guideline for using
+  cryptographic standards in the federal government (useful baseline references)
+- [OWASP Cryptographic Storage Cheat
+  Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html)
 
 ---
 

--- a/docs/pages/encryption/email-encryption.mdx
+++ b/docs/pages/encryption/email-encryption.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Email Encryption | SEAL"
-description: "Harden email with S/MIME or PGP/GPG, client setup patterns for Outlook, Apple Mail, and Thunderbird, and
-privacy-focused providers such as Proton Mail."
+description: "Harden email with S/MIME or PGP/GPG, client setup patterns for Outlook, Apple Mail, and Thunderbird, and privacy-focused providers such as Proton Mail."
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/encryption/email-encryption.mdx
+++ b/docs/pages/encryption/email-encryption.mdx
@@ -7,7 +7,7 @@ tags:
   - Security Specialist
 contributors:
   - role: wrote
-    users: [scode2277]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/encryption/email-encryption.mdx
+++ b/docs/pages/encryption/email-encryption.mdx
@@ -28,7 +28,7 @@ remain confidential if a server or mail host is compromised.
 
 Email is insecure and un-encrypted by default, but can become more secure by following best practices:
 
-## Best Practices
+## Best practices
 
 1. **Implement S/MIME or PGP**:
    - **S/MIME**: Secure/Multipurpose Internet Mail Extensions (S/MIME) is a widely accepted protocol for sending
@@ -74,7 +74,7 @@ eavesdropping and tampering.
    - **ProtonMail**: A secure email service that offers end-to-end encryption and is open-source. It provides an
    easy-to-use interface and strong privacy protections.
 
-## Further Reading & Tools
+## Further Reading
 
 - [Encryption overview](/encryption/overview): framework map and shared concepts
 - [NIST SP 800-175B](https://csrc.nist.gov/publications/detail/sp/800-175b/rev-1/final): guideline for using

--- a/docs/pages/encryption/email-encryption.mdx
+++ b/docs/pages/encryption/email-encryption.mdx
@@ -1,9 +1,17 @@
 ---
-title: "Email Encryption | Security Alliance"
-description: "Secure email communications with S/MIME certificates and PGP/GPG encryption. Setup guides for Outlook, Apple Mail, Thunderbird with Enigmail, and ProtonMail alternatives."
+title: "Email Encryption | SEAL"
+description: "Harden email with S/MIME or PGP/GPG, client setup patterns for Outlook, Apple Mail, and Thunderbird, and
+privacy-focused providers such as Proton Mail."
 tags:
   - Engineer/Developer
   - Security Specialist
+contributors:
+  - role: wrote
+    users: [scode2277]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -12,6 +20,12 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Plain email is not confidential by default. Use S/MIME or PGP/GPG when message content must stay
+> confidential beyond transport TLS.
+
+SMTP and typical mailbox hosting provide at best hop-to-hop TLS. Message-level encryption is required when content must
+remain confidential if a server or mail host is compromised.
 
 Email is insecure and un-encrypted by default, but can become more secure by following best practices:
 
@@ -61,8 +75,13 @@ eavesdropping and tampering.
    - **ProtonMail**: A secure email service that offers end-to-end encryption and is open-source. It provides an
    easy-to-use interface and strong privacy protections.
 
-By following these best practices and utilizing the recommended tools, you can significantly enhance the security of
-your email communications.
+## Further Reading & Tools
+
+- [Encryption overview](/encryption/overview): framework map and shared concepts
+- [NIST SP 800-175B](https://csrc.nist.gov/publications/detail/sp/800-175b/rev-1/final): guideline for using
+  cryptographic standards in the federal government (useful baseline references)
+- [OWASP Cryptographic Storage Cheat
+  Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html)
 
 ---
 

--- a/docs/pages/encryption/encryption-in-transit.mdx
+++ b/docs/pages/encryption/encryption-in-transit.mdx
@@ -30,14 +30,14 @@ Encryption in transit refers to how data is encrypted while it flows across netw
 want anyone eavesdropping on your traffic, and by following best practices such as the ones below, you can reduce the
 risk of that:
 
-## Best Practices
+## Best practices
 
 1. Ensure that all data transmitted over the internet is encrypted using TLS/SSL.
 2. Use secure VPNs to encrypt data transmitted over public networks such as public WiFi.
 3. Use SSH for secure remote access to servers and other infrastructure.
 4. Use encryption protocols such as S/MIME or PGP for email communications.
 
-## Further Reading & Tools
+## Further Reading
 
 - [Encryption overview](/encryption/overview): framework map and shared concepts
 - [NIST SP 800-175B](https://csrc.nist.gov/publications/detail/sp/800-175b/rev-1/final): guideline for using

--- a/docs/pages/encryption/encryption-in-transit.mdx
+++ b/docs/pages/encryption/encryption-in-transit.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Encryption In Transit | SEAL"
-description: "Protect data in motion with TLS for internet traffic, VPN on untrusted networks, SSH for remote admin, and
-message-level crypto for sensitive email."
+description: "Protect data in motion with TLS for internet traffic, VPN on untrusted networks, SSH for remote admin, and message-level crypto for sensitive email."
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/encryption/encryption-in-transit.mdx
+++ b/docs/pages/encryption/encryption-in-transit.mdx
@@ -7,7 +7,7 @@ tags:
   - Security Specialist
 contributors:
   - role: wrote
-    users: [scode2277]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/encryption/encryption-in-transit.mdx
+++ b/docs/pages/encryption/encryption-in-transit.mdx
@@ -1,9 +1,17 @@
 ---
-title: "Encryption In Transit | Security Alliance"
-description: "Protect data flowing across networks with TLS/SSL encryption, secure VPNs for public WiFi, SSH for remote server access, and S/MIME or PGP for email communications."
+title: "Encryption In Transit | SEAL"
+description: "Protect data in motion with TLS for internet traffic, VPN on untrusted networks, SSH for remote admin, and
+message-level crypto for sensitive email."
 tags:
   - Engineer/Developer
   - Security Specialist
+contributors:
+  - role: wrote
+    users: [scode2277]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -12,6 +20,12 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Data crossing networks must use modern encrypted transports (TLS, SSH, VPN as appropriate);
+> cleartext remote admin and bulk HTTP are unacceptable for sensitive systems.
+
+Encryption in transit protects confidentiality and integrity while data moves between systems. Without it, any on-path
+observer on the route can read or alter traffic.
 
 Encryption in transit refers to how data is encrypted while it flows across networks. This is important as you don't
 want anyone eavesdropping on your traffic, and by following best practices such as the ones below, you can reduce the
@@ -23,6 +37,14 @@ risk of that:
 2. Use secure VPNs to encrypt data transmitted over public networks such as public WiFi.
 3. Use SSH for secure remote access to servers and other infrastructure.
 4. Use encryption protocols such as S/MIME or PGP for email communications.
+
+## Further Reading & Tools
+
+- [Encryption overview](/encryption/overview): framework map and shared concepts
+- [NIST SP 800-175B](https://csrc.nist.gov/publications/detail/sp/800-175b/rev-1/final): guideline for using
+  cryptographic standards in the federal government (useful baseline references)
+- [OWASP Cryptographic Storage Cheat
+  Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html)
 
 ---
 

--- a/docs/pages/encryption/file-encryption.mdx
+++ b/docs/pages/encryption/file-encryption.mdx
@@ -1,9 +1,17 @@
 ---
-title: "File Encryption | Security Alliance"
-description: "Protect sensitive files stored on local and network drives using strong encryption algorithms and trusted file encryption tools."
+title: "File Encryption | SEAL"
+description: "Encrypt sensitive files on local and network drives with strong algorithms and trusted tools so offline
+media and shares do not expose plaintext."
 tags:
   - Engineer/Developer
   - Security Specialist
+contributors:
+  - role: wrote
+    users: [scode2277]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -13,10 +21,24 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
+> 🔑 **Key Takeaway**: Sensitive files on disks and shares must use trusted file encryption — OS login locks alone do not
+> protect power-off or copied files.
+
+File encryption protects individual objects when full-disk or volume encryption is unavailable or when files leave the
+encrypted host boundary.
+
 File encryption protects sensitive information stored in files.
 
 Use strong encryption algorithms to encrypt sensitive files stored on local and network drives.
 There are multiple tools available for file encryption; use one that is regarded as trusted.
+
+## Further Reading & Tools
+
+- [Encryption overview](/encryption/overview): framework map and shared concepts
+- [NIST SP 800-175B](https://csrc.nist.gov/publications/detail/sp/800-175b/rev-1/final): guideline for using
+  cryptographic standards in the federal government (useful baseline references)
+- [OWASP Cryptographic Storage Cheat
+  Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html)
 
 ---
 

--- a/docs/pages/encryption/file-encryption.mdx
+++ b/docs/pages/encryption/file-encryption.mdx
@@ -1,7 +1,6 @@
 ---
 title: "File Encryption | SEAL"
-description: "Encrypt sensitive files on local and network drives with strong algorithms and trusted tools so offline
-media and shares do not expose plaintext."
+description: "Encrypt sensitive files on local and network drives with strong algorithms and trusted tools so offline media and shares do not expose plaintext."
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/encryption/file-encryption.mdx
+++ b/docs/pages/encryption/file-encryption.mdx
@@ -7,7 +7,7 @@ tags:
   - Security Specialist
 contributors:
   - role: wrote
-    users: [scode2277]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/encryption/file-encryption.mdx
+++ b/docs/pages/encryption/file-encryption.mdx
@@ -31,7 +31,7 @@ File encryption protects sensitive information stored in files.
 Use strong encryption algorithms to encrypt sensitive files stored on local and network drives.
 There are multiple tools available for file encryption; use one that is regarded as trusted.
 
-## Further Reading & Tools
+## Further Reading
 
 - [Encryption overview](/encryption/overview): framework map and shared concepts
 - [NIST SP 800-175B](https://csrc.nist.gov/publications/detail/sp/800-175b/rev-1/final): guideline for using

--- a/docs/pages/encryption/full-disk-encryption.mdx
+++ b/docs/pages/encryption/full-disk-encryption.mdx
@@ -1,9 +1,17 @@
 ---
-title: "Full Disk Encryption | Security Alliance"
-description: "Enable full disk encryption on laptops, desktops, and mobile devices to protect all data if stolen or lost. Includes secure boot implementation for trusted software loading."
+title: "Full Disk Encryption | SEAL"
+description: "Enable full-disk encryption on laptops, desktops, and mobiles so lost or stolen devices do not expose
+plaintext; combine with secure boot where available."
 tags:
   - Engineer/Developer
   - Security Specialist
+contributors:
+  - role: wrote
+    users: [scode2277]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -12,6 +20,12 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Full-disk encryption must be enabled on endpoints that store work data so lost or stolen devices
+> do not expose plaintext at rest.
+
+Modern operating systems ship FDE capabilities, sometimes on by default. Teams still need to confirm status, algorithms,
+and recovery key custody.
 
 Full disk encryption protects all data stored on a device in the event that it's stolen or lost. Today, all major
 Operating Systems for workstations, servers and mobile phones have full disk encryption capabilities built in, and
@@ -23,6 +37,14 @@ enabled by default.
 1. Ensure that full disk encryption uses strong industry-standard algorithms.
 2. Enable full disk encryption by default on all devices, including laptops, desktops, and mobile devices.
 3. Implement secure boot to ensure that only trusted software can be loaded during the boot process.
+
+## Further Reading & Tools
+
+- [Encryption overview](/encryption/overview): framework map and shared concepts
+- [NIST SP 800-175B](https://csrc.nist.gov/publications/detail/sp/800-175b/rev-1/final): guideline for using
+  cryptographic standards in the federal government (useful baseline references)
+- [OWASP Cryptographic Storage Cheat
+  Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html)
 
 ---
 

--- a/docs/pages/encryption/full-disk-encryption.mdx
+++ b/docs/pages/encryption/full-disk-encryption.mdx
@@ -31,13 +31,13 @@ Operating Systems for workstations, servers and mobile phones have full disk enc
 sometimes enabled by default. Check which full disk encryption is built into your operating system, and enable it if not
 enabled by default.
 
-## Best Practices
+## Best practices
 
 1. Ensure that full disk encryption uses strong industry-standard algorithms.
 2. Enable full disk encryption by default on all devices, including laptops, desktops, and mobile devices.
 3. Implement secure boot to ensure that only trusted software can be loaded during the boot process.
 
-## Further Reading & Tools
+## Further Reading
 
 - [Encryption overview](/encryption/overview): framework map and shared concepts
 - [NIST SP 800-175B](https://csrc.nist.gov/publications/detail/sp/800-175b/rev-1/final): guideline for using

--- a/docs/pages/encryption/full-disk-encryption.mdx
+++ b/docs/pages/encryption/full-disk-encryption.mdx
@@ -7,7 +7,7 @@ tags:
   - Security Specialist
 contributors:
   - role: wrote
-    users: [scode2277]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/encryption/full-disk-encryption.mdx
+++ b/docs/pages/encryption/full-disk-encryption.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Full Disk Encryption | SEAL"
-description: "Enable full-disk encryption on laptops, desktops, and mobiles so lost or stolen devices do not expose
-plaintext; combine with secure boot where available."
+description: "Enable full-disk encryption on laptops, desktops, and mobiles so lost or stolen devices do not expose plaintext; combine with secure boot where available."
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/encryption/hardware-encryption.mdx
+++ b/docs/pages/encryption/hardware-encryption.mdx
@@ -7,7 +7,7 @@ tags:
   - Security Specialist
 contributors:
   - role: wrote
-    users: [scode2277]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/encryption/hardware-encryption.mdx
+++ b/docs/pages/encryption/hardware-encryption.mdx
@@ -29,13 +29,13 @@ custody uses HSMs.
 Hardware encryption, such as HSM, uses dedicated hardware to encrypt data, providing robust security. Utilizing a HSM is
 a fairly specialized thing, but consumers are for example often using TPM.
 
-## Best Practices
+## Best practices
 
 1. Enable TPM when available on your computer to enhance the security of hardware-based encryption.
 2. Consider using self-encrypting drives (SEDs) for storage to ensure data is encrypted at the hardware level.
 3. If relevant for your use case, use HSMs to securely generate, store, and manage encryption keys.
 
-## Further Reading & Tools
+## Further Reading
 
 - [Encryption overview](/encryption/overview): framework map and shared concepts
 - [NIST SP 800-175B](https://csrc.nist.gov/publications/detail/sp/800-175b/rev-1/final): guideline for using

--- a/docs/pages/encryption/hardware-encryption.mdx
+++ b/docs/pages/encryption/hardware-encryption.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Hardware Encryption | SEAL"
-description: "Use TPM, self-encrypting drives, and HSMs where appropriate to generate, store, and apply cryptographic
-keys in hardware-backed environments."
+description: "Use TPM, self-encrypting drives, and HSMs where appropriate to generate, store, and apply cryptographic keys in hardware-backed environments."
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/encryption/hardware-encryption.mdx
+++ b/docs/pages/encryption/hardware-encryption.mdx
@@ -1,9 +1,17 @@
 ---
-title: "Hardware Encryption | Security Alliance"
-description: "Use dedicated hardware for robust encryption: enable TPM on computers, deploy self-encrypting drives (SEDs), and use HSMs to securely generate, store, and manage encryption keys."
+title: "Hardware Encryption | SEAL"
+description: "Use TPM, self-encrypting drives, and HSMs where appropriate to generate, store, and apply cryptographic
+keys in hardware-backed environments."
 tags:
   - Engineer/Developer
   - Security Specialist
+contributors:
+  - role: wrote
+    users: [scode2277]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -13,6 +21,12 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
+> 🔑 **Key Takeaway**: Hardware-backed key storage (TPM, SED, HSM) reduces exposure of keys to host memory and malware
+> when deployed and managed correctly.
+
+Hardware encryption moves key use into purpose-built modules. Consumer endpoints often rely on TPM; high-assurance key
+custody uses HSMs.
+
 Hardware encryption, such as HSM, uses dedicated hardware to encrypt data, providing robust security. Utilizing a HSM is
 a fairly specialized thing, but consumers are for example often using TPM.
 
@@ -21,6 +35,14 @@ a fairly specialized thing, but consumers are for example often using TPM.
 1. Enable TPM when available on your computer to enhance the security of hardware-based encryption.
 2. Consider using self-encrypting drives (SEDs) for storage to ensure data is encrypted at the hardware level.
 3. If relevant for your use case, use HSMs to securely generate, store, and manage encryption keys.
+
+## Further Reading & Tools
+
+- [Encryption overview](/encryption/overview): framework map and shared concepts
+- [NIST SP 800-175B](https://csrc.nist.gov/publications/detail/sp/800-175b/rev-1/final): guideline for using
+  cryptographic standards in the federal government (useful baseline references)
+- [OWASP Cryptographic Storage Cheat
+  Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html)
 
 ---
 

--- a/docs/pages/encryption/overview.mdx
+++ b/docs/pages/encryption/overview.mdx
@@ -9,7 +9,7 @@ tags:
   - Cloud
 contributors:
   - role: wrote
-    users: [scode2277]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/encryption/overview.mdx
+++ b/docs/pages/encryption/overview.mdx
@@ -61,7 +61,7 @@ privacy, or infrastructure.
 - [Infrastructure](/infrastructure/overview): broader platform and network security
 - [Wallet Security](/wallet-security/overview): key material for on-chain assets (distinct from disk/OS encryption)
 
-## Further Reading & Tools
+## Further Reading
 
 - [NIST SP 800-175B Rev. 1](https://csrc.nist.gov/publications/detail/sp/800-175b/rev-1/final): using cryptographic
   standards

--- a/docs/pages/encryption/overview.mdx
+++ b/docs/pages/encryption/overview.mdx
@@ -1,11 +1,19 @@
 ---
 title: "Encryption | Security Alliance"
-description: "Encryption Framework: Comprehensive guide covering cloud, communication, database, email, file, full disk, and hardware encryption to protect sensitive information from unauthorized access."
+description: "Encryption framework for data at rest and in transit: cloud, messaging, email, databases, files, volumes,
+partitions, full disk, and hardware-backed keys."
 tags:
   - Engineer/Developer
   - Security Specialist
   - DevOps
   - Cloud
+contributors:
+  - role: wrote
+    users: [scode2277]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -15,20 +23,53 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Encryption is a fundamental aspect of securing data, ensuring that sensitive information remains confidential and
-protected from unauthorized access. This section covers various types of encryption and best practices for implementing
-them effectively.
+> 🔑 **Key Takeaway**: Encryption protects confidentiality when keys are managed deliberately across data at rest and
+> in transit — algorithms alone do not compensate for weak custody or cleartext channels.
 
-## Contents
+Encryption keeps sensitive information confidential when storage, backups, devices, or network paths are exposed to
+unauthorized parties. In Web3 organizations the same patterns apply to operator laptops, cloud control planes, chat
+used for incident coordination, and databases that hold customer or key-adjacent metadata.
 
-1. [Cloud Data Encryption](/encryption/cloud-data-encryption)
-2. [Communication Encryption](/encryption/communication-encryption)
-3. [Encryption in Transit](/encryption/encryption-in-transit)
-4. [Database Encryption](/encryption/database-encryption)
-5. [Email Encryption](/encryption/email-encryption)
-6. [File Encryption](/encryption/file-encryption)
-7. [Full Disk Encryption](/encryption/full-disk-encryption)
-8. [Hardware Encryption](/encryption/hardware-encryption)
+This framework spans common encryption applications without replacing product-specific hardening guides under OpSec,
+privacy, or infrastructure.
+
+## Core ideas
+
+- **At rest vs in transit:** protect stored data and data in motion with appropriate controls; many systems need both.
+- **Key management:** algorithms fail open when keys are shared widely, never rotated, or live in the same breach domain
+  as the ciphertext without additional controls.
+- **Threat model first:** full-disk encryption addresses device loss; it does not stop a logged-in malware session.
+
+## What this framework covers
+
+1. [Cloud Data Encryption](/encryption/cloud-data-encryption): at-rest and in-transit controls, KMS and BYOK patterns on
+   major clouds.
+2. [Communication Encryption](/encryption/communication-encryption): messaging tools with and without default E2EE.
+3. [Encryption in Transit](/encryption/encryption-in-transit): TLS, VPN, SSH, and message-level email crypto.
+4. [Database Encryption](/encryption/database-encryption): file/column encryption, TDE, HSM-backed keys, access control.
+5. [Email Encryption](/encryption/email-encryption): S/MIME and PGP/GPG patterns and tooling.
+6. [File Encryption](/encryption/file-encryption): encrypting individual sensitive files with trusted tools.
+7. [Full Disk Encryption](/encryption/full-disk-encryption): endpoint FDE and secure boot basics.
+8. [Hardware Encryption](/encryption/hardware-encryption): TPM, self-encrypting drives, and HSMs.
+9. [Partition Encryption](/encryption/partition-encryption): selective partition encryption with BitLocker, LUKS, or
+   VeraCrypt.
+10. [Volume Encryption](/encryption/volume-encryption): volume-level encryption and key-handling practices.
+
+## Related frameworks
+
+- [OpSec](/opsec/overview): endpoint and operational controls that surround encryption choices
+- [Privacy](/privacy/overview): communications privacy and related tooling
+- [Infrastructure](/infrastructure/overview): broader platform and network security
+- [Wallet Security](/wallet-security/overview): key material for on-chain assets (distinct from disk/OS encryption)
+
+## Further Reading & Tools
+
+- [NIST SP 800-175B Rev. 1](https://csrc.nist.gov/publications/detail/sp/800-175b/rev-1/final): using cryptographic
+  standards
+- [OWASP Cryptographic Storage Cheat
+  Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html)
+- [OWASP Transport Layer Protection Cheat
+  Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Protection_Cheat_Sheet.html)
 
 ---
 

--- a/docs/pages/encryption/overview.mdx
+++ b/docs/pages/encryption/overview.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Encryption | Security Alliance"
-description: "Encryption framework for data at rest and in transit: cloud, messaging, email, databases, files, volumes,
-partitions, full disk, and hardware-backed keys."
+description: "Encryption framework for data at rest and in transit: cloud, messaging, email, databases, files, volumes, partitions, full disk, and hardware-backed keys."
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/encryption/partition-encryption.mdx
+++ b/docs/pages/encryption/partition-encryption.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Partition Encryption | SEAL"
-description: "Encrypt selected partitions with BitLocker, LUKS, or VeraCrypt when full-disk encryption is too broad;
-protect keys with MFA and backups."
+description: "Encrypt selected partitions with BitLocker, LUKS, or VeraCrypt when full-disk encryption is too broad; protect keys with MFA and backups. Unlike full"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/encryption/partition-encryption.mdx
+++ b/docs/pages/encryption/partition-encryption.mdx
@@ -1,9 +1,17 @@
 ---
-title: "Partition Encryption | Security Alliance"
-description: "Selectively encrypt specific disk partitions with BitLocker, LUKS, or VeraCrypt. Protect sensitive data while maintaining flexibility for un-encrypted data on the same device."
+title: "Partition Encryption | SEAL"
+description: "Encrypt selected partitions with BitLocker, LUKS, or VeraCrypt when full-disk encryption is too broad;
+protect keys with MFA and backups."
 tags:
   - Engineer/Developer
   - Security Specialist
+contributors:
+  - role: wrote
+    users: [scode2277]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -12,6 +20,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Partition encryption protects high-sensitivity regions of a disk when full-disk encryption is not
+> appropriate for every partition on the device.
 
 ## What is Partition Encryption?
 
@@ -58,8 +69,13 @@ decommissioned or repurposed.
 6. **Monitor and Audit**: Regularly monitor and audit encryption settings and access logs to ensure compliance and
   detect any unauthorized access attempts.
 
-By following these best practices and using reliable partition encryption technologies, organizations can significantly
-enhance the security of their data and protect against unauthorized access and data breaches.
+## Further Reading & Tools
+
+- [Encryption overview](/encryption/overview): framework map and shared concepts
+- [NIST SP 800-175B](https://csrc.nist.gov/publications/detail/sp/800-175b/rev-1/final): guideline for using
+  cryptographic standards in the federal government (useful baseline references)
+- [OWASP Cryptographic Storage Cheat
+  Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html)
 
 ---
 

--- a/docs/pages/encryption/partition-encryption.mdx
+++ b/docs/pages/encryption/partition-encryption.mdx
@@ -7,7 +7,7 @@ tags:
   - Security Specialist
 contributors:
   - role: wrote
-    users: [scode2277]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/encryption/partition-encryption.mdx
+++ b/docs/pages/encryption/partition-encryption.mdx
@@ -23,20 +23,20 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 > 🔑 **Key Takeaway**: Partition encryption protects high-sensitivity regions of a disk when full-disk encryption is not
 > appropriate for every partition on the device.
 
-## What is Partition Encryption?
+## What is partition encryption?
 
 Partition encryption is the process of encrypting specific partitions on a storage device. This allows for selective
 encryption of data, providing flexibility in managing encrypted and un-encrypted data on the same device. Unlike full
 disk encryption, which encrypts the entire disk, partition encryption targets specific areas, making it ideal for
 protecting sensitive data without impacting the entire storage system.
 
-## Importance of Partition Encryption
+## Importance of partition encryption
 
 Partition encryption is crucial for protecting sensitive information from unauthorized access, especially in
 environments where different types of data coexist on the same device. It helps prevent data breaches in case of
 unauthorized access to specific partitions and ensures compliance with data protection regulations.
 
-## Uses of Partition Encryption
+## Uses of partition encryption
 
 - **Protecting Sensitive Data**: Ensures that sensitive information stored on specific partitions is secure.
 - **Compliance**: Helps organizations meet regulatory requirements for data protection.
@@ -44,7 +44,7 @@ unauthorized access to specific partitions and ensures compliance with data prot
 - **Secure Decommissioning**: Ensures that data on encrypted partitions is not recoverable when storage devices are
 decommissioned or repurposed.
 
-## Examples of Partition Encryption
+## Examples of partition encryption
 
 - **BitLocker**: A partition encryption feature included with Microsoft Windows that provides encryption for specific
   partitions. [Learn how to use
@@ -54,7 +54,7 @@ decommissioned or repurposed.
 - **VeraCrypt**: An open-source disk encryption software that can encrypt specific partitions. [Learn how to use
   VeraCrypt](https://www.veracrypt.fr/en/Documentation.html)
 
-## Best Practices for Partition Encryption
+## Best practices for partition encryption
 
 1. **Use Strong Encryption Algorithms**: Ensure that the encryption algorithms used are strong and up-to-date, such as
   AES-256.
@@ -68,7 +68,7 @@ decommissioned or repurposed.
 6. **Monitor and Audit**: Regularly monitor and audit encryption settings and access logs to ensure compliance and
   detect any unauthorized access attempts.
 
-## Further Reading & Tools
+## Further Reading
 
 - [Encryption overview](/encryption/overview): framework map and shared concepts
 - [NIST SP 800-175B](https://csrc.nist.gov/publications/detail/sp/800-175b/rev-1/final): guideline for using

--- a/docs/pages/encryption/volume-encryption.mdx
+++ b/docs/pages/encryption/volume-encryption.mdx
@@ -1,9 +1,17 @@
 ---
-title: "Volume Encryption | Security Alliance"
-description: "Encrypt specific storage volumes with BitLocker, LUKS, or VeraCrypt for selective data protection. Create virtual encrypted disks and implement AES-256 with MFA access controls."
+title: "Volume Encryption | SEAL"
+description: "Encrypt selected volumes with BitLocker, LUKS, or VeraCrypt for flexible protection of sensitive storage,
+with MFA access and secure key backup."
 tags:
   - Engineer/Developer
   - Security Specialist
+contributors:
+  - role: wrote
+    users: [scode2277]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -12,6 +20,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Volume encryption lets teams protect specific sensitive storage volumes without encrypting every
+> volume the same way.
 
 ## What is Volume Encryption?
 
@@ -62,8 +73,13 @@ to specific volumes and ensures compliance with data protection regulations.
 6. **Monitor and Audit**: Regularly monitor and audit encryption settings and access logs to ensure compliance and
   detect any unauthorized access attempts.
 
-By following these best practices and using reliable volume encryption technologies, organizations can significantly
-enhance the security of their data and protect against unauthorized access and data breaches.
+## Further Reading & Tools
+
+- [Encryption overview](/encryption/overview): framework map and shared concepts
+- [NIST SP 800-175B](https://csrc.nist.gov/publications/detail/sp/800-175b/rev-1/final): guideline for using
+  cryptographic standards in the federal government (useful baseline references)
+- [OWASP Cryptographic Storage Cheat
+  Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html)
 
 ---
 

--- a/docs/pages/encryption/volume-encryption.mdx
+++ b/docs/pages/encryption/volume-encryption.mdx
@@ -7,7 +7,7 @@ tags:
   - Security Specialist
 contributors:
   - role: wrote
-    users: [scode2277]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/encryption/volume-encryption.mdx
+++ b/docs/pages/encryption/volume-encryption.mdx
@@ -23,19 +23,19 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 > 🔑 **Key Takeaway**: Volume encryption lets teams protect specific sensitive storage volumes without encrypting every
 > volume the same way.
 
-## What is Volume Encryption?
+## What is volume encryption?
 
 Volume encryption is the process of encrypting a specific storage volume or partition to protect the data it contains.
 Unlike full disk encryption, which encrypts the entire disk, volume encryption allows for selective encryption of
 specific volumes, providing flexibility in managing encrypted and un-encrypted data on the same device.
 
-## Importance of Volume Encryption
+## Importance of volume encryption
 
 Volume encryption is essential for protecting sensitive information from unauthorized access, especially in environments
 where different types of data coexist on the same device. It helps prevent data breaches in case of unauthorized access
 to specific volumes and ensures compliance with data protection regulations.
 
-## Uses of Volume Encryption
+## Uses of volume encryption
 
 - **Protecting Sensitive Data**: Ensures that sensitive information stored on specific volumes is secure.
 - **Compliance**: Helps organizations meet regulatory requirements for data protection.
@@ -43,14 +43,14 @@ to specific volumes and ensures compliance with data protection regulations.
 - **Secure Decommissioning**: Ensures that data on encrypted volumes is not recoverable when storage devices are
   decommissioned or repurposed.
 
-## Examples of Volume Encryption
+## Examples of volume encryption
 
 - **Partition Encryption**: Encrypts specific partitions or volumes on a disk, allowing for selective encryption of
   sensitive data.
 - **Virtual Encrypted Disks**: Creates virtual encrypted disks within files, providing an additional layer of security
   for sensitive data.
 
-## Known Technologies for Volume Encryption
+## Known technologies for volume encryption
 
 - **BitLocker**: A volume encryption feature included with Microsoft Windows that provides encryption for specific
   volumes.
@@ -59,7 +59,7 @@ to specific volumes and ensures compliance with data protection regulations.
 - **VeraCrypt**: An open-source disk encryption software that can create virtual encrypted disks within a file or
   encrypt specific partitions.
 
-## Best Practices for Volume Encryption
+## Best practices for volume encryption
 
 1. **Use Strong Encryption Algorithms**: Ensure that the encryption algorithms used are strong and up-to-date, such as
   AES-256.
@@ -72,7 +72,7 @@ to specific volumes and ensures compliance with data protection regulations.
 6. **Monitor and Audit**: Regularly monitor and audit encryption settings and access logs to ensure compliance and
   detect any unauthorized access attempts.
 
-## Further Reading & Tools
+## Further Reading
 
 - [Encryption overview](/encryption/overview): framework map and shared concepts
 - [NIST SP 800-175B](https://csrc.nist.gov/publications/detail/sp/800-175b/rev-1/final): guideline for using

--- a/docs/pages/encryption/volume-encryption.mdx
+++ b/docs/pages/encryption/volume-encryption.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Volume Encryption | SEAL"
-description: "Encrypt selected volumes with BitLocker, LUKS, or VeraCrypt for flexible protection of sensitive storage,
-with MFA access and secure key backup."
+description: "Encrypt selected volumes with BitLocker, LUKS, or VeraCrypt for flexible protection of sensitive storage, with MFA access and secure key backup."
 tags:
   - Engineer/Developer
   - Security Specialist


### PR DESCRIPTION
## Scope

Framework: Encryption
Pages reviewed: all under `docs/pages/encryption/` except generated `index.mdx`
Pages changed: overview + 10 topic pages

## Why this PR is needed

- Overview was a bare link list without Key Takeaway, descriptions, foundations, or related frameworks
- Partition and volume pages were online but missing from the overview map
- Child pages lacked Key Takeaways, further reading, and contributor metadata
- Filler closings (“By following these best practices…”) and weak recommend phrasing on communications

## Content model applied

| Page | Type |
| --- | --- |
| overview | Framework overview |
| topic pages (cloud, transit, FDE, etc.) | Conceptual + procedure mixture (primary: procedure/checklist style) |
| communication-encryption | Reference / comparison catalog |

## Changes

- Structural: overview foundations + full page map including partition/volume
- Wording: canonical Key Takeaways; removed filler closings; communications default-E2EE preference restated without “it is recommended that”
- Metadata: contributors attributed to existing profile `scode2277` (git history / Sara Russo); description length campaign
- Links: NIST 800-175B and OWASP crypto/transport cheat sheets
- Components:TagList/Attribution/Footer retained

## Substantive security changes

- None beyond editorial restatement. Communications page still prefers default-E2EE messengers; previously “it is recommended…”

## Intentionally unchanged

- Cloud provider console steps and product examples (need steward fact-check over time)
- Relative completeness of thin pages (`file-encryption`) — expert expansion deferred

## Validation

- [x] Signed commits
- [x] cspell clean
- [x] markdownlint-cli2 clean
- [x] Diff limited to encryption content pages
- [x] No hand-edited generated indexes

## Dependencies

https://github.com/security-alliance/frameworks/pull/561

## Reviewer focus

- Attribution of historical pages to `scode2277`
- Whether NIST/OWASP links are preferred external anchors for this framework