### PR TITLE
docs(user-team-security): normalize structure and wording

### DIFF
--- a/docs/pages/user-team-security/overview.mdx
+++ b/docs/pages/user-team-security/overview.mdx
@@ -8,7 +8,7 @@ tags:
   - Engineer/Developer
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/user-team-security/overview.mdx
+++ b/docs/pages/user-team-security/overview.mdx
@@ -1,1 +1,67 @@
+---
+title: "User and Team Security | SEAL"
+description: "Stub overview for people-focused security work: culture, training, and phishing awareness. Prefer the Security Awareness framework until this domain is expanded."
+tags:
+  - Security Specialist
+  - Operations & Strategy
+  - HR
+  - Engineer/Developer
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
+---
+
+import { TagList, AttributionList, ContributeFooter } from '../../../components'
+
 # User and Team Security
+
+<TagList tags={frontmatter.tags} />
+<AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: People-focused controls (culture, training, phishing resistance) need a dedicated home —
+> until this framework is filled, use [Security Awareness](/awareness/overview) as the primary guidance.
+> ⚠️ This article is a [stub](https://en.wikipedia.org/wiki/Wikipedia:Stub). Help expand it by
+> [contributing](/contribute/contributing). Do not treat placeholder pages below as complete controls.
+
+## Why this framework exists
+
+Web3 security failures frequently start with humans: phishing, social engineering, weak habits, and missing training.
+A dedicated **user and team security** framework should collect those practices for founders, people-ops, and
+security leads who are not reading deep OpSec runbooks first.
+
+## Relationship to other frameworks
+
+| Framework | Use for |
+| --- | --- |
+| [Security Awareness](/awareness/overview) | **Primary current content** for threat recognition and mindset |
+| [OpSec](/opsec/overview) | Device, browser, MFA, password, and travel controls |
+| [DPRK IT Workers](/dprk-it-workers/overview) | Hiring and insider-threat patterns affecting teams |
+| [Community Management](/community-management/overview) | Discord, Telegram, and X operational security |
+| [Physical Security](/physical-security/overview) | Coercion, facilities, and physical threat models |
+
+## What this framework will cover
+
+Planned page map (stubs today — expand rather than inventing controls off-repo):
+
+1. [Phishing and Social Engineering](/user-team-security/phishing-social-engineering): recognition and response patterns
+   for operators and staff.
+2. [Security-Aware Culture](/user-team-security/security-aware-culture): leadership norms that make secure behavior
+   durable.
+3. [Security Training](/user-team-security/security-training): program design for recurring education and drills.
+
+Expert authors should replace each stub with content that meets the [content model](/contribute/content-model) rather
+than duplicating Awareness wholesale.
+
+## Further Reading & Tools
+
+- [Security Awareness](/awareness/overview)
+- [Contributing guide](/contribute/contributing)
+- [Content model](/contribute/content-model)
+
+---
+
+<ContributeFooter />

--- a/docs/pages/user-team-security/overview.mdx
+++ b/docs/pages/user-team-security/overview.mdx
@@ -56,7 +56,7 @@ Planned page map (stubs today — expand rather than inventing controls off-repo
 Expert authors should replace each stub with content that meets the [content model](/contribute/content-model) rather
 than duplicating Awareness wholesale.
 
-## Further Reading & Tools
+## Further Reading
 
 - [Security Awareness](/awareness/overview)
 - [Contributing guide](/contribute/contributing)

--- a/docs/pages/user-team-security/overview.mdx
+++ b/docs/pages/user-team-security/overview.mdx
@@ -43,7 +43,7 @@ security leads who are not reading deep OpSec runbooks first.
 | [Community Management](/community-management/overview) | Discord, Telegram, and X operational security |
 | [Physical Security](/physical-security/overview) | Coercion, facilities, and physical threat models |
 
-## What this framework will cover
+## What this framework covers
 
 Planned page map (stubs today — expand rather than inventing controls off-repo):
 

--- a/docs/pages/user-team-security/overview.mdx
+++ b/docs/pages/user-team-security/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "User and Team Security | SEAL"
-description: "Stub overview for people-focused security work: culture, training, and phishing awareness. Prefer the Security Awareness framework until this domain is expanded."
+description: "Stub overview for people-focused security: culture, training, and phishing awareness. Prefer the Security Awareness framework until this domain is expanded."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/user-team-security/phishing-social-engineering.mdx
+++ b/docs/pages/user-team-security/phishing-social-engineering.mdx
@@ -8,7 +8,7 @@ tags:
   - Engineer/Developer
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/user-team-security/phishing-social-engineering.mdx
+++ b/docs/pages/user-team-security/phishing-social-engineering.mdx
@@ -40,7 +40,7 @@ Until this page is written, use:
 - Reporting and escalation paths into incident response
 - Metrics for training effectiveness
 
-## Further Reading & Tools
+## Further Reading
 
 - [User and Team Security overview](/user-team-security/overview)
 - [Security Awareness](/awareness/overview)

--- a/docs/pages/user-team-security/phishing-social-engineering.mdx
+++ b/docs/pages/user-team-security/phishing-social-engineering.mdx
@@ -1,1 +1,51 @@
+---
+title: "Phishing and Social Engineering | SEAL"
+description: "Stub: phishing and social engineering guidance for staff and operators. Use Security Awareness until this page is expanded by a steward-author."
+tags:
+  - Security Specialist
+  - Operations & Strategy
+  - HR
+  - Engineer/Developer
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
+---
+
+import { TagList, AttributionList, ContributeFooter } from '../../../components'
+
 # Phishing and Social Engineering
+
+<TagList tags={frontmatter.tags} />
+<AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Phishing and social engineering bypass technical controls by targeting people — treat unexpected
+> requests involving credentials, seeds, or urgent transfers as hostile until verified out-of-band.
+> ⚠️ This article is a [stub](https://en.wikipedia.org/wiki/Wikipedia:Stub). Help expand it by
+> [contributing](/contribute/contributing).
+
+Until this page is written, use:
+
+- [Security Awareness — threat vectors](/awareness/understanding-threat-vectors)
+- [Community Management](/community-management/overview) for channel-specific lures
+- [Wallet Security](/wallet-security/overview) for drain-and-sign patterns
+
+## Planned sections
+
+- Common Web3 lure patterns (support impostors, fake jobs, poisoned PDFs, calendar invites)
+- Verification procedures (out-of-band callbacks, dual control)
+- Reporting and escalation paths into incident response
+- Metrics for training effectiveness
+
+## Further Reading & Tools
+
+- [User and Team Security overview](/user-team-security/overview)
+- [Security Awareness](/awareness/overview)
+- [Incident Management](/incident-management/overview)
+
+---
+
+<ContributeFooter />

--- a/docs/pages/user-team-security/security-aware-culture.mdx
+++ b/docs/pages/user-team-security/security-aware-culture.mdx
@@ -7,7 +7,7 @@ tags:
   - HR
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/user-team-security/security-aware-culture.mdx
+++ b/docs/pages/user-team-security/security-aware-culture.mdx
@@ -38,7 +38,7 @@ Current guidance:
 - Onboarding and offboarding culture checkpoints
 - Relationship to OpSec and tabletop exercises
 
-## Further Reading & Tools
+## Further Reading
 
 - [User and Team Security overview](/user-team-security/overview)
 - [Security Awareness](/awareness/overview)

--- a/docs/pages/user-team-security/security-aware-culture.mdx
+++ b/docs/pages/user-team-security/security-aware-culture.mdx
@@ -1,1 +1,49 @@
+---
+title: "Security-Aware Culture | SEAL"
+description: "Stub: security-aware culture for teams. Leadership norms, incentives, and habits that make secure behavior default. Expand via contribution."
+tags:
+  - Security Specialist
+  - Operations & Strategy
+  - HR
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
+---
+
+import { TagList, AttributionList, ContributeFooter } from '../../../components'
+
 # Security-Aware Culture
+
+<TagList tags={frontmatter.tags} />
+<AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Culture is the control plane for people risk — incentives, leadership example, and psychological
+> safety determine whether staff report mistakes or hide them.
+> ⚠️ This article is a [stub](https://en.wikipedia.org/wiki/Wikipedia:Stub). Help expand it by
+> [contributing](/contribute/contributing).
+
+Current guidance:
+
+- [Cultivating a security-aware mindset](/awareness/cultivating-a-security-aware-mindset)
+- [Security Awareness overview](/awareness/overview)
+
+## Planned sections
+
+- Leadership modeling and no-blame reporting for near misses
+- Incentive design that does not punish slow security checks on high-value actions
+- Onboarding and offboarding culture checkpoints
+- Relationship to OpSec and tabletop exercises
+
+## Further Reading & Tools
+
+- [User and Team Security overview](/user-team-security/overview)
+- [Security Awareness](/awareness/overview)
+- [OpSec](/opsec/overview)
+
+---
+
+<ContributeFooter />

--- a/docs/pages/user-team-security/security-training.mdx
+++ b/docs/pages/user-team-security/security-training.mdx
@@ -8,7 +8,7 @@ tags:
   - Engineer/Developer
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/user-team-security/security-training.mdx
+++ b/docs/pages/user-team-security/security-training.mdx
@@ -1,1 +1,51 @@
+---
+title: "Security Training | Security Alliance"
+description: "Stub: security training program design for Web3 teams — curricula, drills, measurement, and a defined refresh cadence. Expand with steward expertise."
+tags:
+  - Security Specialist
+  - Operations & Strategy
+  - HR
+  - Engineer/Developer
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
+---
+
+import { TagList, AttributionList, ContributeFooter } from '../../../components'
+
 # Security Training
+
+<TagList tags={frontmatter.tags} />
+<AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Training works when it is role-specific, recurring, and measured against real lure simulations —
+> annual generic slide decks do not change operator behavior.
+> ⚠️ This article is a [stub](https://en.wikipedia.org/wiki/Wikipedia:Stub). Help expand it by
+> [contributing](/contribute/contributing).
+
+Until expanded, pair Awareness reading with drills tied to incident response:
+
+- [Security Awareness](/awareness/overview)
+- [Incident Management](/incident-management/overview)
+- [Multisig operational runbooks](/multisig-for-protocols/runbooks/overview)
+
+## Planned sections
+
+- Role-based curricula (signer, community manager, engineer, executive)
+- Phishing simulations and safe failure handling
+- Tabletop cadence and after-action learning
+- Tracking completion without security theater metrics
+
+## Further Reading & Tools
+
+- [User and Team Security overview](/user-team-security/overview)
+- [Security Awareness](/awareness/overview)
+- [Contributing guide](/contribute/contributing)
+
+---
+
+<ContributeFooter />

--- a/docs/pages/user-team-security/security-training.mdx
+++ b/docs/pages/user-team-security/security-training.mdx
@@ -40,7 +40,7 @@ Until expanded, pair Awareness reading with drills tied to incident response:
 - Tabletop cadence and after-action learning
 - Tracking completion without security theater metrics
 
-## Further Reading & Tools
+## Further Reading
 
 - [User and Team Security overview](/user-team-security/overview)
 - [Security Awareness](/awareness/overview)

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -69,6 +69,25 @@ const config = {
           ]
         },
         {
+          text: 'User and Team Security',
+          collapsed: true,
+          dev: true,
+          items: [
+            { text: 'Overview', link: '/user-team-security/overview', dev: true },
+            {
+              text: 'Phishing and Social Engineering',
+              link: '/user-team-security/phishing-social-engineering',
+              dev: true,
+            },
+            {
+              text: 'Security-Aware Culture',
+              link: '/user-team-security/security-aware-culture',
+              dev: true,
+            },
+            { text: 'Security Training', link: '/user-team-security/security-training', dev: true },
+          ]
+        },
+        {
           text: 'Community Management',
           collapsed: true,
           items: [


### PR DESCRIPTION
## Scope

Framework: User and Team Security
Pages reviewed/changed: overview, phishing-social-engineering, security-aware-culture, security-training
Navigation: `vocs.config.ts` (dev: true)

## Why this PR is needed

- Folder existed on develop with only H1 stubs (1 line each) and no sidebar registration
- LLM index listed an empty framework with no usable structure
- Content overlaps Awareness without an explicit routing story

## Content model applied

| Page | Type |
| --- | --- |
| overview | Framework overview (stub) |
| child pages | Conceptual stubs with planned sections |

## Changes

- Structural stub chrome, page map, related framework table
- Canonical Key Takeaways and stub notices
- Sidebar registration under `dev: true` (hidden on main site)
- Pointers to Awareness / OpSec / incident content for interim guidance

## Substantive security changes

- None. No new controls invented; expert expansion required.

## Intentionally unchanged

- Deep phishing curricula, culture programs, and training metrics (steward-authored)

## Validation

- [x] Signed commits
- [x] cspell clean
- [x] markdownlint clean
- [x] Diff limited to this framework + sidebar entries
- [x] No hand-edited generated indexes

## Dependencies

https://github.com/security-alliance/frameworks/pull/561

## Reviewer focus

- Whether this framework should remain separate from Awareness long-term
- Steward assignment for full write-up