### PR TITLE
docs(iam): normalize structure and wording

### DIFF
--- a/docs/pages/iam/access-management.mdx
+++ b/docs/pages/iam/access-management.mdx
@@ -10,7 +10,7 @@ tags:
   - HR
 contributors:
   - role: wrote
-    users: [scode2277]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/iam/access-management.mdx
+++ b/docs/pages/iam/access-management.mdx
@@ -1,12 +1,20 @@
 ---
 title: "Access Management | Security Alliance"
-description: "Implement just-in-time (JIT) access, timely access revocation, regular access reviews, and clear on-boarding/off-boarding processes to prevent unauthorized access and insider threats."
+description: "Manage access with JIT grants, timely revocation, recurring reviews, deliberate onboarding and
+offboarding, and logging of sensitive access paths."
 tags:
   - Engineer/Developer
   - Security Specialist
   - Operations & Strategy
   - DevOps
   - HR
+contributors:
+  - role: wrote
+    users: [scode2277]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -16,28 +24,35 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Effective access management involves ensuring that users have the right access, at the right time, and that access is
-promptly revoked when no longer needed. Implementing access management practices helps prevent unauthorized access, and
-reduces the risk of insider threats.
+> 🔑 **Key Takeaway**: Access must be right-sized, time-bounded when possible, reviewed on a schedule, and revoked the
+> day a role ends — standing privilege is residual attack surface.
 
-## Practices for Access Management
+Access management ensures people have the right access at the right time and lose it when they no longer need it.
+Strong lifecycle handling limits unauthorized use and reduces insider and ex-employee risk across SaaS, cloud, and
+code hosts.
 
-- **Just-In-Time Access**: Implement just-in-time (JIT) access to provide users with temporary access when needed. This
-minimizes the risk of long-term access being misused.
-- **Timely Access Revocation**: Ensure that access is revoked in a timely manner for users who are no longer part of the
- organization or whose roles within the project have changed.
-- **Access Reviews**: Conduct regular access reviews to ensure that team members have appropriate access based on their
-current functions.
-- **On-boarding and Off-boarding Processes**: Establish clear processes for on-boarding new team members and
-off-boarding departing team members to ensure that access is granted and revoked as appropriate.
-- **Access Logging and Monitoring**: Implement logging and monitoring of access to critical services to detect and
-respond to unauthorized access attempts.
+## Practices
 
-## Best Practices for Access Management
+- **Just-in-time (JIT) access:** Prefer temporary elevation for rare admin tasks over standing admin roles.
+- **Timely revocation:** Revoke access when people leave or change roles; treat offboarding as a security control, not
+  only HR paperwork.
+- **Access reviews:** Review membership of privileged groups on a fixed cadence and after major org changes.
+- **Onboarding and offboarding processes:** Standardize grants and removals so accounts are not improvised in chat.
+- **Access logging and monitoring:** Log access to critical services and alert on anomalous use.
 
-1. Grant users the minimum access necessary to perform their job functions.
-2. Ensure that critical tasks require multiple users to perform them, reducing the risk of misuse.
-3. When possible, use automated tools to manage access provisioning and revocation based on user lifecycle events.
+## Priority controls
+
+1. Grant the minimum access needed for the role (least privilege).
+2. Require multi-party control for critical tasks when a single ambitious or compromised actor could cause severe harm.
+3. Prefer automated provisioning and deprovisioning tied to hiring system lifecycle events when the stack allows it.
+
+## Further Reading & Tools
+
+- [IAM overview](/iam/overview)
+- [Role-based access control](/iam/role-based-access-control)
+- [Secure authentication](/iam/secure-authentication)
+- [DPRK IT Workers](/dprk-it-workers/overview)
+- [Guides — Account Management](/guides/account-management/overview)
 
 ---
 

--- a/docs/pages/iam/access-management.mdx
+++ b/docs/pages/iam/access-management.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Access Management | Security Alliance"
-description: "Manage access with JIT grants, timely revocation, recurring reviews, deliberate onboarding and
-offboarding, and logging of sensitive access paths."
+description: "Manage access with JIT grants, timely revocation, recurring reviews, deliberate onboarding and offboarding, and logging of sensitive access paths."
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/iam/access-management.mdx
+++ b/docs/pages/iam/access-management.mdx
@@ -46,7 +46,7 @@ code hosts.
 2. Require multi-party control for critical tasks when a single ambitious or compromised actor could cause severe harm.
 3. Prefer automated provisioning and deprovisioning tied to hiring system lifecycle events when the stack allows it.
 
-## Further Reading & Tools
+## Further Reading
 
 - [IAM overview](/iam/overview)
 - [Role-based access control](/iam/role-based-access-control)

--- a/docs/pages/iam/overview.mdx
+++ b/docs/pages/iam/overview.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Identity and Access Management | SEAL"
-description: "IAM for Web3 teams: RBAC, secure authentication with MFA/SSO, and access lifecycle management to limit
-unauthorized access and insider risk."
+description: "IAM for Web3 teams: RBAC, secure authentication with MFA/SSO, and access lifecycle management to limit unauthorized access and insider risk."
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/iam/overview.mdx
+++ b/docs/pages/iam/overview.mdx
@@ -54,7 +54,7 @@ IAM has three linked concerns:
 - [DPRK IT Workers](/dprk-it-workers/overview): insider and hiring-path risks
 - [Infrastructure](/infrastructure/overview): platform IAM overlays
 
-## Further Reading & Tools
+## Further Reading
 
 - [NIST SP 800-63 Digital Identity Guidelines](https://pages.nist.gov/800-63-3/)
 - [OWASP Authentication Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html)

--- a/docs/pages/iam/overview.mdx
+++ b/docs/pages/iam/overview.mdx
@@ -10,7 +10,7 @@ tags:
   - HR
 contributors:
   - role: wrote
-    users: [scode2277]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/iam/overview.mdx
+++ b/docs/pages/iam/overview.mdx
@@ -1,10 +1,20 @@
 ---
 title: "Identity and Access Management | SEAL"
-description: "Identity and Access Management Framework: Control who accesses your systems and data with RBAC, secure authentication, and access management to prevent unauthorized access and insider threats."
+description: "IAM for Web3 teams: RBAC, secure authentication with MFA/SSO, and access lifecycle management to limit
+unauthorized access and insider risk."
 tags:
   - Engineer/Developer
   - Security Specialist
   - Operations & Strategy
+  - DevOps
+  - HR
+contributors:
+  - role: wrote
+    users: [scode2277]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -14,15 +24,40 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Identity and Access Management (IAM) is defined as managing who has access to your systems and data, and ensuring that
-access is secure and appropriate. Effective IAM practices help prevent unauthorized access, reduce the risk of insider
-threats, and ensure that users have the necessary access to perform their roles efficiently.
+> 🔑 **Key Takeaway**: IAM answers who can act on which systems, with least privilege, strong authentication, and fast
+> revocation when roles change.
 
-## Contents
+Identity and Access Management (IAM) is how teams control who reaches systems and data, and how that access stays
+appropriate over time. Weak IAM enables account takeover, privilege abuse, and lingering access after people leave —
+common failure modes for Web3 projects that move fast across many SaaS tools and shared admin paths.
 
-1. [Role-Based Access Control (RBAC)](/iam/role-based-access-control)
-2. [Secure Authentication](/iam/secure-authentication)
-3. [Access Management Best Practices](/iam/access-management)
+## Basics
+
+IAM has three linked concerns:
+
+- **Identity:** proving who a person or service is
+- **Authentication:** verifying that identity (passwords, MFA, SSO)
+- **Authorization and access lifecycle:** what that identity may do, for how long, and when access ends
+
+## What this framework covers
+
+1. [Role-Based Access Control](/iam/role-based-access-control): define roles with minimum permissions and separation of
+   duties.
+2. [Secure Authentication](/iam/secure-authentication): MFA (prefer hardware keys), SSO hygiene, and password practices.
+3. [Access Management](/iam/access-management): JIT access, reviews, onboarding/offboarding, and access logging.
+
+## Related frameworks
+
+- [OpSec — Multi-Factor Authentication](/opsec/mfa/overview)
+- [OpSec — Password Management](/opsec/passwords/overview)
+- [Guides — Account Management](/guides/account-management/overview)
+- [DPRK IT Workers](/dprk-it-workers/overview): insider and hiring-path risks
+- [Infrastructure](/infrastructure/overview): platform IAM overlays
+
+## Further Reading & Tools
+
+- [NIST SP 800-63 Digital Identity Guidelines](https://pages.nist.gov/800-63-3/)
+- [OWASP Authentication Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html)
 
 ---
 

--- a/docs/pages/iam/role-based-access-control.mdx
+++ b/docs/pages/iam/role-based-access-control.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Role-Based Access Control | SEAL"
-description: "Implement RBAC with clear role definitions, least-privilege assignments, regular permission reviews, and
-separation of duties to limit blast radius."
+description: "Implement RBAC with clear role definitions, least-privilege assignments, regular permission reviews, and separation of duties to limit blast radius."
 tags:
   - Engineer/Developer
   - Security Specialist
@@ -33,8 +32,7 @@ or malicious privilege use.
 
 ## Key principles
 
-- **Role definition:** Define roles from job responsibilities. Each role must carry a specific permission set. Example:
-  a
+- **Role definition:** Define roles from job responsibilities. Each role must carry a specific permission set. Example: a
   community manager may not need admin rights on the project's GitHub organization.
 - **Role assignment:** Assign roles from responsibilities. Principals must only reach the resources they need.
 - **Permission management:** Review and update role permissions as functions and tooling change.

--- a/docs/pages/iam/role-based-access-control.mdx
+++ b/docs/pages/iam/role-based-access-control.mdx
@@ -47,7 +47,7 @@ or malicious privilege use.
 2. Prefer fewer, well-named roles over snowflake personal grants, except short-lived exceptions under access management.
 3. Document privileged roles (billing admin, root cloud, multisig admin-adjacent SaaS) with owners and review cadence.
 
-## Further Reading & Tools
+## Further Reading
 
 - [IAM overview](/iam/overview)
 - [Access management](/iam/access-management)

--- a/docs/pages/iam/role-based-access-control.mdx
+++ b/docs/pages/iam/role-based-access-control.mdx
@@ -10,7 +10,7 @@ tags:
   - HR
 contributors:
   - role: wrote
-    users: [scode2277]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/iam/role-based-access-control.mdx
+++ b/docs/pages/iam/role-based-access-control.mdx
@@ -1,12 +1,20 @@
 ---
-title: "Role-Based Access Control | Security Alliance"
-description: "Implement RBAC to ensure minimum necessary access: define roles with specific permissions, assign based on job responsibilities, regularly review permissions, and enforce separation of duties."
+title: "Role-Based Access Control | SEAL"
+description: "Implement RBAC with clear role definitions, least-privilege assignments, regular permission reviews, and
+separation of duties to limit blast radius."
 tags:
   - Engineer/Developer
   - Security Specialist
   - Operations & Strategy
   - DevOps
   - HR
+contributors:
+  - role: wrote
+    users: [scode2277]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -16,21 +24,35 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Role-Based Access Control (RBAC) is a method of regulating access to systems and data based on the roles assigned to
-individual users within a project. RBAC ensures that users have the minimum access necessary to perform their job
-functions, reducing the risk of unauthorized access.
+> 🔑 **Key Takeaway**: Assign permissions to roles tied to job functions, not named individuals, and review those roles
+> so privileges do not accumulate silently.
 
-## Key Principles of RBAC
+Role-Based Access Control (RBAC) regulates access based on roles assigned to people (and sometimes services) in a
+project. Well-designed RBAC keeps each principal at the minimum access needed for their function and reduces accidental
+or malicious privilege use.
 
-- **Role Definition**: Clearly define roles within the project based on the team member's job responsibility. Each role
-should have a specific set of permissions, for example a community manager could potentially not require administrative
-permissions to the project's github repository.
-- **Role Assignment**: Assign roles to team members based on their job responsibilities. Ensure that users only have
-access to the resources they need.
-- **Permission Management**: Regularly review and update role permissions to ensure they are aligned with current team
-functions and security requirements.
-- **Separation of Duties**: Implement separation of duties to prevent conflicts of interest and reduce the risk of
-threats.
+## Key principles
+
+- **Role definition:** Define roles from job responsibilities. Each role must carry a specific permission set. Example:
+  a
+  community manager may not need admin rights on the project's GitHub organization.
+- **Role assignment:** Assign roles from responsibilities. Principals must only reach the resources they need.
+- **Permission management:** Review and update role permissions as functions and tooling change.
+- **Separation of duties:** Split critical powers so no single persona can complete a high-impact action alone when the
+  risk model requires dual control.
+
+## Practices
+
+1. Start from deny-by-default; add capabilities only when a role proves need.
+2. Prefer fewer, well-named roles over snowflake personal grants, except short-lived exceptions under access management.
+3. Document privileged roles (billing admin, root cloud, multisig admin-adjacent SaaS) with owners and review cadence.
+
+## Further Reading & Tools
+
+- [IAM overview](/iam/overview)
+- [Access management](/iam/access-management)
+- [Secure authentication](/iam/secure-authentication)
+- [Guides — Account Management](/guides/account-management/overview)
 
 ---
 

--- a/docs/pages/iam/secure-authentication.mdx
+++ b/docs/pages/iam/secure-authentication.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Secure Authentication | SEAL"
-description: "Require MFA with hardware security keys over SMS, harden SSO entry points, enforce strong passwords with
-managers, and monitor suspicious sign-ins."
+description: "Require MFA with hardware security keys over SMS, harden SSO entry points, enforce strong passwords with managers, and monitor suspicious sign-ins."
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/iam/secure-authentication.mdx
+++ b/docs/pages/iam/secure-authentication.mdx
@@ -46,7 +46,7 @@ and unmonitored login anomalies are standard entry points into Web3 organization
 2. Monitor and alert on suspicious authentication (repeated failures, impossible travel, new device enrollment).
 3. Train staff on phishing of MFA prompts, recovery flows, and never sharing OTPs or seed material.
 
-## Further Reading & Tools
+## Further Reading
 
 - [IAM overview](/iam/overview)
 - [OpSec — Multi-Factor Authentication](/opsec/mfa/overview)

--- a/docs/pages/iam/secure-authentication.mdx
+++ b/docs/pages/iam/secure-authentication.mdx
@@ -10,7 +10,7 @@ tags:
   - HR
 contributors:
   - role: wrote
-    users: [scode2277]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/iam/secure-authentication.mdx
+++ b/docs/pages/iam/secure-authentication.mdx
@@ -1,12 +1,20 @@
 ---
-title: "Secure Authentication | Security Alliance"
-description: "Secure authentication best practices: require Multi-Factor Authentication (MFA) with hardware tokens like Yubikeys over SMS, implement SSO, and enforce strong password policies with managers."
+title: "Secure Authentication | SEAL"
+description: "Require MFA with hardware security keys over SMS, harden SSO entry points, enforce strong passwords with
+managers, and monitor suspicious sign-ins."
 tags:
   - Engineer/Developer
   - Security Specialist
   - Operations & Strategy
   - DevOps
   - HR
+contributors:
+  - role: wrote
+    users: [scode2277]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -16,28 +24,35 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Secure authentication is essential for verifying the identity of team members and ensuring that only authorized
-individuals have access. By implementing strong authentication mechanisms you can protect your project against
-unauthorized access and lower the risk for potential security breaches.
+> 🔑 **Key Takeaway**: Authentication must prove identity with phishing-resistant factors where available — prefer
+> hardware-backed MFA over SMS, and protect the SSO account that unlocks everything else.
 
-## Key Authentication Methods
+Secure authentication verifies that only authorized people and services obtain sessions. Weak factors, SMS phishing,
+and unmonitored login anomalies are standard entry points into Web3 organization tooling and funds-adjacent systems.
 
-- **Multi-Factor Authentication (MFA)**: Require multiple forms of verification (e.g., something you know, something you
-have, something you are) to enhance security. It is strongly suggested that one does not use SMS as a form of
-multi-factor authentication, but instead utilizes hardware tokens such as Yubikeys.
-- **Single Sign-On (SSO)**: Enable SSO in services you use to allow team members to authenticate once and gain access to
-multiple systems without re-entering credentials, but make sure that the account connected to SSO is secured by strong
-Multi-Factor Authentication.
-- **Password Management**: Enforce strong password policies and encourage the use of password managers to generate and
-store complex passwords.
+## Core methods
 
-## Best Practices for Secure Authentication
+- **Multi-factor authentication (MFA):** Require multiple independent factors. Do **not** rely on SMS as the primary
+  second factor for sensitive systems; prefer hardware security keys (for example YubiKey-class devices) or other
+  phishing-resistant methods where platforms support them. See [OpSec MFA](/opsec/mfa/overview).
+- **Single sign-on (SSO):** SSO reduces password sprawl but concentrates risk on the identity provider account — that
+  account must itself use strong MFA and hardened recovery paths.
+- **Password management:** Enforce strong password policies and password managers for unique, high-entropy secrets. See
+  [Password management](/opsec/passwords/overview).
 
-1. Require MFA for all team members, especially for accessing sensitive systems and data. Encourage the use of hardware
-tokens (e.g., Yubikeys) over SMS-based MFA.
-2. Implement monitoring and alerting for suspicious authentication attempts, such as repeated failed logins or logins
-from unusual locations.
-3. Provide training on secure authentication practices and the importance of protecting authentication credentials.
+## Practices
+
+1. Require MFA for all team members on sensitive systems; prioritize hardware-backed factors for admins and finance.
+2. Monitor and alert on suspicious authentication (repeated failures, impossible travel, new device enrollment).
+3. Train staff on phishing of MFA prompts, recovery flows, and never sharing OTPs or seed material.
+
+## Further Reading & Tools
+
+- [IAM overview](/iam/overview)
+- [OpSec — Multi-Factor Authentication](/opsec/mfa/overview)
+- [OpSec — Password Management](/opsec/passwords/overview)
+- [OWASP Authentication Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html)
+- [NIST SP 800-63B](https://pages.nist.gov/800-63-3/sp800-63b.html)
 
 ---
 


### PR DESCRIPTION
## Scope

Framework: IAM
Pages: overview, role-based-access-control, secure-authentication, access-management

## Why this PR is needed

Missing Key Takeaways, overview foundations/page map quality, contributor metadata, and further reading; light terminology clean-up (MFA preference aligned with existing OpSec pointers).

## Content model applied

Framework overview + conceptual/procedure pages.

## Changes

Structural chrome, related frameworks, NIST/OWASP references, preserve existing JIT/RBAC/MFA guidance.

## Substantive security changes

- None material. SMS de-preference for sensitive MFA already present; restated and linked to OpSec MFA.

## Intentionally unchanged

Deep IdP product configuration (out of scope / steward).

## Validation

- [x] Signed commits, cspell, markdownlint on path
- [x] Framework-scoped diff

## Dependencies

https://github.com/security-alliance/frameworks/pull/561