### PR TITLE
docs(threat-modeling): normalize structure and wording

### DIFF
--- a/docs/pages/threat-modeling/create-maintain-threat-models.mdx
+++ b/docs/pages/threat-modeling/create-maintain-threat-models.mdx
@@ -7,7 +7,7 @@ tags:
   - Security Specialist
 contributors:
   - role: wrote
-    users: [scode2277]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/threat-modeling/create-maintain-threat-models.mdx
+++ b/docs/pages/threat-modeling/create-maintain-threat-models.mdx
@@ -96,7 +96,7 @@ protect the project.
    - Pros: Free, web-based, supports multiple platforms.
    - Cons: Limited features compared to commercial tools.
 
-## Further Reading & Tools
+## Further Reading
 
 - [Threat modeling overview](/threat-modeling/overview)
 - [OWASP Threat Modeling](https://owasp.org/www-community/Threat_Modeling)

--- a/docs/pages/threat-modeling/create-maintain-threat-models.mdx
+++ b/docs/pages/threat-modeling/create-maintain-threat-models.mdx
@@ -1,9 +1,17 @@
 ---
-title: "Creating Threat Models | Security Alliance"
-description: "Create threat models using STRIDE framework: define scope, identify assets and threats, evaluate risks, and develop mitigations. Tools: Microsoft Threat Modeling Tool, OWASP Threat Dragon."
+title: "Creating Threat Models | SEAL"
+description: "Create and maintain threat models: scope, assets, STRIDE threats, attack scenarios, prioritization,
+mitigations, and tools like Threat Dragon."
 tags:
   - Engineer/Developer
   - Security Specialist
+contributors:
+  - role: wrote
+    users: [scode2277]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -12,6 +20,12 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: A useful threat model is a maintained artifact — redefine scope and mitigations when architecture
+> or value at risk changes.
+
+This page walks through creating a threat model and keeping it current. Pair it with [Identify and Mitigate
+Threats](/threat-modeling/identity-mitigate-threats) for enumeration depth.
 
 Creating and maintaining threat models helps identify potential security risks and develop mitigation strategies to
 protect the project.
@@ -81,6 +95,12 @@ protect the project.
    - An open-source threat modeling tool for creating diagrams and identifying threats.
    - Pros: Free, web-based, supports multiple platforms.
    - Cons: Limited features compared to commercial tools.
+
+## Further Reading & Tools
+
+- [Threat modeling overview](/threat-modeling/overview)
+- [OWASP Threat Modeling](https://owasp.org/www-community/Threat_Modeling)
+- [OWASP Threat Dragon](https://owasp.org/www-project-threat-dragon/)
 
 ---
 

--- a/docs/pages/threat-modeling/create-maintain-threat-models.mdx
+++ b/docs/pages/threat-modeling/create-maintain-threat-models.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Creating Threat Models | SEAL"
-description: "Create and maintain threat models: scope, assets, STRIDE threats, attack scenarios, prioritization,
-mitigations, and tools like Threat Dragon."
+description: "Create and maintain threat models: scope, assets, STRIDE threats, attack scenarios, prioritization, mitigations, and tools like Threat Dragon."
 tags:
   - Engineer/Developer
   - Security Specialist
@@ -27,10 +26,7 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 This page walks through creating a threat model and keeping it current. Pair it with [Identify and Mitigate
 Threats](/threat-modeling/identity-mitigate-threats) for enumeration depth.
 
-Creating and maintaining threat models helps identify potential security risks and develop mitigation strategies to
-protect the project.
-
-## Steps to Create a Threat Model
+## Steps to create a threat model
 
 1. **Define the Scope**
    - Identify the contract, system, application, or component to be analyzed.
@@ -66,7 +62,7 @@ protect the project.
    scenarios, and mitigation strategies.
    - Use templates and standardized formats to ensure consistency.
 
-## Maintaining Threat Models
+## Maintaining threat models
 
 1. **Regular Updates**
    - Update the threat model regularly to reflect changes in the system, new threats, and emerging vulnerabilities.
@@ -84,7 +80,7 @@ protect the project.
    - Provide training for team members on threat modeling concepts and techniques.
    - Raise awareness about the importance of threat modeling in maintaining security.
 
-## Tools for Threat Modeling
+## Tools for threat modeling
 
 1. **Microsoft Threat Modeling Tool**
    - A free tool that helps create threat models using the STRIDE framework.

--- a/docs/pages/threat-modeling/identity-mitigate-threats.mdx
+++ b/docs/pages/threat-modeling/identity-mitigate-threats.mdx
@@ -79,7 +79,7 @@ and developing strategies to address them, projects can help protect their syste
    security incidents.
    - Train team members on incident response procedures and conduct regular drills to ensure readiness.
 
-## Further Reading & Tools
+## Further Reading
 
 - [Threat modeling overview](/threat-modeling/overview)
 - [OWASP Threat Modeling](https://owasp.org/www-community/Threat_Modeling)

--- a/docs/pages/threat-modeling/identity-mitigate-threats.mdx
+++ b/docs/pages/threat-modeling/identity-mitigate-threats.mdx
@@ -1,10 +1,18 @@
 ---
-title: "Identify & Mitigate Threats | Security Alliance"
-description: "Identify threats using STRIDE, attack surface analysis, and adversary modeling. Mitigate with defense in depth, least privilege, security by design, and incident response planning."
+title: "Identify and Mitigate Threats | SEAL"
+description: "Identify threats with STRIDE, attack-surface analysis, and adversary profiles; mitigate with defense in
+depth, least privilege, and response readiness."
 tags:
   - Engineer/Developer
   - Security Specialist
   - DevOps
+contributors:
+  - role: wrote
+    users: [scode2277]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -13,6 +21,12 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Enumerate threats against real entry points, then apply layered mitigations owned by specific
+> teams — lists without owners do not reduce risk.
+
+Identification and mitigation is the analytic core of threat modeling. Expand STRIDE-style analysis with Web3 attack
+surfaces such as contracts, wallets, and third-party integrations.
 
 Identifying and mitigating threats is a crucial part of the threat modeling process. By understanding potential threats
 and developing strategies to address them, projects can help protect their systems and data from security incidents.
@@ -64,6 +78,12 @@ and developing strategies to address them, projects can help protect their syste
    - Develop and maintain an [incident response plan](/incident-management/overview) to quickly and effectively address
    security incidents.
    - Train team members on incident response procedures and conduct regular drills to ensure readiness.
+
+## Further Reading & Tools
+
+- [Threat modeling overview](/threat-modeling/overview)
+- [OWASP Threat Modeling](https://owasp.org/www-community/Threat_Modeling)
+- [OWASP Threat Dragon](https://owasp.org/www-project-threat-dragon/)
 
 ---
 

--- a/docs/pages/threat-modeling/identity-mitigate-threats.mdx
+++ b/docs/pages/threat-modeling/identity-mitigate-threats.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Identify and Mitigate Threats | SEAL"
-description: "Identify threats with STRIDE, attack-surface analysis, and adversary profiles; mitigate with defense in
-depth, least privilege, and response readiness."
+description: "Identify threats with STRIDE, attack-surface analysis, and adversary profiles; mitigate with defense in depth, least privilege, and response readiness."
 tags:
   - Engineer/Developer
   - Security Specialist
@@ -28,10 +27,7 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 Identification and mitigation is the analytic core of threat modeling. Expand STRIDE-style analysis with Web3 attack
 surfaces such as contracts, wallets, and third-party integrations.
 
-Identifying and mitigating threats is a crucial part of the threat modeling process. By understanding potential threats
-and developing strategies to address them, projects can help protect their systems and data from security incidents.
-
-## Identifying Threats
+## Identifying threats
 
 1. **Threat Enumeration**
    - Use frameworks like STRIDE (Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, Elevation
@@ -51,7 +47,7 @@ and developing strategies to address them, projects can help protect their syste
    - Review past security incidents and vulnerabilities to identify common attack patterns and weaknesses.
    - Use vulnerability databases and threat intelligence feeds to stay informed about emerging threats.
 
-## Mitigating Threats
+## Mitigating threats
 
 1. **Security Controls**
    - Implement security controls to mitigate identified threats. These can include technical controls, administrative

--- a/docs/pages/threat-modeling/identity-mitigate-threats.mdx
+++ b/docs/pages/threat-modeling/identity-mitigate-threats.mdx
@@ -8,7 +8,7 @@ tags:
   - DevOps
 contributors:
   - role: wrote
-    users: [scode2277]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/threat-modeling/overview.mdx
+++ b/docs/pages/threat-modeling/overview.mdx
@@ -7,7 +7,7 @@ tags:
   - DevOps
 contributors:
   - role: wrote
-    users: [scode2277]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/threat-modeling/overview.mdx
+++ b/docs/pages/threat-modeling/overview.mdx
@@ -1,9 +1,17 @@
 ---
 title: "Threat Modeling | Security Alliance"
-description: "Threat Modeling Framework: Identify and mitigate security threats with a structured approach. Understand vulnerabilities, attack vectors, and develop effective mitigation strategies for your systems."
+description: "Threat modeling for Web3 systems: structure assets, threats, and mitigations with STRIDE-oriented analysis and maintain models as systems change."
 tags:
   - Engineer/Developer
   - Security Specialist
+  - DevOps
+contributors:
+  - role: wrote
+    users: [scode2277]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -13,8 +21,44 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Threat modeling is a structured approach to identifying and mitigating security threats to a system. It involves
-understanding potential threats, vulnerabilities, and attack vectors, and developing strategies to mitigate them.
+> 🔑 **Key Takeaway**: Threat modeling is a structured way to decide which abuses matter before they happen — name
+> assets, threats, and mitigations, then keep the model current as the system changes.
+
+Threat modeling identifies how a system can fail under attack and which controls reduce that risk. In Web3, models must
+cover smart contracts and keys, plus the operators, front ends, oracles, bridges, and admin paths that move or influence real
+value.
+
+## Basics
+
+A practical threat model answers:
+
+1. What are we building and where are the trust boundaries?
+2. What assets matter (funds, keys, governance, availability, integrity of data)?
+3. Who might attack them and through which entry points?
+4. Which controls reduce likelihood or impact — and who owns them?
+
+Models go stale. Treat them as living documents tied to design changes and major releases.
+
+## What this framework covers
+
+1. [Create and Maintain Threat Models](/threat-modeling/create-maintain-threat-models): step-by-step modeling, upkeep,
+   and common tools.
+2. [Identify and Mitigate Threats](/threat-modeling/identity-mitigate-threats): STRIDE-oriented enumeration, attack
+   surface analysis, and mitigation patterns.
+
+## Related frameworks
+
+- [Secure Software Development](/secure-software-development/overview)
+- [Security Testing](/security-testing/overview)
+- [External Security Reviews](/external-security-reviews/overview)
+- [Incident Management](/incident-management/overview)
+- [Monitoring](/monitoring/overview)
+
+## Further Reading & Tools
+
+- [OWASP Threat Modeling](https://owasp.org/www-community/Threat_Modeling)
+- [OWASP Threat Dragon](https://owasp.org/www-project-threat-dragon/)
+- [NIST SP 800-154 Guide to Data-Centric System Threat Modeling](https://csrc.nist.gov/pubs/sp/800/154/ipd)
 
 ---
 

--- a/docs/pages/threat-modeling/overview.mdx
+++ b/docs/pages/threat-modeling/overview.mdx
@@ -54,7 +54,7 @@ Models go stale. Treat them as living documents tied to design changes and major
 - [Incident Management](/incident-management/overview)
 - [Monitoring](/monitoring/overview)
 
-## Further Reading & Tools
+## Further Reading
 
 - [OWASP Threat Modeling](https://owasp.org/www-community/Threat_Modeling)
 - [OWASP Threat Dragon](https://owasp.org/www-project-threat-dragon/)

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -528,7 +528,7 @@ const config = {
           items: [
             { text: 'Overview', link: '/threat-modeling/overview', dev: true },
             { text: 'Create and Maintain Threat Models', link: '/threat-modeling/create-maintain-threat-models', dev: true },
-            { text: 'Identity Mitigate Threats', link: '/threat-modeling/identity-mitigate-threats', dev: true },
+            { text: 'Identify and Mitigate Threats', link: '/threat-modeling/identity-mitigate-threats', dev: true },
           ]
         },
         {


### PR DESCRIPTION
## Scope

Framework: Threat Modeling
Pages: overview, create-maintain-threat-models, identity-mitigate-threats

## Why this PR is needed

Overview was a single paragraph without map or takeaway; child pages lacked Key Takeaways, contributors, and further reading.

## Content model applied

Framework overview + procedure pages.

## Changes

Structural chrome, related frameworks, OWASP/NIST links; preserved STRIDE steps and tool notes.

## Substantive security changes

None.

## Intentionally unchanged

Web3-specific threat libraries beyond existing surface list (needs steward depth).

## Validation

- [x] Signed commits, cspell, markdownlint
- [x] Framework-scoped diff

## Dependencies

https://github.com/security-alliance/frameworks/pull/561