### PR TITLE
docs(vulnerability-disclosure): normalize structure and wording

### DIFF
--- a/docs/pages/vulnerability-disclosure/bug-bounties.mdx
+++ b/docs/pages/vulnerability-disclosure/bug-bounties.mdx
@@ -1,9 +1,16 @@
 ---
 title: "Bug Bounty Programs | Security Alliance"
-description: "Run effective bug bounty programs with Immunefi, HackerOne, or Bugcrowd. Define scope, set competitive rewards, implement triage processes, and maintain safe harbor provisions for researchers."
+description: "Design bug bounty programs: clear scope, competitive rewards, triage capacity, researcher communication, and safe harbor on Immunefi, HackerOne, Bugcrowd, or in-house."
 tags:
   - Engineer/Developer
   - Security Specialist
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -13,67 +20,82 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Bug bounty programs incentivize security researchers to identify and report vulnerabilities in your project. They
-augment a security team and complement audits by allowing external security researchers to disclose vulnerabilities in your
-project in a way that should be a good experience for the security researcher. Depending on what the scope of the bug
-bounty program is, you may have a higher success rate having certain parts at different types of bug bounty as a service
-providers, as they generally have security researchers with different skill sets using their platforms.
+> 🔑 **Key Takeaway**: Bug bounties work when scope, rewards, and triage capacity match the asset risk—and researchers
+> can report safely under explicit safe harbor and disclosure rules.
 
-## Bug Bounty as a Service
+Bug bounty programs pay independent security researchers to find and report vulnerabilities. They extend internal
+security work and complement audits by giving external researchers a defined channel. Platform choice matters: different
+“bug bounty as a service” providers attract different skill sets, so assets in scope should match the researchers the
+platform actually reaches.
+
+Pair any bounty program with a durable [security contact](/vulnerability-disclosure/security-contact) so reports still
+have a path if platform settings change.
+
+## Bug bounty as a service
 
 ### Web3
 
-- Immunefi
-  - **Pros**: One of the largest bug bounty as a service platforms for web3
-- Hackenproof
-  - **Pros**: Provides end-to-end encryption for reports, ensuring only a project's security team can decrypt it using
-  their own private keys.
+- **Immunefi** — among the largest Web3-focused bounty platforms.
+- **Hackenproof** — end-to-end encryption for reports so only the project security team can decrypt with its own private
+  keys (as described by the vendor).
 
 ### Web2
 
-- HackerOne
-- Bugcrowd
+- **HackerOne**
+- **Bugcrowd**
 
-## Pros and Cons of Running Your Own Bug Bounty Program
+Treat vendor capabilities and rankings as changing markets; verify current program features and researcher coverage
+before committing.
+
+## Self-run programs
 
 ### Pros
 
-1. Full control over the scope, rewards, and rules of the program.
-2. Potentially lower cost.
-3. Direct interaction with security researchers could build strong relationships.
+1. Full control over scope, rewards, and rules.
+2. Potentially lower cash outlay versus full-service platforms (ops cost still lands on the team).
+3. Direct researcher relationships when interactions stay professional and timely.
 
 ### Cons
 
-1. Requires significant time and resources to manage.
-2. Need for skilled triage abilities to handle and prioritize reports.
-3. Risk of being overwhelmed by reports, including false positives.
+1. Significant ongoing time to operate intake, triage, and payouts.
+2. Need skilled triage to prioritize real issues over noise.
+3. Risk of overload, including high volumes of low-quality or out-of-scope reports.
 
-## Key Elements of a Successful Bug Bounty Program
+## Key elements of a successful program
 
 ### Scope
 
-1. Clearly define the scope of the program, including in-scope and out-of-scope assets.
-2. Regularly update the scope to include new features and exclude deprecated ones.
+1. Define in-scope and out-of-scope assets clearly.
+2. Update scope when features ship or systems retire.
 
 ### Rewards
 
-1. Offer competitive rewards based on the severity and impact of the vulnerabilities.
-2. Be transparent about the reward structure and criteria for evaluating reports.
+1. Offer competitive rewards tied to severity and impact.
+2. Publish transparent reward structure and evaluation criteria.
 
-### Triage and Response
+### Triage and response
 
-1. Have skilled personnel to triage incoming reports, assess severity, and prioritize responses.
-2. Respond to reports promptly, acknowledging receipt and providing regular updates.
+1. Staff triage with people who can assess severity and prioritize fixes.
+2. Acknowledge reports promptly and give regular status updates.
 
 ### Communication
 
-1. Treat all reporters with respect and professionalism.
-2. Provide feedback to researchers on the status of their reports and any actions taken.
+1. Treat reporters with respect and professionalism.
+2. Tell researchers what happened to their report and which actions followed.
 
-### Legal and Ethical Considerations
+### Legal and ethical considerations
 
-1. Clearly state safe harbor provisions to protect researchers from legal action when acting in good faith.
-2. Define your policy on public disclosure of vulnerabilities, including timelines and conditions.
+1. State safe harbor provisions so good-faith research is not treated as unauthorized access when rules are followed.
+2. Define public disclosure policy, including timelines and conditions (coordinate with
+   [Safe Harbor](/safe-harbor/overview) when emergency paths apply).
+
+## Further Reading & Tools
+
+- [Immunefi](https://immunefi.com/)
+- [HackerOne](https://www.hackerone.com/)
+- [Bugcrowd](https://www.bugcrowd.com/)
+- [Hackenproof](https://hackenproof.com/)
+- [Disclose.io](https://disclose.io/): open safe harbor and vulnerability disclosure policy resources
 
 ---
 

--- a/docs/pages/vulnerability-disclosure/bug-bounties.mdx
+++ b/docs/pages/vulnerability-disclosure/bug-bounties.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Bug Bounty Programs | Security Alliance"
-description: "Design bug bounty programs: clear scope, competitive rewards, triage capacity, researcher communication, and safe harbor on Immunefi, HackerOne, Bugcrowd, or in-house."
+description: "Design bug bounty programs: clear scope, competitive rewards, triage capacity, researcher communication, and safe harbor on Immunefi, HackerOne, Bugcrowd"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/vulnerability-disclosure/bug-bounties.mdx
+++ b/docs/pages/vulnerability-disclosure/bug-bounties.mdx
@@ -89,7 +89,7 @@ before committing.
 2. Define public disclosure policy, including timelines and conditions (coordinate with
    [Safe Harbor](/safe-harbor/overview) when emergency paths apply).
 
-## Further Reading & Tools
+## Further Reading
 
 - [Immunefi](https://immunefi.com/)
 - [HackerOne](https://www.hackerone.com/)

--- a/docs/pages/vulnerability-disclosure/bug-bounties.mdx
+++ b/docs/pages/vulnerability-disclosure/bug-bounties.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Bug Bounty Programs | Security Alliance"
-description: "Design bug bounty programs: clear scope, competitive rewards, triage capacity, researcher communication, and safe harbor on Immunefi, HackerOne, Bugcrowd"
+description: "Design bug bounty programs: clear scope, competitive rewards, triage capacity, researcher communication, and safe harbor on Immunefi, HackerOne, Bugcrowd."
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/vulnerability-disclosure/bug-bounties.mdx
+++ b/docs/pages/vulnerability-disclosure/bug-bounties.mdx
@@ -6,7 +6,7 @@ tags:
   - Security Specialist
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/vulnerability-disclosure/overview.mdx
+++ b/docs/pages/vulnerability-disclosure/overview.mdx
@@ -60,7 +60,7 @@ contacts, triage ownership, or disclosure discipline.
 - [Secure Software Development](/secure-software-development/overview): fixing and preventing classes of defects
 - [Security Testing](/security-testing/overview): proactive testing alongside external researchers
 
-## Further Reading & Tools
+## Further Reading
 
 - [ISO/IEC 29147 Vulnerability disclosure](https://www.iso.org/standard/72311.html) (overview of the standard family)
 - [FIRST product security incident response services framework](https://www.first.org/standards/frameworks/psirts/)

--- a/docs/pages/vulnerability-disclosure/overview.mdx
+++ b/docs/pages/vulnerability-disclosure/overview.mdx
@@ -7,7 +7,7 @@ tags:
   - DevOps
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/vulnerability-disclosure/overview.mdx
+++ b/docs/pages/vulnerability-disclosure/overview.mdx
@@ -38,8 +38,7 @@ Effective disclosure programs share three layers:
 
 - **Inbound reporting:** researchers and users must know how to reach the right people (see
   [Security Contact](/vulnerability-disclosure/security-contact)).
-- **Triage and fix:** skilled intake, severity assessment, and remediation before passwords, keys, or public write-ups
-  go live.
+- **Triage and fix:** skilled intake, severity assessment, and remediation before any public write-up.
 - **Outbound disclosure:** clear public communication after the fix (or under Safe Harbor when quiet coordination fails).
 
 Bug bounty platforms and self-run programs change how reports arrive and how rewards work; they do not replace security

--- a/docs/pages/vulnerability-disclosure/overview.mdx
+++ b/docs/pages/vulnerability-disclosure/overview.mdx
@@ -59,7 +59,7 @@ contacts, triage ownership, or disclosure discipline.
 - [Secure Software Development](/secure-software-development/overview): fixing and preventing classes of defects
 - [Security Testing](/security-testing/overview): proactive testing alongside external researchers
 
-## Further Reading
+## Further reading
 
 - [ISO/IEC 29147 Vulnerability disclosure](https://www.iso.org/standard/72311.html) (overview of the standard family)
 - [FIRST product security incident response services framework](https://www.first.org/standards/frameworks/psirts/)

--- a/docs/pages/vulnerability-disclosure/overview.mdx
+++ b/docs/pages/vulnerability-disclosure/overview.mdx
@@ -1,10 +1,17 @@
 ---
 title: "Vulnerability Disclosure | Security Alliance"
-description: "Vulnerability Disclosure Framework: Responsible disclosure of identified vulnerabilities after fixes are implemented. Includes bug bounty reporting and Safe Harbor procedures for active exploits."
+description: "Vulnerability disclosure after fixes: public communication, security contacts, bug bounty programs, and when Safe Harbor applies under active exploit pressure."
 tags:
   - Engineer/Developer
   - Security Specialist
   - DevOps
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -14,12 +21,51 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Vulnerability disclosure is the task that is done after a vulnerability has been identified and fixed, and means to make
-the vulnerability known to the larger public. Often, a vulnerability disclosure will come after a
-[bug bounty](/vulnerability-disclosure/bug-bounties) report has been filed and the vulnerability has been corrected,
-or from a team member that noticed a vulnerability which was then fixed. In the event that responsible disclosure of
-the vulnerability is not possible because the vulnerable code is actively or will imminently be exploited,
-[Safe Harbor](/safe-harbor/overview) may be applicable.
+> 🔑 **Key Takeaway**: Vulnerability disclosure makes fixed issues public on a deliberate timeline. Before that, teams
+> need inbound reporting paths, triage, and a plan when quiet disclosure is no longer safe.
+
+Vulnerability disclosure is the work of informing the wider community after a vulnerability has been identified and
+addressed (or when public awareness is otherwise required). Disclosure often follows a
+[bug bounty](/vulnerability-disclosure/bug-bounties) report that has been triaged and fixed, or an internal finding that
+has been remediated.
+
+When responsible coordinated disclosure is not possible because vulnerable code is already under active exploit or
+imminently will be, [Safe Harbor](/safe-harbor/overview) may be the applicable path.
+
+## Basics
+
+Effective disclosure programs share three layers:
+
+- **Inbound reporting:** researchers and users must know how to reach the right people (see
+  [Security Contact](/vulnerability-disclosure/security-contact)).
+- **Triage and fix:** skilled intake, severity assessment, and remediation before passwords, keys, or public write-ups
+  go live.
+- **Outbound disclosure:** clear public communication after the fix (or under Safe Harbor when quiet coordination fails).
+
+Bug bounty platforms and self-run programs change how reports arrive and how rewards work; they do not replace security
+contacts, triage ownership, or disclosure discipline.
+
+## What this framework covers
+
+1. [Security Contact](/vulnerability-disclosure/security-contact): `SECURITY.md`, dedicated security mailboxes, and
+   `.well-known/security.txt` so researchers can report issues reliably.
+2. [Bug Bounties](/vulnerability-disclosure/bug-bounties): platform choices, self-run tradeoffs, and program elements
+   (scope, rewards, triage, safe harbor language, disclosure policy).
+
+## Related frameworks
+
+- [Safe Harbor](/safe-harbor/overview): coordination when active or imminent exploitation changes the disclosure path
+- [External Security Reviews](/external-security-reviews/overview): paid audits complementary to continuous bounty intake
+- [Incident Management](/incident-management/overview): response when a reported issue is actively exploited
+- [Secure Software Development](/secure-software-development/overview): fixing and preventing classes of defects
+- [Security Testing](/security-testing/overview): proactive testing alongside external researchers
+
+## Further Reading & Tools
+
+- [ISO/IEC 29147 Vulnerability disclosure](https://www.iso.org/standard/72311.html) (overview of the standard family)
+- [FIRST product security incident response services framework](https://www.first.org/standards/frameworks/psirts/)
+- [security.txt](https://securitytxt.org/): machine-readable security contact discovery
+- [GitHub documenting a security policy](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository)
 
 ---
 

--- a/docs/pages/vulnerability-disclosure/security-contact.mdx
+++ b/docs/pages/vulnerability-disclosure/security-contact.mdx
@@ -96,7 +96,7 @@ Preferred-Languages: en
 - **Acknowledgement:** consider public credit for researchers who want it, only with their permission.
 - **Transparency:** publish disclosure process and expected timelines so reporters know the rules.
 
-## Further Reading & Tools
+## Further Reading
 
 - [security.txt](https://securitytxt.org/)
 - [GitHub: Add a security policy](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository)

--- a/docs/pages/vulnerability-disclosure/security-contact.mdx
+++ b/docs/pages/vulnerability-disclosure/security-contact.mdx
@@ -96,7 +96,7 @@ Preferred-Languages: en
 - **Acknowledgement:** consider public credit for researchers who want it, only with their permission.
 - **Transparency:** publish disclosure process and expected timelines so reporters know the rules.
 
-## Further Reading
+## Further reading
 
 - [security.txt](https://securitytxt.org/)
 - [GitHub: Add a security policy](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository)

--- a/docs/pages/vulnerability-disclosure/security-contact.mdx
+++ b/docs/pages/vulnerability-disclosure/security-contact.mdx
@@ -1,9 +1,16 @@
 ---
 title: "Security Contact | Security Alliance"
-description: "Set up security contacts: SECURITY.md files, dedicated security email addresses, and .well-known/security.txt. Best practices for triage, communication, and vulnerability report handling."
+description: "Publish security contacts via SECURITY.md, a monitored security mailbox, and .well-known/security.txt so researchers can report issues for timely triage."
 tags:
   - Engineer/Developer
   - Security Specialist
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -13,17 +20,21 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Having a security contact provides a designated point of contact for security researchers to report vulnerabilities to.
+> 🔑 **Key Takeaway**: A security contact is useless unless someone skilled monitors it, acknowledges reports quickly,
+> and keeps findings confidential until fixes ship.
 
-## SECURITY.md File
+A security contact is the designated path for external researchers (and users) to report vulnerabilities. Without it,
+findings route through public issues, social media, or nowhere—raising exploit risk and burning researcher trust.
 
-### Importance
+## SECURITY.md
 
-A SECURITY.md file in your GitHub repository provides clear instructions on how to report security vulnerabilities.
+### Why it matters
 
-### Example Content
+A `SECURITY.md` file in a GitHub repository tells reporters how to submit vulnerabilities and what to expect next.
 
-```
+### Example content
+
+```text
 # Security Policy
 
 We take the security of our project seriously. If you discover any security vulnerabilities, please report them
@@ -36,29 +47,28 @@ Please email us at security@projectname.TLD with the details of the vulnerabilit
 We appreciate your help in improving the security of our project.
 ```
 
-## Security Email Address
+## Security email address
 
-### Importance
+### Why it matters
 
-Having a dedicated security email address (e.g., [security@projectname.TLD](mailto:security@projectname.TLD))
-ensures that vulnerability reports are directed to the appropriate team members.
+A dedicated address (for example `security@projectname.TLD`) routes reports to people who can act, instead of a shared
+inbox no one owns.
 
 ### Setup
 
-- Dedicated Team: Ensure that the security email is monitored by a team with the expertise to handle vulnerability
-reports.
-- Prompt Responses: Aim to acknowledge receipt of vulnerability reports within 24 hours.
+- **Dedicated team:** ensure the mailbox is monitored by people who can triage vulnerability reports.
+- **Prompt responses:** acknowledge receipt quickly (teams often target within 24 hours).
 
 ## .well-known/security.txt
 
-### Importance
+### Why it matters
 
-The .well-known/[security.txt](https://securitytxt.org/) file is a standardized way to provide security contact
-information on your website.
+The [security.txt](https://securitytxt.org/) file is a standard web path for publishing security contact and policy
+metadata.
 
-### Example Content
+### Example content
 
-```
+```text
 Contact: mailto:security@projectname.TLD
 Encryption: https://projectname.TLD/pgp-key.txt
 Acknowledgements: https://projectname.TLD/hall-of-fame.html
@@ -68,24 +78,29 @@ Preferred-Languages: en
 
 ### Implementation
 
-- Standard Location: Place the security.txt file in the .well-known directory of your website (e.g.,
-[https://projectname.TLD/.well-known/security.txt](https://projectname.TLD/.well-known/security.txt)).
-- Regular Updates: Keep the security.txt file updated with current contact information and policies.
+- **Standard location:** serve the file at `https://projectname.TLD/.well-known/security.txt`.
+- **Regular updates:** keep contact information and policy URLs current.
 
-## Managing Security Contacts
+## Managing security contacts
 
 ### Responsibilities
 
-- Triage: Assess and prioritize vulnerability reports based on severity and impact.
-- Communication: Maintain clear and respectful communication with reporters. Provide regular updates on the status of
-their reports.
-- Resolution: Work promptly to resolve reported vulnerabilities and update the reporter on the actions taken.
+- **Triage:** assess and prioritize reports by severity and impact.
+- **Communication:** stay clear and respectful with reporters; give regular status updates.
+- **Resolution:** remediate promptly and tell the reporter what changed.
 
-## Best Practices
+## Best practices
 
-- Confidentiality: Treat all vulnerability reports as confidential until a fix is implemented.
-- Acknowledgement: Consider publicly acknowledging researchers who report vulnerabilities, with their permission.
-- Transparency: Be transparent about your vulnerability disclosure process and timelines.
+- **Confidentiality:** treat reports as confidential until a fix is in place (unless a coordinated public path or
+  [Safe Harbor](/safe-harbor/overview) scenario requires faster warning).
+- **Acknowledgement:** consider public credit for researchers who want it, only with their permission.
+- **Transparency:** publish disclosure process and expected timelines so reporters know the rules.
+
+## Further Reading & Tools
+
+- [security.txt](https://securitytxt.org/)
+- [GitHub: Add a security policy](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository)
+- [RFC 9116 — security.txt](https://www.rfc-editor.org/rfc/rfc9116.html)
 
 ---
 

--- a/docs/pages/vulnerability-disclosure/security-contact.mdx
+++ b/docs/pages/vulnerability-disclosure/security-contact.mdx
@@ -6,7 +6,7 @@ tags:
   - Security Specialist
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked


### PR DESCRIPTION
## Scope

Normalize the **Vulnerability Disclosure** framework (`docs/pages/vulnerability-disclosure/`) to the content model.

## Why

Structure as of `develop` lacked Key Takeaways, contributors frontmatter, overview page map, Related frameworks, and Further reading. Prose needed light editorial cleanup (clarity only).

## Content model applied

- Framework overview + conceptual pages
- Canonical Key Takeaway form
- Shared page chrome (TagList, AttributionList, ContributeFooter)
- Frontmatter contract
- Overview page map synced to sidebar children

## Changes

- `overview.mdx`: KT, basics, page map, related frameworks, further reading, contributors
- `security-contact.mdx`: KT, clearer sectioning, further reading, contributors
- `bug-bounties.mdx`: KT, platform notes softened as market-time (no new controls), further reading, contributors

## Substantive security changes

**None.** Editorial/structural only. Existing platform names and practices retained; vendor claims labeled as vendor-described where relevant.

## Intentionally unchanged

- Sidebar entries already present (`dev: true`)
- Generated `index.mdx`
- No Safe Harbor legal text changes (cross-link only)

## Validation

- [x] cspell on touched paths — clean
- [x] markdownlint-cli2 on touched paths — clean
- [ ] full `docs:build` (not re-run this PR; structural MDX only)
- [x] no generated files hand-edited
- [x] commit signed

## Dependencies

Depends on content standards in **#561** (unmerged). Apply #561 rules by reference; this PR does not copy standards files.

## Reviewer focus

- Disclosure/Safe Harbor vs bounty boundary wording stays accurate
- External links (ISO overview, FIRST, security.txt, GitHub docs) acceptable
- No invented legal or bounty-policy requirements