### PR TITLE
docs(security-automation): normalize structure and wording

### DIFF
--- a/docs/pages/security-automation/compliance-checks.mdx
+++ b/docs/pages/security-automation/compliance-checks.mdx
@@ -72,7 +72,7 @@ Product names and capabilities change; verify current features before adoption.
    is not yet practical.
 4. Review exception lists on a fixed cadence—permanent mute rules recreate drift under a new name.
 
-## Further Reading
+## Further reading
 
 - [AWS Config](https://docs.aws.amazon.com/config/)
 - [Azure Policy](https://learn.microsoft.com/en-us/azure/governance/policy/)

--- a/docs/pages/security-automation/compliance-checks.mdx
+++ b/docs/pages/security-automation/compliance-checks.mdx
@@ -72,7 +72,7 @@ Product names and capabilities change; verify current features before adoption.
    is not yet practical.
 4. Review exception lists on a fixed cadence—permanent mute rules recreate drift under a new name.
 
-## Further Reading & Tools
+## Further Reading
 
 - [AWS Config](https://docs.aws.amazon.com/config/)
 - [Azure Policy](https://learn.microsoft.com/en-us/azure/governance/policy/)

--- a/docs/pages/security-automation/compliance-checks.mdx
+++ b/docs/pages/security-automation/compliance-checks.mdx
@@ -9,7 +9,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/security-automation/compliance-checks.mdx
+++ b/docs/pages/security-automation/compliance-checks.mdx
@@ -1,12 +1,19 @@
 ---
-title: "Automated Compliance Checks | Security Alliance"
-description: "Automate compliance monitoring with AWS Config, Azure Policy, HashiCorp Sentinel, and OpenSCAP. Ensure continuous adherence to security policies and reduce non-compliance risks from configuration drift."
+title: "Automated Compliance Checks | SEAL"
+description: "Automate compliance monitoring with AWS Config, Azure Policy, HashiCorp Sentinel, and OpenSCAP to catch drift and enforce security policies continuously."
 tags:
   - Engineer/Developer
   - Security Specialist
   - DevOps
   - Cloud
   - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -16,53 +23,62 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Automating compliance checks helps projects ensure that they adhere to security policies, standards, and potential
-regulatory requirements consistently. Automated compliance tools can continuously monitor, assess, and report on the
-compliance status of systems and applications.
+> 🔑 **Key Takeaway**: Automated compliance checks catch configuration drift against written policy. They do not replace
+> choosing the right policies or remediating failures.
 
-## Benefits of Automated Compliance Checks
+Automating compliance checks helps projects measure adherence to security policies, internal standards, and (where
+applicable) regulatory expectations. Tools continuously monitor, assess, and report status so teams see drift before
+audit season—or before an attacker finds the open path.
 
-1. **Continuous Monitoring**
-   - Automated tools provide continuous monitoring of systems to ensure ongoing compliance.
-   - Reduces the risk of non-compliance due to configuration drift or changes.
+## Benefits
 
+1. **Continuous monitoring**
+   - Ongoing evaluation instead of point-in-time screenshots.
+   - Lower risk of silent drift after manual changes.
 2. **Efficiency**
-   - Automates repetitive compliance tasks, freeing up security teams to focus on more strategic activities.
-   - Speeds up the compliance assessment process.
+   - Repetitive assessment work moves off overloaded security staff.
+   - Faster feedback in delivery pipelines.
+3. **Consistency**
+   - Repeatable checks reduce human scoring variance.
 
-3. **Accuracy**
-   - Reduces human error in compliance assessments.
-   - Provides consistent and repeatable compliance checks.
+## Tools
 
-## Tools for Automated Compliance Checks
+Product names and capabilities change; verify current features before adoption.
 
 1. **AWS Config**
-   - A service that continuously monitors and records AWS resource configurations and allows automated compliance checks
-   based on predefined rules.
-   - Pros: Deep integration with AWS services, customizable rules.
-   - Cons: Limited to AWS environments.
-
+   - Continuously records AWS resource configuration and evaluates predefined or custom rules.
+   - Pros: deep AWS integration, customizable rules.
+   - Cons: AWS-oriented; multi-cloud still needs other coverage.
 2. **Azure Policy**
-   - A service that enables the creation, assignment, and management of policies to enforce organizational standards and
-   assess compliance at scale.
-   - Pros: Integrated with Azure services, supports custom policies.
-   - Cons: Limited to Azure environments.
-
+   - Define, assign, and manage policies to enforce standards and report compliance at scale.
+   - Pros: integrated with Azure; custom policies supported.
+   - Cons: Azure-oriented.
 3. **HashiCorp Sentinel**
-   - A policy-as-code framework for defining and enforcing policies across infrastructure as code and cloud
-   environments.
-   - Pros: Flexible and extensible, integrates with Terraform and other HashiCorp tools.
-   - Cons: Requires knowledge of policy language.
-
+   - Policy-as-code across HashiCorp tooling and IaC workflows.
+   - Pros: flexible; strong Terraform connection for many teams.
+   - Cons: requires policy-language expertise.
 4. **OpenSCAP**
-   - An open-source tool for implementing and enforcing security policies and compliance checks.
-   - Pros: Supports various compliance frameworks (e.g., NIST, CIS), open-source.
-   - Cons: Requires configuration and management.
+   - Open-source evaluation against security content (for example CIS- and NIST-oriented benchmarks, depending on
+     content packs).
+   - Pros: open-source; multiple content frameworks.
+   - Cons: must be operated and kept content-current.
 
-## Best Practices
+## Best practices
 
-1. Integrate compliance checks into the CI/CD pipeline to ensure that code changes and deployments comply with security
-policies.
+1. Integrate compliance evaluation into the CI/CD path so code and infrastructure changes fail closed (or clearly raise
+   exceptions) when they violate must-fix policy.
+2. Map automated rules to documented controls so failures name an owner and a remediation path.
+3. Prefer preventative policy (deny/deploy-time) for high-impact misconfigurations; use detective checks where prevention
+   is not yet practical.
+4. Review exception lists on a fixed cadence—permanent mute rules recreate drift under a new name.
+
+## Further Reading & Tools
+
+- [AWS Config](https://docs.aws.amazon.com/config/)
+- [Azure Policy](https://learn.microsoft.com/en-us/azure/governance/policy/)
+- [HashiCorp Sentinel](https://developer.hashicorp.com/sentinel)
+- [OpenSCAP](https://www.open-scap.org/)
+- [CIS Benchmarks](https://www.cisecurity.org/cis-benchmarks)
 
 ---
 

--- a/docs/pages/security-automation/infrastructure-as-code.mdx
+++ b/docs/pages/security-automation/infrastructure-as-code.mdx
@@ -1,12 +1,19 @@
 ---
 title: "Infrastructure as Code Security | SEAL"
-description: "Secure your Infrastructure as Code (IaC) with Terraform, AWS CloudFormation, and Ansible. Integrate security scans using Checkov, tfsec, and Terrascan to prevent misconfigurations."
+description: "Secure Infrastructure as Code (IaC) with trusted modules, least privilege, encryption, and scanners such as Checkov, tfsec, and Terrascan in the delivery pipeline."
 tags:
   - Engineer/Developer
   - Security Specialist
   - DevOps
   - Cloud
   - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -16,63 +23,60 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Infrastructure as Code (IaC) is the management and provisioning of computing infrastructure through machine-readable
-definition files, rather than manual configuration or interactive configuration tools. Automating security within IaC
-helps ensure that infrastructure is configured securely and consistently.
+> 🔑 **Key Takeaway**: Treat infrastructure definitions as production code—review them, scan them, and apply least
+> privilege—because a bad template can recreate a bad estate at scale.
 
-## Benefits of Automating Security in IaC
+Infrastructure as Code (IaC) provisions and manages infrastructure from machine-readable definitions instead of
+one-off console clicks. Automating security around IaC helps environments stay consistent and reduces recurring
+misconfigurations.
+
+## Benefits of securing IaC
 
 1. **Consistency**
-   - Ensures that infrastructure is provisioned and configured consistently across environments.
-   - Reduces the risk of configuration drift and security misconfigurations.
-
+   - Same definitions across environments reduce snowflake risks.
+   - Lower chance of silent manual drift (when humans stop “fixing prod by hand”).
 2. **Scalability**
-   - Enables scalable deployment of secure infrastructure.
-   - Simplifies management of large-scale environments.
+   - Secure patterns encode once and deploy many times.
+3. **Version control**
+   - History, code review, and rollback become available for infrastructure changes.
 
-3. **Version Control**
-   - Treats infrastructure configurations as code, allowing version control and change tracking.
-   - Facilitates rollback to previous configurations if issues arise.
+## Practices
 
-## Best Practices for Secure IaC
+1. **Use trusted modules**
+   - Prefer verified modules or templates.
+   - Avoid unverified or abandoned modules that may ship weak defaults.
+2. **Implement least privilege**
+   - Grant infrastructure components only required permissions.
+   - Use role-based access control (RBAC) and short-lived credentials where possible (see [IAM](/iam/overview)).
+3. **Automate security scans**
+   - Integrate scanners into the IaC pipeline.
+   - Common Terraform-oriented options cited by practitioners include Checkov, tfsec, and Terrascan—evaluate current
+     fit for the stack.
+4. **Encrypt sensitive data**
+   - Encrypt sensitive data at rest and in transit as the platform allows.
+   - Prefer managed key services over bespoke secret sprawl (see [Encryption](/encryption/overview)).
+5. **Keep templates current**
+   - Update modules and base images or AMIs as vendors fix issues.
+   - Re-review high-risk stacks when threat models change.
 
-1. **Use Trusted Modules**
-   - Use trusted and verified modules or templates for infrastructure provisioning.
-   - Avoid using unverified or outdated modules that may contain vulnerabilities.
+## Tools and platforms
 
-2. **Implement Least Privilege**
-   - Ensure that infrastructure components have the minimum necessary permissions.
-   - Use role-based access control (RBAC) to manage permissions.
+Capability matrix changes frequently; treat this as a starting catalog.
 
-3. **Automate Security Scans**
-   - Integrate security scanning tools into the IaC pipeline to automatically detect and remediate vulnerabilities.
-   - Use tools like Checkov, tfsec, and Terrascan to scan Terraform configurations for security issues.
+1. **Terraform** — multi-cloud IaC with a large module ecosystem; commonly paired with policy and scan tools.
+2. **AWS CloudFormation** — native AWS IaC; pairs with AWS Config-style compliance evaluation.
+3. **Azure Resource Manager (ARM) / Bicep templates** — Azure native IaC; pairs with Azure Policy.
+4. **Ansible** — configuration management and deployment automation; use hardened roles and avoid shipping secrets in
+   plain playbooks.
 
-4. **Encrypt Sensitive Data**
-   - Encrypt sensitive data at rest and in transit within the infrastructure.
-   - Use managed encryption services provided by cloud providers.
+## Further Reading & Tools
 
-5. **Regularly Update IaC Templates**
-   - Keep IaC templates and modules up to date with the latest security patches and best practices.
-   - Regularly review and update configurations to address new security threats.
-
-## Tools for Automating Security in IaC
-
-1. **Terraform**
-   - A widely used IaC tool that allows for the automated provisioning of infrastructure across various cloud providers.
-   - Supports integration with security scanning tools like tfsec and Checkov.
-
-2. **AWS CloudFormation**
-   - An IaC service provided by AWS for modeling and setting up AWS resources.
-   - Supports AWS Config rules for automated compliance checks.
-
-3. **Azure Resource Manager (ARM) Templates**
-   - IaC templates for deploying and managing Azure resources.
-   - Integrates with Azure Policy for enforcing security policies.
-
-4. **Ansible**
-   - An open-source automation tool for configuration management and application deployment.
-   - Supports security roles and playbooks for automating security configurations.
+- [Checkov](https://www.checkov.io/)
+- [tfsec](https://aquasecurity.github.io/tfsec/)
+- [Terrascan](https://runterrascan.io/)
+- [OWASP Infrastructure as Code Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Infrastructure_as_Code_Security_Cheat_Sheet.html)
+  (if maintained for your version, verify content currency)
+- Project [DevSecOps](/devsecops/overview)
 
 ---
 

--- a/docs/pages/security-automation/infrastructure-as-code.mdx
+++ b/docs/pages/security-automation/infrastructure-as-code.mdx
@@ -69,13 +69,13 @@ Capability matrix changes frequently; treat this as a starting catalog.
 4. **Ansible** — configuration management and deployment automation; use hardened roles and avoid shipping secrets in
    plain playbooks.
 
-## Further Reading
+## Further reading
 
 - [Checkov](https://www.checkov.io/)
 - [tfsec](https://aquasecurity.github.io/tfsec/)
 - [Terrascan](https://runterrascan.io/)
 - [OWASP Infrastructure as Code Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Infrastructure_as_Code_Security_Cheat_Sheet.html)
-  (if maintained for your version, verify content currency)
+  (if maintained for the target version, verify content currency)
 - Project [DevSecOps](/devsecops/overview)
 
 ---

--- a/docs/pages/security-automation/infrastructure-as-code.mdx
+++ b/docs/pages/security-automation/infrastructure-as-code.mdx
@@ -9,7 +9,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/security-automation/infrastructure-as-code.mdx
+++ b/docs/pages/security-automation/infrastructure-as-code.mdx
@@ -69,7 +69,7 @@ Capability matrix changes frequently; treat this as a starting catalog.
 4. **Ansible** — configuration management and deployment automation; use hardened roles and avoid shipping secrets in
    plain playbooks.
 
-## Further Reading & Tools
+## Further Reading
 
 - [Checkov](https://www.checkov.io/)
 - [tfsec](https://aquasecurity.github.io/tfsec/)

--- a/docs/pages/security-automation/overview.mdx
+++ b/docs/pages/security-automation/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Security Automation | Security Alliance"
-description: "Security automation for Web3 teams: compliance checks, infrastructure-as-code scanning, and threat detection workflows that cut repetitive risk and speed response."
+description: "Security automation for Web3 teams: compliance checks, infrastructure-as-code scanning, and threat detection workflows that cut repetitive risk and speed"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/security-automation/overview.mdx
+++ b/docs/pages/security-automation/overview.mdx
@@ -1,12 +1,19 @@
 ---
 title: "Security Automation | Security Alliance"
-description: "Security Automation Framework: Automate compliance checks, IaC security scans, and threat detection. Reduce human error and respond to threats faster."
+description: "Security automation for Web3 teams: compliance checks, infrastructure-as-code scanning, and threat detection workflows that cut repetitive risk and speed response."
 tags:
   - Engineer/Developer
   - Security Specialist
   - DevOps
   - Cloud
   - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -16,10 +23,47 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Security automation involves using technology to perform security tasks with minimal human intervention. By automating
-repetitive and complex security processes, teams can improve efficiency, reduce the risk of human error, and respond to
-threats more quickly. This section covers best practices and tools for automating various aspects of security, including
-compliance checks, infrastructure as code, and threat detection and response.
+> 🔑 **Key Takeaway**: Automate security work that is repetitive, measurable, and easy to get wrong by hand—then keep a
+> human owner for triage, exceptions, and response.
+
+Security automation uses tooling to run security tasks with minimal manual steps. Done well, it improves consistency,
+reduces configuration drift and other human error, and shortens time from detection to action. Done poorly, it floods
+teams with unowned alerts or encodes wrong policies.
+
+This framework covers three common automation surfaces: continuous compliance evaluation, secure infrastructure as
+code (IaC), and detection-and-response automation that feeds human process.
+
+## Basics
+
+- **Automate the check, not placeholder judgment.** Policy engines and scanners excel at known configurations, not at
+  deciding business risk without an owner.
+- **Wire into delivery.** Checks that run only on a yearly spreadsheet do not prevent drift; prefer pipeline and
+  continuous control-plane evaluation.
+- **Link to response.** Detection without [incident management](/incident-management/overview) runbooks is noise.
+
+## What this framework covers
+
+1. [Threat Detection and Response](/security-automation/threat-detection-response): continuous monitoring, SIEM-style
+   aggregation, and a sample detection-to-recovery flow.
+2. [Compliance Checks](/security-automation/compliance-checks): automated policy evaluation (cloud and open-source
+   options) and pipeline integration.
+3. [Infrastructure as Code](/security-automation/infrastructure-as-code): secure IaC practices and common scanners or
+   platforms.
+
+## Related frameworks
+
+- [DevSecOps](/devsecops/overview): CI/CD security automation and pipeline controls
+- [Monitoring](/monitoring/overview): on-chain monitoring complementary to off-chain detection
+- [Incident Management](/incident-management/overview): human response when automation fires
+- [Infrastructure](/infrastructure/overview): platform baseline security
+- [IAM](/iam/overview): identity controls that automation often encodes as policy
+
+## Further Reading & Tools
+
+- [OWASP DevSecOps Guideline](https://owasp.org/www-project-devsecops-guideline/)
+- [CIS Benchmarks](https://www.cisecurity.org/cis-benchmarks)
+- [NIST SP 800-53 control catalog](https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final) (for mapping automated
+  checks to controls)
 
 ---
 

--- a/docs/pages/security-automation/overview.mdx
+++ b/docs/pages/security-automation/overview.mdx
@@ -9,7 +9,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/security-automation/overview.mdx
+++ b/docs/pages/security-automation/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Security Automation | Security Alliance"
-description: "Security automation for Web3 teams: compliance checks, infrastructure-as-code scanning, and threat detection workflows that cut repetitive risk and speed"
+description: "Security automation for Web3 teams: compliance checks, infrastructure-as-code scanning, and threat detection workflows that cut repetitive risk and speed response."
 tags:
   - Engineer/Developer
   - Security Specialist
@@ -58,7 +58,7 @@ code (IaC), and detection-and-response automation that feeds human process.
 - [Infrastructure](/infrastructure/overview): platform baseline security
 - [IAM](/iam/overview): identity controls that automation often encodes as policy
 
-## Further Reading
+## Further reading
 
 - [OWASP DevSecOps Guideline](https://owasp.org/www-project-devsecops-guideline/)
 - [CIS Benchmarks](https://www.cisecurity.org/cis-benchmarks)

--- a/docs/pages/security-automation/overview.mdx
+++ b/docs/pages/security-automation/overview.mdx
@@ -58,7 +58,7 @@ code (IaC), and detection-and-response automation that feeds human process.
 - [Infrastructure](/infrastructure/overview): platform baseline security
 - [IAM](/iam/overview): identity controls that automation often encodes as policy
 
-## Further Reading & Tools
+## Further Reading
 
 - [OWASP DevSecOps Guideline](https://owasp.org/www-project-devsecops-guideline/)
 - [CIS Benchmarks](https://www.cisecurity.org/cis-benchmarks)

--- a/docs/pages/security-automation/threat-detection-response.mdx
+++ b/docs/pages/security-automation/threat-detection-response.mdx
@@ -64,7 +64,7 @@ compromise; it may also be travel, VPN use, or a false positive. Automation shou
 5. **Recovery:** restore affected systems, apply missing patches or config fixes, and re-enable access deliberately.
 6. **Lessons learned:** run a post-incident review; fix detection gaps and runbook holes.
 
-## Further Reading & Tools
+## Further Reading
 
 - [NIST SP 800-61 Rev. 2 — Computer Security Incident Handling Guide](https://csrc.nist.gov/publications/detail/sp/800-61/rev-2/final)
 - [MITRE ATT&CK](https://attack.mitre.org/)

--- a/docs/pages/security-automation/threat-detection-response.mdx
+++ b/docs/pages/security-automation/threat-detection-response.mdx
@@ -64,7 +64,7 @@ compromise; it may also be travel, VPN use, or a false positive. Automation shou
 5. **Recovery:** restore affected systems, apply missing patches or config fixes, and re-enable access deliberately.
 6. **Lessons learned:** run a post-incident review; fix detection gaps and runbook holes.
 
-## Further Reading
+## Further reading
 
 - [NIST SP 800-61 Rev. 2 — Computer Security Incident Handling Guide](https://csrc.nist.gov/publications/detail/sp/800-61/rev-2/final)
 - [MITRE ATT&CK](https://attack.mitre.org/)

--- a/docs/pages/security-automation/threat-detection-response.mdx
+++ b/docs/pages/security-automation/threat-detection-response.mdx
@@ -1,11 +1,18 @@
 ---
-title: "Threat Detection & Response | SEAL"
-description: "Implement continuous threat detection and response using SIEM systems. Detect suspicious activity, establish response protocols, and follow the detection-analysis-containment-recovery process."
+title: "Threat Detection and Response | SEAL"
+description: "Automate continuous threat detection and response with SIEM-style monitoring, clear protocols, threat intelligence inputs, and a detection-to-recovery process."
 tags:
   - Engineer/Developer
   - Security Specialist
   - DevOps
   - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -15,50 +22,53 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Threat detection and response is a critical aspect of maintaining the security of your project. It involves identifying
-potential threats, monitoring for signs of malicious activity, and responding effectively to mitigate any identified
-risks. By implementing robust threat detection and response strategies, you can protect your project from security
-breaches and minimize the impact of any incidents that do occur.
+> 🔑 **Key Takeaway**: Detection automation only reduces risk when every meaningful alert has an owner, a playbook, and
+> a path into containment and recovery.
 
-## Guidelines for Threat Detection and Response
+Threat detection and response means finding malicious or abusive activity early enough to limit impact. Automation helps
+ingest signals, correlate events, and page humans; people still analyze ambiguous cases and execute containment.
 
-1. **Implement Continuous Monitoring**: Use automated tools to continuously monitor your systems for signs of suspicious
-activity. This can help you detect threats early and respond quickly.
-2. **Establish Clear Response Protocols**: Develop and document clear protocols for responding to different types of
-security incidents. Ensure that all team members are familiar with these protocols and know their roles in the response
-process.
-3. **Conduct Regular Threat Assessments**: Regularly assess your systems for potential vulnerabilities and update your
-threat detection and response strategies accordingly.
-4. **Use Threat Intelligence**: Leverage threat intelligence sources to stay informed about the latest threats and
-trends in the security landscape. This can help you anticipate and prepare for new types of attacks.
-5. **Train Your Team**: Provide regular training for your team on threat detection and response best practices. This can
-help ensure that everyone is prepared to act quickly and effectively in the event of a security incident.
+Keep Web3 on-chain detection in [Monitoring](/monitoring/overview); use this page for broader systems, identity, and
+network telemetry habits.
 
-## Example Best Practice
+## Guidelines
 
-One effective approach to threat detection and response is to use a Security Information and Event Management (SIEM)
-system. A SIEM system collects and analyzes data from various sources within your network, helping you to identify and
-respond to potential threats in real-time. By integrating a SIEM system into your security strategy, you can improve
-your ability to detect and respond to threats, ultimately enhancing the overall security of your project.
+1. **Implement continuous monitoring.** Use automated tooling to watch for suspicious activity so teams can detect and
+   act while cost of failure is still contained.
+2. **Establish clear response protocols.** Document how different incident types are handled. Every team member in the
+   on-call path must know their role (see [Incident Management](/incident-management/overview)).
+3. **Conduct regular threat assessments.** Revisit detection coverage as systems and threat models change.
+4. **Use threat intelligence.** Consume reputable feeds and community signals so detection content stays current—without
+   treating unverified IOCs as ground truth.
+5. **Train the team.** Practice detection and response so people execute under time pressure.
 
-## Incident Example
+## SIEM-style practice
 
-Imagine that your SIEM system detects unusual login activity from an IP address located in a different country than your
-usual operations. This could be an indication of a potential security breach.
+A security information and event management (SIEM) system (or equivalent telemetry platform) collects and analyzes logs
+from many sources so operators can pick out real threats from noise. Integrating SIEM-class analytics into the security
+program improves detection quality when use cases and parsing are maintained—not when the tool is installed and left
+idle.
 
-## Sample Process
+## Illustrative scenario
 
-1. **Detection**: The SIEM system flags the unusual login activity and generates an alert.
-2. **Analysis**: A security analyst reviews the alert and examines the login activity to determine if it is indeed
-suspicious.
-3. **Containment**: If the activity is confirmed to be malicious, the analyst takes steps to contain the threat, such as
-blocking the IP address and disabling the compromised account.
-4. **Eradication**: The analyst investigates the extent of the breach and removes any malicious software or unauthorized
-access points.
-5. **Recovery**: The affected systems are restored to normal operation, and any necessary security patches or updates
-are applied.
-6. **Lessons Learned**: A post-incident review is conducted to identify any gaps in the threat detection and response
-process and to implement improvements for future incidents.
+A SIEM flags unusual login activity from an IP geography far from normal operations. That signal may indicate account
+compromise; it may also be travel, VPN use, or a false positive. Automation should raise the alert; humans decide.
+
+## Sample process
+
+1. **Detection:** the platform flags the unusual login and generates an alert.
+2. **Analysis:** an analyst reviews context (user, MFA, device, history) to decide if the activity is malicious.
+3. **Containment:** if confirmed malicious, block or challenge the source, disable or reset the account, and limit blast
+   radius.
+4. **Eradication:** remove persistence, unauthorized access paths, or malware if present.
+5. **Recovery:** restore affected systems, apply missing patches or config fixes, and re-enable access deliberately.
+6. **Lessons learned:** run a post-incident review; fix detection gaps and runbook holes.
+
+## Further Reading & Tools
+
+- [NIST SP 800-61 Rev. 2 — Computer Security Incident Handling Guide](https://csrc.nist.gov/publications/detail/sp/800-61/rev-2/final)
+- [MITRE ATT&CK](https://attack.mitre.org/)
+- Project [Incident Management](/incident-management/overview) playbooks
 
 ---
 

--- a/docs/pages/security-automation/threat-detection-response.mdx
+++ b/docs/pages/security-automation/threat-detection-response.mdx
@@ -8,7 +8,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked


### PR DESCRIPTION
## Scope

Normalize the **Security Automation** framework (`docs/pages/security-automation/`).

## Why

Missing Key Takeaways, contributors, overview page map, related frameworks, and Further reading. Prose was generic and benefit-heavy without routing readers to child pages.

## Content model applied

Framework overview + procedure/reference hybrid child pages; canonical KT; shared chrome; overview map synced to sidebar.

## Changes

- overview, threat-detection-response, compliance-checks, infrastructure-as-code

## Substantive security changes

**None.** Editorial/structural only. Existing tool names retained; product claims framed as verify-before-adopt.

## Intentionally unchanged

- Sidebar (`dev: true` entries)
- Generated `index.mdx`

## Validation

- [x] cspell — clean
- [x] markdownlint-cli2 — clean
- [x] commit signed
- [x] no generated hand-edits

## Dependencies

**#561** (unmerged) by reference.

## Reviewer focus

- Boundary vs Monitoring (on-chain) and Incident Management
- Tool catalog not oversold as must-use products