### PR TITLE
docs(community-management): normalize structure and wording

### DIFF
--- a/docs/pages/community-management/discord.mdx
+++ b/docs/pages/community-management/discord.mdx
@@ -86,7 +86,7 @@ The guide is structured by privilege level—start with the matching role.
 
 For step-by-step procedures, see the [Discord Security Guide](/guides/account-management/discord).
 
-## Further Reading & Tools
+## Further Reading
 
 - [Discord Security Guide](/guides/account-management/discord)
 - [Discord Safety Center](https://discord.com/safety)

--- a/docs/pages/community-management/discord.mdx
+++ b/docs/pages/community-management/discord.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Discord Security | Security Alliance"
-description: "Secure your Discord server against raids and phishing with 2FA for moderation, Raid Protection, Auto-Moderation Rules, Cold Admin Accounts, and anti-impersonation bots like Wick."
+description: "Secure Discord servers against raids and phishing: managed MFA for mods, raid protection, AutoMod, Cold Admin accounts, bot least privilege, and anti-impersonation."
 tags:
   - Community & Marketing
   - Security Specialist
@@ -20,64 +20,76 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Discord server security spans account hygiene, role architecture, server hardening, and bot management — each covered in depth in the [Discord Security Guide](/guides/account-management/discord). Use this page to find the right section.
+> 🔑 **Key Takeaway**: Discord trust is centralized in operator and bot permissions. Harden accounts and roles before a
+> compromise turns the server into a broadcast phishing channel.
 
----
+Discord server security spans account hygiene, role architecture, server hardening, and bot management—each covered in
+depth in the [Discord Security Guide](/guides/account-management/discord). Use this page to find the right section.
 
 ## The community manager's role in security
 
-A community manager is the primary public-facing operator of a project's Discord server. They control who gets access, which bots run, what permissions roles carry, and how the server responds when something goes wrong. In a Web3 context, that responsibility is significant: your server is often the first place users go to ask questions, verify information, and form their opinion of your project's legitimacy.
+A community manager is the primary public-facing operator of a project's Discord server. They control who gets access,
+which bots run, what permissions roles carry, and how the server responds when something goes wrong. In a Web3 context,
+that responsibility is significant: the server is often the first place users go to ask questions, verify information,
+and form their opinion of project legitimacy.
 
-That visibility is also what makes the community manager one of the most targeted roles in the organization. Attackers specifically pursue community manager accounts because a compromised account grants immediate access to a trusted, high-reach communication channel. A bad actor who takes control of your Discord can post malicious links to your entire community, impersonate your team to drain wallets, lock out your administrators, and permanently damage user trust, often within minutes.
+That visibility is also what makes the community manager one of the most targeted roles in the organization. Attackers
+pursue community manager accounts because compromise grants immediate access to a trusted, high-reach channel. A bad
+actor who takes control can post malicious links, impersonate the team, lock out administrators, and damage trust—often
+within minutes.
 
 ### Why following this guide is not optional
 
-Most Discord compromises do not happen because of sophisticated zero-day exploits. They happen because of predictable, preventable failures: reused passwords, SMS-based 2FA, over-permissioned bots, and admin accounts used for everyday activity. The controls in this guide exist specifically because these attack patterns repeat across projects at scale.
+Most Discord compromises do not require advanced exploits. They follow predictable failures: reused passwords, SMS-based
+multi-factor authentication (MFA), over-permissioned bots, and admin accounts used for everyday activity. The controls
+in the linked guide exist because these patterns repeat across projects.
 
-As a community manager, you are a custodian of user trust. Members follow links you post, believe announcements you make, and act on guidance your account sends. That trust is the attack surface. Hardening your account and your server configuration is not a technical exercise; it is a direct obligation to the people in your community.
+As a community manager, operators are custodians of user trust. Members follow posted links, believe announcements, and
+act on guidance from trusted accounts. That trust is the attack surface. Hardening accounts and server configuration is
+a direct obligation to the community.
 
-### What's at stake if you don't
+### What is at stake
 
 | Risk | Consequence |
-|---|---|
-| **Account takeover** | Attacker posts phishing links to your entire member base from a trusted account |
-| **Admin privilege abuse** | Compromised admin role used to add malicious bots, wipe channels, or ban legitimate team members |
-| **Bot or webhook hijack** | Automated announcements replaced with scam content; hard to detect and revoke quickly |
-| **Impersonation** | Lookalike accounts exploit gaps in anti-impersonation rules to social-engineer users at scale |
-| **Raid or coordinated attack** | Unprotected servers can be flooded with spam or illegal content, triggering platform action against your server |
-| **Reputational damage** | Even brief compromise events are publicly visible, screenshot, and shared; recovery of community trust is slow |
+| --- | --- |
+| **Account takeover** | Attacker posts phishing links to the full member base from a trusted account |
+| **Admin privilege abuse** | Compromised admin role used to add malicious bots, wipe channels, or ban team |
+| **Bot or webhook hijack** | Automated announcements replaced with scam content; slow to detect and revoke |
+| **Impersonation** | Lookalike accounts exploit gaps in anti-impersonation rules at scale |
+| **Raid or coordinated attack** | Unprotected servers flooded with spam or illegal content; platform risk |
+| **Reputational damage** | Brief compromise events are captured publicly; trust recovery is slow |
 
-The controls in this guide address each of these directly. None of them require advanced technical skills. All of them take significantly less time to implement than a compromise takes to recover from.
-
----
+The linked guide addresses these risks with controls that do not require advanced technical skills and take less time
+than compromise recovery.
 
 ## What the guide covers
 
-The guide is structured by privilege level, so find your role and start there.
+The guide is structured by privilege level—start with the matching role.
 
 | Audience | What it covers |
-|---|---|
+| --- | --- |
 | **All team members** | DM spam filtering, authorized app review, connected device audit |
-| **Moderators** | Reading your role permissions, understanding AutoMod rule scope |
+| **Moderators** | Reading role permissions, understanding AutoMod rule scope |
 | **Administrators** | Role architecture, Cold Admin setup, verification levels, raid protection, bot vetting, anti-impersonation, integration security |
-
----
 
 ## Topic index
 
 | Topic | Summary | Guide section |
-|---|---|---|
-| **Role permissions** | Restrict Administrator, Manage Webhooks, Manage Server, Manage Roles, and Manage Channels to the minimum required roles | [Role permissions →](/guides/account-management/discord#roles) |
-| **Cold Admin account** | A dedicated owner account on a factory-reset device, used only for major changes and incident recovery | [Cold Admin →](/guides/account-management/discord#cold-admin-setup) |
-| **Verification level** | Set to at least Medium (5+ minutes on Discord) — Moderate recommended for public servers | [Verification →](/guides/account-management/discord#member-screening-setup) |
-| **Raid protection** | ML-based join-raid detection with auto-lockdown and CAPTCHA for new users | [Raid protection →](/guides/account-management/discord#safety-setup) |
-| **AutoMod rules** | Block spam, harmful links, mention spam, and impersonation keywords in usernames | [AutoMod →](/guides/account-management/discord#automod) |
-| **Anti-impersonation** | Custom rules blocking lookalike usernames and profile pictures; bots like Wick | [Anti-impersonation →](/guides/account-management/discord#anti-impersonation-bots) |
-| **Bot & integration security** | Apply least privilege to bots; restrict command permissions; audit webhooks | [Integrations →](/guides/account-management/discord#additional-recommendations) |
+| --- | --- | --- |
+| **Role permissions** | Restrict Administrator, Manage Webhooks, Manage Server, Manage Roles, and Manage Channels to the minimum required roles | [Role permissions](/guides/account-management/discord#roles) |
+| **Cold Admin account** | Dedicated owner account on a factory-reset device, used only for major changes and incident recovery | [Cold Admin](/guides/account-management/discord#cold-admin-setup) |
+| **Verification level** | Set to at least Medium (5+ minutes on Discord); Moderate recommended for public servers | [Verification](/guides/account-management/discord#member-screening-setup) |
+| **Raid protection** | ML-based join-raid detection with auto-lockdown and CAPTCHA for new users | [Raid protection](/guides/account-management/discord#safety-setup) |
+| **AutoMod rules** | Block spam, harmful links, mention spam, and impersonation keywords in usernames | [AutoMod](/guides/account-management/discord#automod) |
+| **Anti-impersonation** | Custom rules blocking lookalike usernames and profile pictures; bots such as Wick | [Anti-impersonation](/guides/account-management/discord#anti-impersonation-bots) |
+| **Bot and integration security** | Least privilege for bots; restrict command permissions; audit webhooks | [Integrations](/guides/account-management/discord#additional-recommendations) |
 
----
+For step-by-step procedures, see the [Discord Security Guide](/guides/account-management/discord).
 
-For a comprehensive guide on securing your Discord server, see the [**Discord Security Guide**](/guides/account-management/discord).
+## Further Reading & Tools
+
+- [Discord Security Guide](/guides/account-management/discord)
+- [Discord Safety Center](https://discord.com/safety)
 
 ---
 

--- a/docs/pages/community-management/overview.mdx
+++ b/docs/pages/community-management/overview.mdx
@@ -61,7 +61,7 @@ Deep, step-by-step controls live in the linked account-management guides.
 - [OpSec](/opsec/overview): credentials, MFA, and device hygiene for people who run community tools
 - [Incident Management](/incident-management/overview): response when a community channel is compromised
 
-## Further Reading & Tools
+## Further Reading
 
 - Platform pages above and their linked guides under `/guides/account-management/`
 - [Discord Safety Center](https://discord.com/safety)

--- a/docs/pages/community-management/overview.mdx
+++ b/docs/pages/community-management/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Community Management | Security Alliance"
-description: "Community Management Framework: Secure your Web3 community on Telegram, Discord, and X (Twitter). Essential practices for 2FA, phishing prevention, and emergency response planning."
+description: "Secure Web3 communities on Discord, X (Twitter), and Telegram: operator credentials, anti-impersonation, phishing resistance, and incident handoff when channels fail."
 tags:
   - Community & Marketing
 contributors:
@@ -8,6 +8,8 @@ contributors:
     users: [mattaereal, robert, nftdreww]
   - role: reviewed
     users: [ghadi8]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -17,33 +19,54 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Communities are often the foundation of Web3 projects, serving as the primary connection point between organizations and their users. However, they also represent one of the largest attack surfaces. From community members and moderators to founders and executives, every individual within an ecosystem can become a target of social engineering, phishing, impersonation, account compromise, malware, and other attacks across platforms such as Discord, Telegram, X (formerly Twitter), Google Workspace, and beyond.
+> 🔑 **Key Takeaway**: Community channels are high-trust broadcast paths. Compromised operator accounts and weak platform
+> configuration turn that trust into phishing scale.
 
-When a community channel is compromised—whether through a malicious link, a compromised team member account, fraudulent support interaction, or a coordinated social engineering campaign—it can quickly become a launch point for wider attacks that impact users, project assets, and organizational reputation.
+Communities are often the foundation of Web3 projects and the primary connection between organizations and users. They
+are also a large attack surface. Community members, moderators, founders, and executives can be targeted with social
+engineering, phishing, impersonation, account compromise, malware, and related attacks across Discord, Telegram,
+X (formerly Twitter), shared workspaces, and more.
 
-This framework provides essential guidance, best practices, and security controls to help organizations build, operate, and maintain secure communities. The following sections explore platform-specific recommendations and defensive strategies in greater detail, enabling teams to reduce risk while fostering safe and trusted environments for their communities.
+When a community channel is compromised—whether through a malicious link, a compromised team account, a fraudulent
+support interaction, or a coordinated social engineering campaign—it can become a launch point for wider attacks that
+impact users, project assets, and organizational reputation.
 
----
+This framework orients teams to platform-specific pages and the broader security domains that constrain community risk.
+Deep, step-by-step controls live in the linked account-management guides.
 
-## Platform frameworks
+## What this framework covers
 
-| Platform | What it covers | Link |
-|---|---|---|
-| **Discord** | Server permissions, role hygiene, raid protection, bot vetting, and anti-impersonation | [→ Discord framework](/community-management/discord) |
-| **X (Twitter)** | Account security, impersonation risks, API token scope, and official channel hygiene | [→ X framework](/community-management/twitter) |
-| **Telegram** | Two-step verification, phone number privacy, admin permissions, and man-in-the-group attacks | [→ Telegram framework](/community-management/telegram) |
+1. [Discord](/community-management/discord): server permissions, role hygiene, raid protection, bot vetting, and
+   anti-impersonation (hub into the Discord guide).
+2. [X (Twitter)](/community-management/twitter): account security, SIM-swap failure modes, OAuth token hygiene, and
+   official-channel practices.
+3. [Telegram](/community-management/telegram): two-step verification, phone-number privacy, admin permissions, and
+   man-in-the-group style threats.
 
----
-
-## Security domain index
+## Related security domains
 
 | Domain | What it covers | Framework |
-|---|---|---|
-| **Authentication & passwords** | Unique credentials per service, hardware token preference, and 2FA requirements for linked email accounts | [Operational Security →](/opsec/overview) |
-| **Phishing & social engineering** | Official channel verification, DM policies, and recognizing impersonation tactics targeting your team and users | [Security Awareness →](/awareness/overview) |
-| **Operational security** | Device hygiene, software update discipline, and reducing the attack surface used to manage community channels | [Operational Security →](/opsec/overview) |
-| **Emergency response** | Pre-defined protocols for account compromise, rapid revocation of access, and community notification procedures | [Incident Response →](/incident-management/overview) |
+| --- | --- | --- |
+| Authentication and passwords | Unique credentials, hardware-backed multi-factor authentication (MFA), linked email protection | [Operational Security](/opsec/overview) |
+| Phishing and social engineering | Official channel verification, DM policy, impersonation recognition | [Security Awareness](/awareness/overview) |
+| Operational security | Device hygiene, update discipline, reduced attack surface for operators | [Operational Security](/opsec/overview) |
+| Emergency response | Compromise playbooks, access revocation, community notification | [Incident Management](/incident-management/overview) |
 
+## Related frameworks
+
+- [Guides — Account Management](/guides/account-management/overview): platform hardening procedures referenced by each
+  child page
+- [User and Team Security](/user-team-security/overview): staff-facing security postures (when expanded)
+- [Awareness](/awareness/overview): phishing and social-engineering education for operators and members
+- [OpSec](/opsec/overview): credentials, MFA, and device hygiene for people who run community tools
+- [Incident Management](/incident-management/overview): response when a community channel is compromised
+
+## Further Reading & Tools
+
+- Platform pages above and their linked guides under `/guides/account-management/`
+- [Discord Safety Center](https://discord.com/safety)
+- [X Help Center — How to protect your account](https://help.x.com/en/safety-and-security/account-security-tips)
+- [Telegram FAQ — Two-Step Verification](https://telegram.org/faq#q-what-is-two-step-verification)
 
 ---
 

--- a/docs/pages/community-management/telegram.mdx
+++ b/docs/pages/community-management/telegram.mdx
@@ -92,7 +92,7 @@ The guide is structured by scope: personal account first, then group.
 
 For step-by-step procedures, see the [Telegram Security Guide](/guides/account-management/telegram).
 
-## Further Reading & Tools
+## Further Reading
 
 - [Telegram Security Guide](/guides/account-management/telegram)
 - [Telegram FAQ — Two-Step Verification](https://telegram.org/faq#q-what-is-two-step-verification)

--- a/docs/pages/community-management/telegram.mdx
+++ b/docs/pages/community-management/telegram.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Telegram Security | Security Alliance"
-description: "Secure Telegram against SIM swapping and Man-in-the-Group attacks. Configure passkeys, Two-Step Verification, hide your phone number, use Secret Chats with end-to-end encryption, and manage admin permissions."
+description: "Secure Telegram accounts and groups: two-step verification, phone-number privacy, session hygiene, Secret Chats, admin least privilege, and man-in-the-group defenses."
 tags:
   - Community & Marketing
 contributors:
@@ -8,6 +8,8 @@ contributors:
     users: [mattaereal, zedt3ster, fredriksvantes, auditware, nftdreww]
   - role: reviewed
     users: [mattaereal]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -17,71 +19,83 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
+> 🔑 **Key Takeaway**: Telegram ties recovery to phone numbers by default. Enable two-step verification, hide phone
+> exposure, and limit admin rights so one SIM swap or compromised mod cannot own the community.
 
-Telegram account and group security spans two-step verification, phone number privacy, session management, admin permissions, and group hardening — each covered in depth in the [Telegram Security Guide](/guides/account-management/telegram). Use this page to find the right section.
-
----
+Telegram account and group security spans two-step verification, phone number privacy, session management, admin
+permissions, and group hardening—each covered in depth in the
+[Telegram Security Guide](/guides/account-management/telegram). Use this page to find the right section.
 
 ## The community manager's role in security
 
-Telegram is the de facto community platform for Web3 projects. Large groups, public channels, and direct access to members make it uniquely valuable and uniquely dangerous. A community manager running a Telegram group holds a position of structural authority: you control who has admin rights, who can add new members, what bots operate in the group, and how announcements reach your community. Attackers understand that authority and target it specifically.
+Telegram is a de facto community platform for many Web3 projects. Large groups, public channels, and direct member
+access make it valuable and risky. A community manager controlling a group holds structural authority: admin rights,
+member adds, bots, and announcement reach. Attackers target that authority.
 
-What makes Telegram different from Discord and X is its phone number dependency. By default, every Telegram account is tied to a phone number — and that number is the primary recovery mechanism. If an attacker successfully SIM swaps your number, they receive your Telegram login code directly and can take over your account without ever knowing your password. Two-step verification is the only control that stands between a SIM swap and a full account compromise.
+What differs from Discord and X is phone-number dependency. By default, Telegram accounts tie to a phone number used as
+a primary recovery path. If an attacker successfully SIM swaps that number, they can receive login codes and take over
+the account without knowing the cloud password—unless two-step verification is configured. Two-step verification is the
+control that stands between many SIM swaps and full account compromise.
 
-Telegram also introduces a threat that has no direct equivalent on other platforms: the Man-in-the-Group attack. An attacker creates an account impersonating a team member, joins your community group, and begins operating as if they have authority; answering questions, directing users to malicious links, or instructing members to send funds. Because Telegram groups can be large and fast-moving, these imposters often operate undetected for significant periods.
+Telegram also enables man-in-the-group style attacks: an impostor account joins, answers questions as if staff, and
+directs members to malicious links or fund transfers. Large, fast-moving groups can delay detection.
 
 ### Why following this guide is not optional
 
-Regular Telegram chats are not end-to-end encrypted by default. Messages sent in group chats are stored on Telegram's servers, which means a compromised account exposes not just future messages but your full accessible chat history. Combined with the platform's phone number dependency, this makes Telegram one of the highest-risk surfaces a community manager operates on.
+Regular Telegram chats are not end-to-end encrypted by default. Group messages live on Telegram's infrastructure, so a
+compromised account can expose accessible history as well as future traffic. Combined with phone-number dependency, this
+makes Telegram a high-risk surface for community operators.
 
-Admin permissions in Telegram groups are also less granular than Discord's role system. It is easy to over-grant permissions to moderators or bots out of convenience, and difficult to audit what each admin can actually do. The guide covers how to structure permissions so that a single compromised admin account cannot do irreversible damage to your group.
+Admin permissions in Telegram groups are also less granular than Discord roles. It is easy to over-grant permissions to
+moderators or bots and hard to audit actual capability. The linked guide covers tighter permission structure so one
+compromised admin account cannot do irreversible damage.
 
-As a community manager, your members assume that anything coming from your account or your admins is legitimate. That assumption is the attack surface. The controls in this guide exist to ensure that the assumption is as difficult to exploit as possible.
+Members assume messages from project accounts and admins are legitimate. That assumption is the attack surface. The
+controls in the guide make that assumption harder to exploit.
 
-### What's at stake if you don't
+### What is at stake
 
 | Risk | Consequence |
-|---|---|
-| **SIM swap account takeover** | Attacker ports your phone number, receives your Telegram login code, and gains full account access; bypassing your password entirely |
-| **Man-in-the-Group attack** | Impersonator joins your group posing as a team member, social-engineers members from within a trusted environment |
-| **IP address exposure** | Peer-to-peer Telegram calls reveal your real IP address, enabling targeted doxing or follow-on attacks |
-| **Group cloning** | Attackers replicate your group with a near-identical name and invite link, redirecting members into a scam environment |
-| **Mini app phishing** | Malicious mini apps redirect users outside Telegram to harvest credentials or seed malware |
-| **Message history exposure** | Compromised account gives attacker access to unencrypted chat history stored on Telegram's servers |
-| **Over-permissioned admin compromise** | A single breached moderator account with excessive rights can add bots, remove legitimate admins, or flood the group with scam content |
+| --- | --- |
+| **SIM swap account takeover** | Attacker ports the number, receives login codes, and gains account access |
+| **Man-in-the-group attack** | Impersonator social-engineers members from inside a trusted group |
+| **IP address exposure** | Peer-to-peer calls can reveal real IP addresses and enable follow-on harassment |
+| **Group cloning** | Near-identical groups and invite links redirect members into scam environments |
+| **Mini app phishing** | Malicious mini apps redirect outside Telegram to harvest credentials or malware |
+| **Message history exposure** | Compromise can expose non-E2EE history accessible to the account |
+| **Over-permissioned admin compromise** | One breached moderator can add bots, remove admins, or push scam content |
 
-The guide addresses each of these with specific, actionable controls. Several of them — two-step verification and phone number privacy in particular- take under five minutes to configure and eliminate the most common attack paths entirely.
-
----
+The guide addresses these with actionable controls. Two-step verification and phone-number privacy in particular are
+fast to configure and block common takeover paths when applied correctly.
 
 ## What the guide covers
 
-The guide is structured by scope: your personal account first, then your group.
+The guide is structured by scope: personal account first, then group.
 
 | Scope | What it covers |
-|---|---|
-| **Personal account** | Two-step verification, phone number privacy, active session review, auto-delete, P2P call settings, contact sync |
-| **Group management** | Admin permission structure, member add restrictions, bot vetting, mini app guidance, scam ad awareness, community education |
-
----
+| --- | --- |
+| **Personal account** | Two-step verification, phone privacy, sessions, auto-delete, P2P calls, contact sync |
+| **Group management** | Admin permission structure, member-add limits, bot vetting, mini apps, education |
 
 ## Topic index
 
 | Topic | Summary | Guide section |
-|---|---|---|
-| **Two-step verification** | Set an additional password on your account — the only control that prevents takeover if your phone number is SIM swapped | [→ Two-step verification](/guides/account-management/telegram#account-security-checklist) |
-| **Phone number privacy** | Hide your number from contacts and the public; consider a burner or Fragment anonymous number for the account itself | [→ Phone number](/guides/account-management/telegram#account-security-checklist) |
-| **Active sessions** | Review all logged-in devices; terminate unrecognized sessions; set auto-termination for inactive sessions | [→ Active sessions](/guides/account-management/telegram#account-security-checklist) |
-| **Auto-delete messages** | Set a global message deletion timer to limit the value of your history if your account is compromised | [→ Auto-delete](/guides/account-management/telegram#account-security-checklist) |
-| **Secret Chats** | Use end-to-end encrypted Secret Chats for sensitive team communication; regular chats are not E2EE by default | [→ Secret Chats](/guides/account-management/telegram#account-security-checklist) |
-| **P2P call settings** | Disable peer-to-peer calls or route them via Telegram's servers to prevent IP address leakage | [→ P2P calls](/guides/account-management/telegram#account-security-checklist) |
-| **Group admin permissions** | Restrict who can add members; apply least privilege to all admin roles; audit bot permissions regularly | [→ Admin permissions](/guides/account-management/telegram#admin-permissions-management) |
-| **Mini app caution** | Verify mini app usernames carefully; avoid apps that redirect outside Telegram; never run commands received via Telegram | [→ Mini apps](/guides/account-management/telegram#best-practices-for-safe-use) |
+| --- | --- | --- |
+| **Two-step verification** | Additional account password—critical if the phone number is SIM swapped | [Two-step verification](/guides/account-management/telegram#account-security-checklist) |
+| **Phone number privacy** | Hide the number; consider secondary/anonymous numbers where policy allows | [Phone number](/guides/account-management/telegram#account-security-checklist) |
+| **Active sessions** | Review devices; terminate unknowns; auto-terminate inactive sessions | [Active sessions](/guides/account-management/telegram#account-security-checklist) |
+| **Auto-delete messages** | Global deletion timer limits history value after compromise | [Auto-delete](/guides/account-management/telegram#account-security-checklist) |
+| **Secret Chats** | Prefer end-to-end encrypted Secret Chats for sensitive team traffic | [Secret Chats](/guides/account-management/telegram#account-security-checklist) |
+| **P2P call settings** | Disable P2P or route via Telegram servers to reduce IP leakage | [P2P calls](/guides/account-management/telegram#account-security-checklist) |
+| **Group admin permissions** | Least privilege; restrict member adds; audit bot rights | [Admin permissions](/guides/account-management/telegram#admin-permissions-management) |
+| **Mini app caution** | Verify usernames; avoid off-platform redirects; never run untrusted commands | [Mini apps](/guides/account-management/telegram#best-practices-for-safe-use) |
 
----
+For step-by-step procedures, see the [Telegram Security Guide](/guides/account-management/telegram).
 
+## Further Reading & Tools
 
-For a comprehensive guide on securing your Telegram account and groups, see the [**Telegram Security Guide**](/guides/account-management/telegram).
+- [Telegram Security Guide](/guides/account-management/telegram)
+- [Telegram FAQ — Two-Step Verification](https://telegram.org/faq#q-what-is-two-step-verification)
 
 ---
 

--- a/docs/pages/community-management/twitter.mdx
+++ b/docs/pages/community-management/twitter.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Twitter/X Security | Security Alliance"
-description: "Protect project X (Twitter) accounts from SIM swapping and OAuth abuse: remove phone recovery paths, prefer strong MFA, audit apps and sessions, enable reset protection."
+description: "Protect project X (Twitter) accounts from SIM swapping and OAuth abuse: remove phone recovery paths, prefer strong MFA, audit apps and sessions"
 tags:
   - Community & Marketing
 contributors:

--- a/docs/pages/community-management/twitter.mdx
+++ b/docs/pages/community-management/twitter.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Twitter/X Security | Security Alliance"
-description: "Protect your X (Twitter) account from SIM swapping: remove your phone number, enable 2FA with an authenticator app or security key, and enable password reset protection."
+description: "Protect project X (Twitter) accounts from SIM swapping and OAuth abuse: remove phone recovery paths, prefer strong MFA, audit apps and sessions, enable reset protection."
 tags:
   - Community & Marketing
 contributors:
@@ -8,6 +8,8 @@ contributors:
     users: [mattaereal, zedt3ster, fredriksvantes, auditware, nftdreww]
   - role: reviewed
     users: [mattaereal, nftdreww]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -17,62 +19,77 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-X account security spans authentication hardening, session management, third-party app access, and recovery settings — each covered in depth in the [X (Twitter) Security Guide](/guides/account-management/twitter). Use this page to find the right section.
+> 🔑 **Key Takeaway**: A project X account can broadcast scams in one post. Prefer strong multi-factor authentication
+> (MFA), remove SIM-swapable recovery paths, and revoke stale OAuth access.
 
----
+X account security spans authentication hardening, session management, third-party app access, and recovery settings—
+each covered in depth in the [X (Twitter) Security Guide](/guides/account-management/twitter). Use this page to find the
+right section.
 
 ## The community manager's role in security
 
-A community manager running a project's X account is one of the highest-value targets in Web3. Your account is public-facing, often verified, and carries the implicit trust of every follower you've built. When you post a link, people click it. When you make an announcement, people act on it. That reach is exactly what attackers are after.
+A community manager running a project's X account is a high-value Web3 target. The account is public-facing, often
+verified, and carries follower trust. Posted links get clicked; announcements get acted on. That reach is what attackers
+want.
 
-Unlike Discord — where compromise requires navigating server permissions and roles- a taken-over X account can do damage in a single post. Scam links, fake token launches, fraudulent airdrop announcements: all of these reach your entire audience instantly, from an account they already trust. The window between compromise and widespread harm is measured in minutes.
+Unlike Discord—where compromise often still navigates roles and permissions—a taken-over X account can do damage in a
+single post. Scam links, fake token launches, and fraudulent airdrop announcements can reach the full audience from an
+account followers already trust. The window between compromise and widespread harm is measured in minutes.
 
-X account takeovers in the Web3 space follow a small number of well-documented patterns: SIM swapping to bypass SMS-based 2FA, phishing via fake login screens, and exploitation of forgotten third-party app tokens that retain OAuth access long after the app was last used. None of these require sophisticated attacks. All of them are preventable with the controls in this guide.
+X account takeovers in Web3 often follow documented patterns: SIM swapping against SMS-based MFA, phishing via fake
+login screens, and exploitation of forgotten third-party OAuth tokens that retain access long after the app was last
+used. These paths do not require exotic vulnerabilities. The linked guide documents preventable controls.
 
 ### Why following this guide is not optional
 
-The most common failure mode is not ignorance; it is configuration drift. An account that was secured at setup gradually accumulates risk: a phone number added for convenience, a scheduling tool connected years ago with broad permissions, a session left open on an old device. Each of these is a door. Attackers look for unlocked ones.
+A common failure mode is configuration drift. An account secured at setup gradually accumulates risk: a phone number
+added for convenience, a scheduling tool connected years ago with broad permissions, a session left open on an old
+device. Each is a door. Attackers look for unlocked ones.
 
-As a community manager, you are also the last line of defense before your followers are exposed. Your organization can have excellent internal security practices and still have its community harmed through a single unsecured social account. The guide exists to close those gaps in a way that is repeatable and auditable.
+Community managers are also a last line of defense before followers are exposed. Strong internal security does not help
+if a single social account is the weak outbound path. The guide closes those gaps in a repeatable way.
 
-### What's at stake if you don't
+### What is at stake
 
 | Risk | Consequence |
-|---|---|
-| **Account takeover via SIM swap** | Attacker ports your phone number, resets your X password, and locks you out; often within the same hour |
-| **Phishing via fake login screen** | Credentials harvested through convincing X login replicas; account access transferred before you notice |
-| **Third-party app token abuse** | Old OAuth tokens from connected apps exploited after those apps are breached, granting persistent account access without your password |
-| **Retained access post-recovery** | Connected accounts left in place allow an attacker to regain access even after you change your password |
-| **Scam broadcast to followers** | Fake links, fraudulent token launches, or malicious airdrops posted from your account to an audience that trusts it |
-| **Reputational damage** | Compromise events on public accounts are screenshotted and shared within minutes; community trust takes months to rebuild |
+| --- | --- |
+| **Account takeover via SIM swap** | Attacker ports the phone number, resets the X password, and locks operators out |
+| **Phishing via fake login screen** | Credentials harvested; account access transfers before detection |
+| **Third-party app token abuse** | Old OAuth tokens from connected apps grant persistent access without the password |
+| **Retained access post-recovery** | Connected accounts left in place allow re-entry after a password change |
+| **Scam broadcast to followers** | Fake links or malicious airdrops posted from a trusted account |
+| **Reputational damage** | Public compromise is captured quickly; trust rebuild is slow |
 
-The guide addresses each of these with specific, step-by-step controls. None require technical expertise. All of them significantly reduce the probability and impact of a takeover.
+The guide addresses these with specific controls that do not require deep technical expertise.
 
 ## What the guide covers
 
-The guide applies to every team member with access to the account, not only the primary account holder.
+The guide applies to every team member with access to the account, not only the primary holder.
 
 | Audience | What it covers |
-|---|---|
-| **All account holders** | 2FA method selection, phone number removal, email security, backup codes |
+| --- | --- |
+| **All account holders** | MFA method selection, phone number removal, email security, backup codes |
 | **Account admins** | Password reset protection, connected account audit, third-party app permissions, active session review |
-
----
 
 ## Topic index
 
 | Topic | Summary | Guide section |
-|---|---|---|
-| **2FA method** | Use an authenticator app or hardware security key; SMS-based 2FA is vulnerable to SIM swapping and should be removed | [→ 2FA](/guides/account-management/twitter#account-security-checklist) |
-| **Phone number removal** | Remove your phone number from the account entirely — it is the primary vector for SIM swap takeovers | [→ Phone number](/guides/account-management/twitter#account-security-checklist) |
-| **Email security** | Use a non-obvious email address not linked to your public identity; enable password reset protection | [→ Email](/guides/account-management/twitter#1-email-security) |
-| **Password reset protection** | Require email or phone confirmation before a reset can be initiated, blocking hint-based attacks | [→ Reset protection](/guides/account-management/twitter#account-security-checklist) |
-| **Connected accounts** | Review and remove any third-party accounts used to log in; prior compromise can persist through these | [→ Connected accounts](/guides/account-management/twitter#account-security-checklist) |
-| **Third-party app permissions** | Audit and revoke OAuth access for apps no longer in use; old tokens remain valid until explicitly revoked | [→ App permissions](/guides/account-management/twitter#best-practices--additional-tips) |
-| **Active session review** | Log out of unrecognized devices and sessions; any unfamiliar session is a potential persistent access point | [→ Sessions](/guides/account-management/twitter#best-practices--additional-tips) |
+| --- | --- | --- |
+| **MFA method** | Prefer authenticator apps or hardware security keys; remove SMS MFA when feasible (SIM-swap risk) | [MFA](/guides/account-management/twitter#account-security-checklist) |
+| **Phone number removal** | Remove the phone number from the account when operationally possible—primary SIM-swap vector | [Phone number](/guides/account-management/twitter#account-security-checklist) |
+| **Email security** | Prefer a non-obvious email not tied to public identity; enable password reset protection | [Email](/guides/account-management/twitter#1-email-security) |
+| **Password reset protection** | Require email or controlled confirmation before reset to block weak recovery paths | [Reset protection](/guides/account-management/twitter#account-security-checklist) |
+| **Connected accounts** | Review and remove third-party login linkages that can retain compromise | [Connected accounts](/guides/account-management/twitter#account-security-checklist) |
+| **Third-party app permissions** | Audit and revoke OAuth for unused apps; tokens remain until revoked | [App permissions](/guides/account-management/twitter#best-practices--additional-tips) |
+| **Active session review** | Sign out unrecognized devices; treat unfamiliar sessions as potential persistence | [Sessions](/guides/account-management/twitter#best-practices--additional-tips) |
+
+For step-by-step procedures, see the [X (Twitter) Security Guide](/guides/account-management/twitter).
+
+## Further Reading & Tools
+
+- [X (Twitter) Security Guide](/guides/account-management/twitter)
+- [X Help Center — Account security](https://help.x.com/en/safety-and-security/account-security-tips)
 
 ---
-
-For a comprehensive guide on securing your X (Twitter) account, see the [**Twitter/X Security Guide**](/guides/account-management/twitter).
 
 <ContributeFooter />

--- a/docs/pages/community-management/twitter.mdx
+++ b/docs/pages/community-management/twitter.mdx
@@ -85,7 +85,7 @@ The guide applies to every team member with access to the account, not only the 
 
 For step-by-step procedures, see the [X (Twitter) Security Guide](/guides/account-management/twitter).
 
-## Further Reading & Tools
+## Further Reading
 
 - [X (Twitter) Security Guide](/guides/account-management/twitter)
 - [X Help Center — Account security](https://help.x.com/en/safety-and-security/account-security-tips)


### PR DESCRIPTION
## Scope

Normalize the **Community Management** framework (`docs/pages/community-management/`).

## Why

Pages were comparatively mature (guide hubs + tables) but missing Key Takeaways, overview map in recommended form, Further reading chrome, and had **pre-existing markdownlint failures** (MD013/MD060) on touch paths.

## Content model applied

Framework overview + reference/hub child pages; keep deep content in `/guides/account-management/*`; retained original writers/reviewers.

## Changes

- overview, discord, twitter, telegram

## Substantive security changes

**None.** Editorial/structural; 2FA wording generalized to multi-factor authentication (MFA) where helpful; content preserved.

## Intentionally unchanged

- Guide body pages under `/guides/`
- Sidebar (already public, no `dev: true` change)

## Validation

- [x] cspell — clean
- [x] markdownlint-cli2 on touched paths — **clean** (was failing before)
- [x] signed commit
- [x] no generated hand-edits

## Dependencies

**#561** by reference.

## Reviewer focus

- Guide deep-link anchors still correct
- No product claim inflation