### PR TITLE
docs(awareness): normalize structure and wording

### DIFF
--- a/docs/pages/awareness/core-awareness-principles.mdx
+++ b/docs/pages/awareness/core-awareness-principles.mdx
@@ -61,7 +61,12 @@ understand their role in maintaining security.
 
 ## Further Reading
 
-- [Awareness overview](/awareness/overview)
+- [Awareness overview](/awareness/overview): how the pages of this framework fit together
+- [Understanding Threat Vectors](/awareness/understanding-threat-vectors): the attack paths these principles are meant
+  to catch
+- [Zero Trust Principles](/infrastructure/zero-trust-principles): verify-before-trust translated into technical controls
+- [NIST SP 800-207: Zero Trust Architecture](https://csrc.nist.gov/pubs/sp/800/207/final): the reference definition of
+  zero trust
 
 ---
 

--- a/docs/pages/awareness/core-awareness-principles.mdx
+++ b/docs/pages/awareness/core-awareness-principles.mdx
@@ -12,6 +12,8 @@ contributors:
     users: [mattaereal, zedt3ster, fredriksvantes]
   - role: reviewed
     users: [mattaereal]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -21,9 +23,8 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> 🔑 **Key Takeaway**: Security awareness is built on fundamental principles like threat recognition, risk assessment,
-> and zero trust verification. These principles form the foundation of a security-conscious culture where every
-> individual plays a vital role in protecting organizational assets.
+> 🔑 **Key Takeaway**: Security awareness rests on threat recognition, risk perception, and verification before trust.
+> Culture fails when only tools are expected to notice danger.
 
 ## Key concepts
 

--- a/docs/pages/awareness/core-awareness-principles.mdx
+++ b/docs/pages/awareness/core-awareness-principles.mdx
@@ -59,7 +59,6 @@ understand their role in maintaining security.
 > details. An employee with a strong zero trust mindset will independently verify the request through known contact
 > numbers or an established internal process, thereby avoiding a potential fraud.
 
-
 ## Further Reading
 
 - [Awareness overview](/awareness/overview)

--- a/docs/pages/awareness/core-awareness-principles.mdx
+++ b/docs/pages/awareness/core-awareness-principles.mdx
@@ -59,6 +59,11 @@ understand their role in maintaining security.
 > details. An employee with a strong zero trust mindset will independently verify the request through known contact
 > numbers or an established internal process, thereby avoiding a potential fraud.
 
+
+## Further Reading
+
+- [Awareness overview](/awareness/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/awareness/core-awareness-principles.mdx
+++ b/docs/pages/awareness/core-awareness-principles.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Core Awareness Principles | Security Alliance"
-description: "Master the Zero Trust Mindset and Threat Recognition principles to defend against phishing, social engineering, and malware. Build a security-conscious culture in your organization."
+description: "Master the Zero Trust Mindset and Threat Recognition principles to defend against phishing, social engineering, and malware"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/awareness/cultivating-a-security-aware-mindset.mdx
+++ b/docs/pages/awareness/cultivating-a-security-aware-mindset.mdx
@@ -12,6 +12,8 @@ contributors:
     users: [mattaereal, zedt3ster, fredriksvantes]
   - role: reviewed
     users: [mattaereal]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -21,9 +23,8 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> 🔑 **Key Takeaway**: Developing a security-aware mindset is about building habits that prioritize caution and
-> verification. By questioning unusual requests, pausing before acting, and leveraging peer support, you transform
-> security from a set of rules into an intuitive approach to daily interactions.
+> 🔑 **Key Takeaway**: A security-aware mindset is habits—pause, verify unusual requests out-of-band, and use peer
+> support—not a rule list memorized once.
 
 ## Behavioral Best Practices
 

--- a/docs/pages/awareness/cultivating-a-security-aware-mindset.mdx
+++ b/docs/pages/awareness/cultivating-a-security-aware-mindset.mdx
@@ -203,6 +203,11 @@ A team member notices unusual login attempts to their account. Instead of ignori
 immediately report it to the security team, who can then investigate whether this is part of a larger attack pattern
 affecting other users.
 
+
+## Further Reading
+
+- [Awareness overview](/awareness/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/awareness/cultivating-a-security-aware-mindset.mdx
+++ b/docs/pages/awareness/cultivating-a-security-aware-mindset.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Cultivating A Security Aware Mindset | SEAL"
-description: "Build security habits with Password Management, Multi-Factor Authentication (MFA), and Incident Response Awareness. Practical tips for Discord, Twitter, and Telegram community settings."
+description: "Build security habits with Password Management, Multi-Factor Authentication (MFA), and Incident Response Awareness. Covers Cultivating A Security Aware"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/awareness/cultivating-a-security-aware-mindset.mdx
+++ b/docs/pages/awareness/cultivating-a-security-aware-mindset.mdx
@@ -205,7 +205,12 @@ affecting other users.
 
 ## Further Reading
 
-- [Awareness overview](/awareness/overview)
+- [Awareness overview](/awareness/overview): how the pages of this framework fit together
+- [Security-Aware Culture](/user-team-security/security-aware-culture): making shared responsibility an organizational
+  norm
+- [Multi-Factor Authentication](/opsec/mfa/overview): picking factors that resist SIM swapping and phishing
+- [NIST SP 800-63B: Digital Identity Guidelines](https://pages.nist.gov/800-63-3/sp800-63b.html): the evidence behind
+  passphrases over forced complexity
 
 ---
 

--- a/docs/pages/awareness/cultivating-a-security-aware-mindset.mdx
+++ b/docs/pages/awareness/cultivating-a-security-aware-mindset.mdx
@@ -203,7 +203,6 @@ A team member notices unusual login attempts to their account. Instead of ignori
 immediately report it to the security team, who can then investigate whether this is part of a larger attack pattern
 affecting other users.
 
-
 ## Further Reading
 
 - [Awareness overview](/awareness/overview)

--- a/docs/pages/awareness/overview.mdx
+++ b/docs/pages/awareness/overview.mdx
@@ -65,7 +65,7 @@ when something is off, pause, verify through a separate channel, and escalate wh
 - [DPRK IT Workers](/dprk-it-workers/overview): hiring and insider-path risks
 - [Incident Management](/incident-management/overview): what happens after a suspected compromise
 
-## Further Reading & Tools
+## Further Reading
 
 See [Resources and Further Reading](/awareness/resources-and-further-reading) for the curated list maintained with this
 framework.

--- a/docs/pages/awareness/overview.mdx
+++ b/docs/pages/awareness/overview.mdx
@@ -67,8 +67,13 @@ when something is off, pause, verify through a separate channel, and escalate wh
 
 ## Further Reading
 
-See [Resources and Further Reading](/awareness/resources-and-further-reading) for the curated list maintained with this
-framework.
+- [Resources and Further Reading](/awareness/resources-and-further-reading): the curated source and tool list
+  maintained with this framework
+- [User and Team Security](/user-team-security/overview): the next layer of staff and team security controls
+- [CISA: Secure Our World](https://www.cisa.gov/secure-our-world): plain-language awareness material for non-technical
+  staff
+- [Verizon Data Breach Investigations Report](https://www.verizon.com/business/resources/reports/dbir/): evidence on
+  how often the human path is the entry point
 
 ---
 

--- a/docs/pages/awareness/overview.mdx
+++ b/docs/pages/awareness/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Security Awareness | Security Alliance"
-description: "Security Awareness Framework: Learn to recognize risk signals and cultivate a security-aware mindset. Protect against Web3 threats like crypto drainers, rug pulls, phishing, and social engineering."
+description: "Security awareness for Web3 teams: recognize risk signals, understand threat vectors, build secure habits, and keep learning without replacing technical control frameworks."
 tags:
   - Security Specialist
   - Operations & Strategy
@@ -12,6 +12,8 @@ contributors:
     users: [mattaereal]
   - role: reviewed
     users: [mattaereal, robert]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -21,43 +23,52 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> **Key Takeaway**
-Stay vigilant, your awareness is your strongest defense against cyber threats. Recognizing red flags and questioning
-unexpected requests can prevent costly breaches.
+> 🔑 **Key Takeaway**: Awareness is recognizing risk signals early—especially unexpected requests and urgency tricks—so
+> technical controls are not the only line of defense.
 
-This framework is all about understanding the threat landscape, recognizing risk signals, and cultivating a
-security-aware mindset. It serves as a high-level guide to help individuals and organizations identify potential
-vulnerabilities and remain vigilant—without overlapping with the detailed, technical scenarios covered in other
-sections.
+This framework covers the threat landscape at a high level: risk signals, threat vectors, and a security-aware mindset.
+It is intentionally light on step-by-step technical controls; those live in OpSec, IAM, community management, wallet
+security, and related frameworks.
 
-## Introduction & Objectives
+## Objectives
 
-The modern digital landscape is filled with sophisticated attacks, including web3-specific threats like crypto drainers
-and rug pulls. This section lays the foundation for why a high level of security awareness is essential. It's about
-empowering you to notice, question, and respond appropriately when something feels off. Trust, but verify!
+The digital landscape includes sophisticated attacks and Web3-specific fraudulent or abusive patterns (for example
+phishing for wallet approvals, drainers, and social-engineered “support”). High security awareness means people notice
+when something is off, pause, verify through a separate channel, and escalate when needed.
 
-### Objectives
+- **Recognize threats:** common tactics across traditional and Web3-adjacent vectors
+- **Adopt a proactive stance:** early recognition reduces incident cost
+- **Foster a security culture:** security is an organizational habit, not a single role
+- **Implement effective training:** structured education for all team members
+- **Separate awareness from implementation:** this family is about recognizing and responding in the moment, not
+  configuring every control end to end
 
-- Recognize Threats: Understand common tactics used by cybercriminals, including both traditional and web3-specific
-attack vectors.
-- Adopt a Proactive Stance: Learn how early recognition can stop an attack in its tracks.
-- Foster a Security Culture: Build an organizational environment where security is everyone's responsibility.
-- Implement Effective Training: Develop structured approaches to security education for all team members.
-- Separate Awareness from Implementation: Focus here on "being aware" rather than the step-by-step controls, which are
-covered in other sections.
+## What this framework covers
 
-## Contents
+1. [Core Awareness Principles](/awareness/core-awareness-principles): foundational mindsets such as threat recognition,
+   risk perception, and verification habits.
+2. [Understanding Threat Vectors](/awareness/understanding-threat-vectors): common attack methods, indicators, and
+   prevention orientation.
+3. [Cultivating a Security-Aware Mindset](/awareness/cultivating-a-security-aware-mindset): day-to-day habits and
+   organizational culture practices.
+4. [Staying Informed and Continuous Learning](/awareness/staying-informed-and-continuous-learning): training approaches
+   and information habits.
+5. [Resources and Further Reading](/awareness/resources-and-further-reading): curated external learning materials and
+   tools.
 
-1. [Core Awareness Principles](/awareness/core-awareness-principles) - Foundational security concepts and mindsets that
-form the basis of security awareness
-2. [Understanding Threat Vectors](/awareness/understanding-threat-vectors.mdx) - Comprehensive overview of attack
-methods, indicators, and preventive measures
-3. [Cultivating a Security-Aware Mindset](/awareness/cultivating-a-security-aware-mindset.mdx) - Behavioral practices
-and organizational strategies for building a security culture
-4. [Staying Informed & Continuous Learning](/awareness/staying-informed-and-continuous-learning.mdx) - Training
-frameworks, educational approaches, and information sources
-5. [Resources & Further Reading](/awareness/resources-and-further-reading.mdx) - External tools, references, and
-resources for ongoing security education
+## Related frameworks
+
+- [User and Team Security](/user-team-security/overview): broader staff and team security (expanding)
+- [Community Management](/community-management/overview): public channel and operator risks
+- [OpSec](/opsec/overview): technical and operational controls after awareness
+- [IAM](/iam/overview): authentication and access lifecycle
+- [DPRK IT Workers](/dprk-it-workers/overview): hiring and insider-path risks
+- [Incident Management](/incident-management/overview): what happens after a suspected compromise
+
+## Further Reading & Tools
+
+See [Resources and Further Reading](/awareness/resources-and-further-reading) for the curated list maintained with this
+framework.
 
 ---
 

--- a/docs/pages/awareness/overview.mdx
+++ b/docs/pages/awareness/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Security Awareness | Security Alliance"
-description: "Security awareness for Web3 teams: recognize risk signals, understand threat vectors, build secure habits, and keep learning without replacing technical control frameworks."
+description: "Security awareness for Web3 teams: recognize risk signals, understand threat vectors, build secure habits, and keep learning without replacing technical control"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/awareness/resources-and-further-reading.mdx
+++ b/docs/pages/awareness/resources-and-further-reading.mdx
@@ -118,6 +118,11 @@ wallets
 - [Signal](https://signal.org/) - End-to-end encrypted messaging
 - [ProtonMail](https://protonmail.com/) - Encrypted email service
 
+
+## Further Reading
+
+- [Awareness overview](/awareness/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/awareness/resources-and-further-reading.mdx
+++ b/docs/pages/awareness/resources-and-further-reading.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Security Resources & Further Reading | SEAL"
-description: "Curated Web3 security resources: SANS newsletters, Darknet Diaries podcast, Immunefi learning materials, token approval tools like Unrekt, and recommended password managers like Bitwarden."
+description: "Curated Web3 security resources: SANS newsletters, Darknet Diaries podcast, Immunefi learning materials, token approval tools like Unrekt"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/awareness/resources-and-further-reading.mdx
+++ b/docs/pages/awareness/resources-and-further-reading.mdx
@@ -118,7 +118,6 @@ wallets
 - [Signal](https://signal.org/) - End-to-end encrypted messaging
 - [ProtonMail](https://protonmail.com/) - Encrypted email service
 
-
 ## Further Reading
 
 - [Awareness overview](/awareness/overview)

--- a/docs/pages/awareness/resources-and-further-reading.mdx
+++ b/docs/pages/awareness/resources-and-further-reading.mdx
@@ -120,7 +120,12 @@ wallets
 
 ## Further Reading
 
-- [Awareness overview](/awareness/overview)
+- [Awareness overview](/awareness/overview): how the pages of this framework fit together
+- [Staying Informed and Continuous Learning](/awareness/staying-informed-and-continuous-learning): how to turn these
+  sources into a recurring routine
+- [Wallet Tools and Resources](/wallet-security/tools-and-resources): wallet comparisons, verification tools, and
+  signing aids
+- [Overview of Each Framework](/intro/overview-of-each-framework): map of everything else published here
 
 ---
 

--- a/docs/pages/awareness/resources-and-further-reading.mdx
+++ b/docs/pages/awareness/resources-and-further-reading.mdx
@@ -12,7 +12,8 @@ contributors:
     users: [mattaereal, zedt3ster, fredriksvantes]
   - role: reviewed
     users: [mattaereal]
-
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -22,9 +23,8 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> 🔑 **Key Takeaway**: Expanding your security knowledge requires reliable resources and continuous engagement with the
-> security community. By leveraging curated learning materials, self-assessment tools, and professional networks, you
-> can deepen your expertise and stay ahead of emerging threats.
+> 🔑 **Key Takeaway**: Prefer curated, reputable sources and tools over random social tips. Resources need maintenance as
+> products and scams change.
 
 ## Additional Learning Materials
 

--- a/docs/pages/awareness/staying-informed-and-continuous-learning.mdx
+++ b/docs/pages/awareness/staying-informed-and-continuous-learning.mdx
@@ -184,7 +184,6 @@ Use security incidents (both internal and external) as learning opportunities.
 Example: After major industry breaches, conduct brief sessions to discuss what happened and how similar issues could be
 prevented in your organization.
 
-
 ## Further Reading
 
 - [Awareness overview](/awareness/overview)

--- a/docs/pages/awareness/staying-informed-and-continuous-learning.mdx
+++ b/docs/pages/awareness/staying-informed-and-continuous-learning.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Staying Informed And Continuous Learning | SEAL"
-description: "Create effective security training with phishing simulations, role-based learning, and SEAL Wargames. Stay current with trusted sources like SANS NewsBites and DeFi Security Summit."
+description: "Create effective security training with phishing simulations, role-based learning, and SEAL Wargames. Stay current with trusted sources like SANS NewsBites and"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/awareness/staying-informed-and-continuous-learning.mdx
+++ b/docs/pages/awareness/staying-informed-and-continuous-learning.mdx
@@ -12,6 +12,8 @@ contributors:
     users: [mattaereal, zedt3ster, fredriksvantes]
   - role: reviewed
     users: [mattaereal]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -21,9 +23,8 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> 🔑 **Key Takeaway**: Security is not a one-time achievement but an ongoing journey of learning and adaptation. By
-> establishing regular training routines, staying current with emerging threats, and fostering a culture of continuous
-> improvement, you ensure your security awareness remains effective against evolving challenges.
+> 🔑 **Key Takeaway**: Awareness decays without practice. Regular training, current threat inputs, and continuous
+> improvement keep recognition skills effective as attackers change.
 
 ## Comprehensive Security Training Framework
 

--- a/docs/pages/awareness/staying-informed-and-continuous-learning.mdx
+++ b/docs/pages/awareness/staying-informed-and-continuous-learning.mdx
@@ -184,6 +184,11 @@ Use security incidents (both internal and external) as learning opportunities.
 Example: After major industry breaches, conduct brief sessions to discuss what happened and how similar issues could be
 prevented in your organization.
 
+
+## Further Reading
+
+- [Awareness overview](/awareness/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/awareness/staying-informed-and-continuous-learning.mdx
+++ b/docs/pages/awareness/staying-informed-and-continuous-learning.mdx
@@ -186,7 +186,11 @@ prevented in your organization.
 
 ## Further Reading
 
-- [Awareness overview](/awareness/overview)
+- [Awareness overview](/awareness/overview): how the pages of this framework fit together
+- [Resources and Further Reading](/awareness/resources-and-further-reading): the curated source list maintained with
+  this framework
+- [Security Training](/user-team-security/security-training): building a role-based curriculum and tracking completion
+- [SANS NewsBites](https://www.sans.org/newsletters/newsbites/): twice-weekly summary of significant security news
 
 ---
 

--- a/docs/pages/awareness/understanding-threat-vectors.mdx
+++ b/docs/pages/awareness/understanding-threat-vectors.mdx
@@ -206,6 +206,11 @@ Use hardware wallets for storing significant cryptocurrency holdings.
 **Scenario Example:** Keeping your long-term investments on a hardware wallet while only maintaining small amounts in
 hot wallets for daily transactions.
 
+
+## Further Reading
+
+- [Awareness overview](/awareness/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/awareness/understanding-threat-vectors.mdx
+++ b/docs/pages/awareness/understanding-threat-vectors.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Understanding Threat Vectors | Security Alliance"
-description: "Identify phishing, vishing, and social engineering attacks. Learn about Web3 threats like crypto drainers, rug pulls, token approval exploits, and smart contract vulnerabilities."
+description: "Identify phishing, vishing, and social engineering attacks. Learn about Web3 threats like crypto drainers, rug pulls, token approval exploits"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/awareness/understanding-threat-vectors.mdx
+++ b/docs/pages/awareness/understanding-threat-vectors.mdx
@@ -12,6 +12,8 @@ contributors:
     users: [mattaereal, zedt3ster, fredriksvantes]
   - role: reviewed
     users: [mattaereal]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -21,9 +23,8 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> 🔑 **Key Takeaway**: Understanding the various ways attackers can target you and your organization is essential for
-> effective defense. By recognizing common attack patterns like phishing, social engineering, and emerging threats in
-> digital spaces, you can better protect yourself and your team from potential security breaches.
+> 🔑 **Key Takeaway**: Effective defense starts by knowing common attack paths—phishing, social engineering, and
+> Web3-specific fraud patterns—and recognizing their indicators before acting.
 
 ## Traditional Attack Vectors
 

--- a/docs/pages/awareness/understanding-threat-vectors.mdx
+++ b/docs/pages/awareness/understanding-threat-vectors.mdx
@@ -208,7 +208,12 @@ hot wallets for daily transactions.
 
 ## Further Reading
 
-- [Awareness overview](/awareness/overview)
+- [Awareness overview](/awareness/overview): how the pages of this framework fit together
+- [Phishing and Social Engineering](/user-team-security/phishing-social-engineering): deeper treatment of lures,
+  pretexts, and team-level defenses
+- [Smart Contract Interaction Security](/wallet-security/smart-contract-interaction-security): how approvals and
+  allowances are abused by drainers
+- [MITRE ATT&CK](https://attack.mitre.org/): catalogue of adversary techniques mapped to real campaigns
 
 ---
 

--- a/docs/pages/awareness/understanding-threat-vectors.mdx
+++ b/docs/pages/awareness/understanding-threat-vectors.mdx
@@ -206,7 +206,6 @@ Use hardware wallets for storing significant cryptocurrency holdings.
 **Scenario Example:** Keeping your long-term investments on a hardware wallet while only maintaining small amounts in
 hot wallets for daily transactions.
 
-
 ## Further Reading
 
 - [Awareness overview](/awareness/overview)


### PR DESCRIPTION
## Scope

Normalize the **Awareness** framework (`docs/pages/awareness/`).

## Why

Near-complete content already had KTs on child pages, but overview used a non-canonical Key Takeaway label, linked with `.mdx` suffixes, and lacked Related frameworks routing. Child KT copy used first-person.

## Content model applied

Framework overview + conceptual pages; preserve deep existing body prose; fix chrome and overview map.

## Changes

- overview rewrite chrome/map/related
- canonical KTs + `fact-checked: []` on all content pages

## Substantive security changes

**None.**

## Intentionally unchanged

- Long body sections on threat vectors, mindset, training, and resources lists (need steward refresh separately)
- Sidebar

## Validation

- [x] cspell
- [x] markdownlint-cli2
- [x] signed commit
- [x] no generated hand-edits

## Dependencies

**#561** by reference.

## Reviewer focus

- Overview objectives still match intent
- Related-framework routing for User/Team Security and Community Management