### PR TITLE
docs(secure-software-development): normalize structure and wording

### DIFF
--- a/docs/pages/secure-software-development/code-reviews-peer-audits.mdx
+++ b/docs/pages/secure-software-development/code-reviews-peer-audits.mdx
@@ -57,7 +57,7 @@ They reduce the chance that single-author blind spots ship into production.
    - Update checklists when incidents or near-misses reveal gaps.
    - Revisit tool rules when noise blocks real signal.
 
-## Further Reading & Tools
+## Further Reading
 
 - [OWASP Code Review Guide](https://owasp.org/www-project-code-review-guide/)
 - [Google Engineering Practices — Code Review](https://google.github.io/eng-practices/review/)

--- a/docs/pages/secure-software-development/code-reviews-peer-audits.mdx
+++ b/docs/pages/secure-software-development/code-reviews-peer-audits.mdx
@@ -1,9 +1,16 @@
 ---
-title: "Code Reviews & Peer Audits | Security Alliance"
-description: "Conduct effective security code reviews: use checklists for input validation, error handling, authentication. Automate with SonarQube, Checkmarx, Snyk. Foster collaborative peer audit culture."
+title: "Code Reviews and Peer Audits | SEAL"
+description: "Run security-focused code reviews with checklists, automated analysis, peer audits, tracked findings, and continuous improvement of the review process."
 tags:
   - Engineer/Developer
   - Security Specialist
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -13,44 +20,48 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Code reviews and peer audits help identifying and mitigating security vulnerabilities in software. They involve
-systematically examining code to ensure it adheres to the security standards and best practices of the project.
+> 🔑 **Key Takeaway**: Code reviews catch vulnerabilities early when security is an explicit checklist item, findings are
+> tracked to close, and automation backs human judgment.
 
-## Best Practices for Code Reviews
+Code reviews and peer audits systematically examine changes for security defects and project standards before merge.
+They reduce the chance that single-author blind spots ship into production.
 
-1. **Regular Reviews**
-   - Conduct code reviews regularly to identify and fix security vulnerabilities early in the development process.
-   - Integrate code reviews into the development workflow to make them a routine part of the process.
+## Best practices
 
-2. **Review Checklists**
-   - Use review checklists to ensure that all security aspects are covered during the review.
-   - Checklists should include common security issues such as input validation, error handling, and authentication.
+1. **Regular reviews**
+   - Review early and often; late mega-reviews hide issues.
+   - Make review a required workflow step for protected branches.
+2. **Review checklists**
+   - Cover security items: input handling, authz, crypto misuse, secrets, error paths, and dangerous defaults.
+   - Keep checklists short enough that reviewers actually use them.
+3. **Automated tools**
+   - Use static and dependency analysis to flag candidates for human attention.
+   - Examples practitioners use include SonarQube, Checkmarx, and Snyk—evaluate fit for the stack and false-positive load.
+4. **Peer audits**
+   - Have teammates review each other’s code for a second perspective.
+   - Rotate reviewers so knowledge and scrutiny spread across the team.
 
-3. **Automated Tools**
-   - Use automated code analysis tools to assist in identifying potential security vulnerabilities.
-   - Tools like SonarQube, Checkmarx, and Snyk can help in detecting issues that might be missed during manual reviews.
+## Conducting effective reviews
 
-4. **Peer Audits**
-   - Encourage peer audits where team members review each other's code.
-   - Peer audits provide a fresh perspective and can help identify issues that the original developer might overlook.
+1. **Focus on security**
+   - Explicitly prioritize security-relevant diffs, not only style.
+   - Hold changes to the project’s
+     [secure coding standards](/secure-software-development/secure-coding-standards-guidelines).
+2. **Collaborative approach**
+   - Treat review as joint quality work, not gatekeeping theater.
+   - Prefer specific, constructive comments tied to risk.
+3. **Document findings**
+   - Record issues and track resolution in the team’s issue system.
+   - Do not merge “we’ll fix later” critical findings without a tracked follow-up and acceptance criteria.
+4. **Continuous improvement**
+   - Update checklists when incidents or near-misses reveal gaps.
+   - Revisit tool rules when noise blocks real signal.
 
-## Conducting Effective Code Reviews
+## Further Reading & Tools
 
-1. **Focus on Security**
-   - Prioritize security issues during code reviews.
-   - Ensure that code follows secure coding standards and guidelines.
-
-2. **Collaborative Approach**
-   - Foster a collaborative environment where reviewers and developers work together to improve code quality.
-   - Provide constructive feedback and encourage open communication.
-
-3. **Document Findings**
-   - Document all findings from code reviews and track their resolution.
-   - Use issue tracking systems to manage identified vulnerabilities and ensure they are addressed.
-
-4. **Continuous Improvement**
-   - Continuously improve the code review process based on feedback and lessons learned.
-   - Regularly update review checklists and practices to keep up with evolving security threats.
+- [OWASP Code Review Guide](https://owasp.org/www-project-code-review-guide/)
+- [Google Engineering Practices — Code Review](https://google.github.io/eng-practices/review/)
+- Project [Security Testing](/security-testing/overview)
 
 ---
 

--- a/docs/pages/secure-software-development/code-reviews-peer-audits.mdx
+++ b/docs/pages/secure-software-development/code-reviews-peer-audits.mdx
@@ -6,7 +6,7 @@ tags:
   - Security Specialist
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/secure-software-development/overview.mdx
+++ b/docs/pages/secure-software-development/overview.mdx
@@ -59,7 +59,7 @@ It complements [DevSecOps](/devsecops/overview) (pipeline automation), [Supply C
 - [Security Automation](/security-automation/overview): continuous policy and scan automation
 - [External Security Reviews](/external-security-reviews/overview): third-party audits and assessments
 
-## Further Reading & Tools
+## Further Reading
 
 - [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/)
 - [OWASP Application Security Verification Standard](https://owasp.org/www-project-application-security-verification-standard/)

--- a/docs/pages/secure-software-development/overview.mdx
+++ b/docs/pages/secure-software-development/overview.mdx
@@ -7,7 +7,7 @@ tags:
   - DevOps
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/secure-software-development/overview.mdx
+++ b/docs/pages/secure-software-development/overview.mdx
@@ -1,10 +1,17 @@
 ---
 title: "Secure Software Development | SEAL"
-description: "Secure Software Development Framework: Integrate security throughout the SDLC with code reviews, secure coding standards, version control, threat modeling, and secure design principles."
+description: "Secure software development across the SDLC: coding standards, peer reviews, repository controls, and threat modeling with secure design principles."
 tags:
   - Engineer/Developer
   - Security Specialist
   - DevOps
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -14,10 +21,49 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Secure software development is the practice of integrating security measures throughout the entire software development
-lifecycle (SDLC). This approach ensures that software is designed, developed, and maintained with security in mind,
-protecting against vulnerabilities and threats. This section provides guidelines and best practices for secure software
-development, including code reviews, secure coding standards, version control, and threat modeling.
+> 🔑 **Key Takeaway**: Security in the software development lifecycle (SDLC) is continuous—design, code, review, and
+> repository controls—not a final gate before ship.
+
+Secure software development integrates security work throughout the SDLC so software is designed, built, and maintained
+with enforceable controls—not only late audits. This framework covers coding standards, peer review practices, version
+control hardening, and design-time threat modeling.
+
+It complements [DevSecOps](/devsecops/overview) (pipeline automation), [Supply Chain](/supply-chain/overview)
+(dependencies and build integrity), [Threat Modeling](/threat-modeling/overview) (broader modeling methods), and
+[External Security Reviews](/external-security-reviews/overview) (independent assessment).
+
+## Basics
+
+- **Shift decisions left:** fix classes of defect cheaper in design and review than in production response.
+- **Standards without enforcement fail:** branch protection, review requirements, and scanners must match written rules.
+- **Web3 raises stakes:** smart contracts and frontends that touch wallets make many bugs irreversible asset loss.
+
+## What this framework covers
+
+1. [Secure Coding Standards and Guidelines](/secure-software-development/secure-coding-standards-guidelines): input
+   validation, encoding, authz checks, error handling, least privilege in code, and secure data handling.
+2. [Code Reviews and Peer Audits](/secure-software-development/code-reviews-peer-audits): review cadence, checklists,
+   automation assist, and collaborative peer audit culture.
+3. [Secure Code Repositories and Version Control](/secure-software-development/secure-code-repositories-version-control):
+   access control, multi-factor authentication (MFA), branch protection, audit logs, commit signing, backups, CI/CD
+   security checks.
+4. [Threat Modeling and Secure Design Principles](/secure-software-development/threat-modeling-secure-design-principles):
+   asset/threat/risk/mitigation loops and durable design principles.
+
+## Related frameworks
+
+- [Threat Modeling](/threat-modeling/overview): dedicated modeling workflow and depth
+- [DevSecOps](/devsecops/overview): pipeline security and automation
+- [Supply Chain](/supply-chain/overview): dependency and build artifact integrity
+- [Security Testing](/security-testing/overview): dynamic and specialized testing beyond review
+- [Security Automation](/security-automation/overview): continuous policy and scan automation
+- [External Security Reviews](/external-security-reviews/overview): third-party audits and assessments
+
+## Further Reading & Tools
+
+- [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/)
+- [OWASP Application Security Verification Standard](https://owasp.org/www-project-application-security-verification-standard/)
+- [NIST SSDF (SP 800-218)](https://csrc.nist.gov/publications/detail/sp/800-218/final)
 
 ---
 

--- a/docs/pages/secure-software-development/secure-code-repositories-version-control.mdx
+++ b/docs/pages/secure-software-development/secure-code-repositories-version-control.mdx
@@ -55,7 +55,7 @@ code that becomes production artifacts.
      ([DevSecOps](/devsecops/overview), [Security Automation](/security-automation/overview)).
    - Deploy only builds that passed required checks and came from protected history.
 
-## Further Reading & Tools
+## Further Reading
 
 - [GitHub — About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
 - [GitLab — Protected branches](https://docs.gitlab.com/ee/user/project/protected_branches.html)

--- a/docs/pages/secure-software-development/secure-code-repositories-version-control.mdx
+++ b/docs/pages/secure-software-development/secure-code-repositories-version-control.mdx
@@ -7,7 +7,7 @@ tags:
   - DevOps
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/secure-software-development/secure-code-repositories-version-control.mdx
+++ b/docs/pages/secure-software-development/secure-code-repositories-version-control.mdx
@@ -1,10 +1,17 @@
 ---
-title: "Secure Code Repositories & Version Control | SEAL"
-description: "Secure code repositories: implement RBAC access controls, require MFA with hardware tokens, enable branch protection, audit logging, GPG commit signing, and integrate security into CI/CD pipelines."
+title: "Secure Code Repositories | SEAL"
+description: "Harden code repositories with RBAC, MFA, branch protection, audit logs, commit signing, secure backups, and security checks in CI/CD."
 tags:
   - Engineer/Developer
   - Security Specialist
   - DevOps
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -14,40 +21,45 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Managing secure code repositories and having version control practices helps protect your project from unauthorized
-access and ensuring the integrity of your project.
+> 🔑 **Key Takeaway**: Repository compromise is supply-chain compromise. Enforce least privilege, strong authentication,
+> protected branches, and review-required merges.
 
-## Best Practices for Secure Code Repositories
+Secure repositories and version control practices protect against unauthorized access and preserve integrity of the
+code that becomes production artifacts.
 
-1. **Access Control**
-   - Implement strict access controls to limit who can view, modify, and commit code.
-   - Use role-based access control (RBAC) to grant permissions based on the user's role within the organization.
+## Best practices for repositories
 
-2. **Multi-Factor Authentication (MFA)**
-   - Require MFA for all users accessing the code repository to add an extra layer of security.
-   - Use hardware tokens or authentication apps for stronger security.
+1. **Access control**
+   - Limit who can view, modify, and administer repositories.
+   - Use role-based access control (RBAC) aligned to job function ([IAM](/iam/overview)).
+2. **Multi-factor authentication (MFA)**
+   - Require MFA for all human access to the forge.
+   - Prefer hardware-backed second factors over SMS where available.
+3. **Branch protection**
+   - Protect default and release branches against force-push and unreviewed merges.
+   - Require reviews (and CI green status) before merge to protected branches.
+4. **Audit logs**
+   - Enable audit logging for administrative and access-sensitive events.
+   - Review logs on a cadence and on anomaly alerts.
 
-3. **Branch Protection**
-   - Enable branch protection rules to prevent unauthorized changes to critical branches such as main/master.
-   - Require code reviews and approvals by another person before changes can be merged into the main/master branch.
+## Version control practices
 
-4. **Audit Logs**
-   - Enable audit logging to track all activities within the repository.
-   - Regularly review logs to detect any suspicious activities or unauthorized access attempts.
+1. **Commit signing**
+   - Prefer signed commits (for example OpenPGP/SSH signing) so authors are cryptographically attributable.
+   - Enforce signing policy on critical repositories where tooling allows.
+2. **Regular backups**
+   - Back up repository data so history is not a single-host failure mode.
+   - Store backups with access controls comparable to production source.
+3. **CI/CD integration**
+   - Run security checks in continuous integration before deployable artifacts leave the pipeline
+     ([DevSecOps](/devsecops/overview), [Security Automation](/security-automation/overview)).
+   - Deploy only builds that passed required checks and came from protected history.
 
-## Secure Version Control Practices
+## Further Reading & Tools
 
-1. **Commit Signing**
-   - Require developers to sign their commits with GPG keys to verify the authenticity of the code changes.
-   - Enforce commit signing policies in the version control system.
-
-2. **Regular Backups**
-   - Regularly back up the code repository to prevent data loss.
-   - Store backups in a secure, offsite location.
-
-3. **Continuous Integration/Continuous Deployment (CI/CD)**
-   - Integrate security checks into the CI/CD pipeline to automatically scan code for vulnerabilities.
-   - Ensure that only tested and approved code is deployed to production.
+- [GitHub — About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
+- [GitLab — Protected branches](https://docs.gitlab.com/ee/user/project/protected_branches.html)
+- [Supply Chain framework](/supply-chain/overview)
 
 ---
 

--- a/docs/pages/secure-software-development/secure-coding-standards-guidelines.mdx
+++ b/docs/pages/secure-software-development/secure-coding-standards-guidelines.mdx
@@ -60,7 +60,7 @@ every stage of development. Adopt language- and stack-specific rules on top of t
    - Keep developers current on relevant vulnerability classes and internal standards.
    - Encourage participation in security communities and learning paths ([Awareness](/awareness/overview)).
 
-## Further Reading & Tools
+## Further Reading
 
 - [OWASP Top Ten](https://owasp.org/www-project-top-ten/)
 - [OWASP Cheat Sheet Series](https://cheatsheetseries.owasp.org/)

--- a/docs/pages/secure-software-development/secure-coding-standards-guidelines.mdx
+++ b/docs/pages/secure-software-development/secure-coding-standards-guidelines.mdx
@@ -1,9 +1,16 @@
 ---
-title: "Secure Coding Standards & Guidelines | SEAL"
-description: "Secure coding standards: input validation with whitelisting, output encoding, strong authentication, error handling. Follow least privilege, use vetted libraries, encrypt sensitive data."
+title: "Secure Coding Standards | SEAL"
+description: "Secure coding standards: validate inputs with allowlists, encode output, authenticate and authorize correctly, handle errors safely, and protect sensitive data."
 tags:
   - Engineer/Developer
   - Security Specialist
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -13,49 +20,51 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Using secure coding standards and guidelines increases the likelihood of you being resilient to security threats. Having
-these type of standards can help developers avoid common vulnerabilities, and help ensure that security is considered
-at every stage of development.
+> 🔑 **Key Takeaway**: Shared coding standards reduce common vulnerability classes when teams enforce them in review and
+> tooling—not only in a wiki page.
 
-## Secure Coding Standards
+Secure coding standards and guidelines help developers avoid common vulnerability classes and keep security visible at
+every stage of development. Adopt language- and stack-specific rules on top of these general controls.
 
-1. **Input Validation**
-   - Validate all inputs to ensure they conform to expected formats and ranges.
-   - Use whitelisting (allowing only known good inputs) rather than blacklisting.
+## Secure coding standards
 
-2. **Output Encoding**
-   - Encode output data.
-   - Use libraries and frameworks that provide built-in encoding functions.
+1. **Input validation**
+   - Validate all inputs against expected formats and ranges.
+   - Prefer allowlisting (only known-good inputs) over blocklisting alone.
+2. **Output encoding**
+   - Encode output appropriate to the sink (HTML, SQL parameters via APIs, etc.).
+   - Prefer frameworks and libraries with built-in safe encoding or parameterized interfaces.
+3. **Authentication and authorization**
+   - Use strong authentication appropriate to the risk (see [IAM](/iam/overview)).
+   - Enforce authorization checks on every privileged action—not only at the UI edge.
+4. **Error handling**
+   - Handle errors without leaking secrets, stack traces, or internal paths to users.
+   - Log detail securely for operators; show generic messages to end users.
 
-3. **Authentication and Authorization**
-   - Implement strong authentication mechanisms to verify user identities.
-   - Ensure proper authorization checks are in place to control access to resources based on user roles.
+## Guidelines
 
-4. **Error Handling**
-   - Handle errors gracefully without revealing sensitive information.
-   - Log errors securely and provide generic error messages to users.
+1. **Use secure libraries and frameworks**
+   - Prefer maintained libraries with a security track record and update cadence.
+   - Avoid deprecated or abandoned dependencies (see [Supply Chain](/supply-chain/overview)).
+2. **Follow least privilege**
+   - Grant code and service accounts only the access they need.
+   - Avoid running unrestricted privileges “for convenience.”
+3. **Secure data storage**
+   - Protect sensitive data at rest and in transit with appropriate cryptography ([Encryption](/encryption/overview)).
+   - Store credentials and secrets in purpose-built secret stores—not source control.
+4. **Regular code reviews**
+   - Review for security issues as part of normal merge process
+     ([Code Reviews and Peer Audits](/secure-software-development/code-reviews-peer-audits)).
+   - Use automated analysis to complement—not replace—human review.
+5. **Continuous security training**
+   - Keep developers current on relevant vulnerability classes and internal standards.
+   - Encourage participation in security communities and learning paths ([Awareness](/awareness/overview)).
 
-## Guidelines for Secure Coding
+## Further Reading & Tools
 
-1. **Use Secure Libraries and Frameworks**
-   - Use libraries and frameworks that have been vetted for security and are regularly updated.
-   - Avoid using deprecated or unmaintained libraries.
-
-2. **Follow Principle of Least Privilege**
-   - Grant the minimum level of access necessary for code to function.
-   - Avoid running code high privileges.
-
-3. **Secure Data Storage**
-   - Encrypt sensitive data both at rest and in transit.
-   - Use secure storage mechanisms for credentials and secrets.
-
-4. **Regular Code Reviews**
-   - Conduct regular code reviews to identify and fix security vulnerabilities.
-   - Use automated tools to complement manual code reviews.
-
-5. **Continuous Security Training**
-   - Provide ongoing security training for developers to keep them informed about the latest threats and best practices.
-   - Encourage participation in security communities and events.
+- [OWASP Top Ten](https://owasp.org/www-project-top-ten/)
+- [OWASP Cheat Sheet Series](https://cheatsheetseries.owasp.org/)
+- [CWE Top 25](https://cwe.mitre.org/top25/)
 
 ---
 

--- a/docs/pages/secure-software-development/secure-coding-standards-guidelines.mdx
+++ b/docs/pages/secure-software-development/secure-coding-standards-guidelines.mdx
@@ -6,7 +6,7 @@ tags:
   - Security Specialist
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/secure-software-development/threat-modeling-secure-design-principles.mdx
+++ b/docs/pages/secure-software-development/threat-modeling-secure-design-principles.mdx
@@ -57,7 +57,7 @@ assumptions. For broader organizational threat-modeling practice, see the dedica
 6. **Secure by design**
    - Treat security as a first-class design constraint at every major architecture decision.
 
-## Further Reading & Tools
+## Further Reading
 
 - [Threat Modeling framework](/threat-modeling/overview)
 - [OWASP Threat Modeling](https://owasp.org/www-community/Threat_Modeling)

--- a/docs/pages/secure-software-development/threat-modeling-secure-design-principles.mdx
+++ b/docs/pages/secure-software-development/threat-modeling-secure-design-principles.mdx
@@ -1,9 +1,16 @@
 ---
-title: "Threat Modeling & Secure Design | SEAL"
-description: "Identify and mitigate security threats during the design phase using STRIDE methodology and secure design principles like least privilege, defense in depth, and fail securely."
+title: "Threat Modeling and Secure Design | SEAL"
+description: "Identify and mitigate design-time threats with STRIDE-style modeling and secure design principles: least privilege, defense in depth, fail securely, and secure defaults."
 tags:
   - Engineer/Developer
   - Security Specialist
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -13,55 +20,49 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Threat modeling and secure design principles help identify and mitigating potential security threats during the design
-phase of software development. T
+> 🔑 **Key Takeaway**: Threat modeling before build chooses which controls matter. Secure design principles keep residual
+> risk from depending on a single lucky check.
 
-## Threat Modeling
+Threat modeling and secure design identify and mitigate security threats during design—before code cements bad
+assumptions. For broader organizational threat-modeling practice, see the dedicated
+[Threat Modeling](/threat-modeling/overview) framework.
 
-1. **Identify Assets**
-   - Determine the valuable assets that need protection, such as user funds, sensitive data, user credentials, and
-   intellectual property.
+## Threat modeling
 
-2. **Identify Threats**
-   - Identify potential threats to the assets using models like STRIDE (Spoofing, Tampering, Repudiation, Information
-   Disclosure, Denial of Service, Elevation of Privilege).
+1. **Identify assets**
+   - Name what needs protection: user funds, sensitive data, credentials, admin keys, intellectual property, and
+     reputation-critical services.
+2. **Identify threats**
+   - Enumerate threats against those assets. STRIDE (Spoofing, Tampering, Repudiation, Information Disclosure, Denial of
+     Service, Elevation of Privilege) is one common structure—not the only valid one.
+3. **Assess risks**
+   - Rank threats by likelihood and impact in the real deployment context.
+4. **Develop mitigations**
+   - Design controls that reduce the top risks first; accept residual risk consciously.
+5. **Validate and iterate**
+   - Update the model as architecture, trust boundaries, and assets change.
 
-3. **Assess Risks**
-   - Evaluate the risks associated with each identified threat based on its likelihood and potential impact.
+## Secure design principles
 
-4. **Develop Mitigations**
-   - Design and implement security controls to mitigate the identified threats. Prioritize mitigations based on the
-   assessed risks.
+1. **Least privilege**
+   - Grant users and systems only the access required for the function.
+2. **Defense in depth**
+   - Layer independent controls so single failures do not equal total loss.
+3. **Fail securely**
+   - On error, prefer closed/safe states; do not leak secrets in failure paths.
+4. **Secure defaults**
+   - Ship restrictive defaults; require deliberate action to weaken security.
+5. **Separation of duties**
+   - Split powerful actions so one person or service cannot unilaterally abuse the system.
+6. **Secure by design**
+   - Treat security as a first-class design constraint at every major architecture decision.
 
-5. **Validate and Iterate**
-   - Regularly validate the threat model and update it as the application evolves. Continuously assess and improve
-   security measures.
+## Further Reading & Tools
 
-## Secure Design Principles
-
-1. **Principle of Least Privilege**
-   - Grant users and systems the minimum level of access necessary to perform their functions. Reduce the attack surface
-   by limiting permissions.
-
-2. **Defense in Depth**
-   - Implement multiple layers of security controls to protect against different types of threats. Ensure that security
-   is not reliant on a single control.
-
-3. **Fail Securely**
-   - Design systems to fail in a secure manner. Ensure that errors and failures do not expose sensitive information or
-   create security vulnerabilities.
-
-4. **Secure Defaults**
-   - Configure systems with secure default settings. Require users to opt into less secure configurations rather than
-   opting into secure ones.
-
-5. **Separation of Duties**
-   - Separate critical functions to prevent a single individual or system from having excessive control. Implement
-   checks and balances.
-
-6. **Secure by Design**
-   - Integrate security into the design and architecture of the application. Consider security implications during every
-   stage of the design process.
+- [Threat Modeling framework](/threat-modeling/overview)
+- [OWASP Threat Modeling](https://owasp.org/www-community/Threat_Modeling)
+- [Microsoft SDL — Threat modeling](https://www.microsoft.com/en-us/securityengineering/sdl/threatmodeling)
+- [NIST SSDF (SP 800-218)](https://csrc.nist.gov/publications/detail/sp/800-218/final)
 
 ---
 

--- a/docs/pages/secure-software-development/threat-modeling-secure-design-principles.mdx
+++ b/docs/pages/secure-software-development/threat-modeling-secure-design-principles.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Threat Modeling and Secure Design | SEAL"
-description: "Identify and mitigate design-time threats with STRIDE-style modeling and secure design principles: least privilege, defense in depth, fail securely, and secure defaults."
+description: "Identify and mitigate design-time threats with STRIDE-style modeling and secure design principles: least privilege, defense in depth, fail securely"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/secure-software-development/threat-modeling-secure-design-principles.mdx
+++ b/docs/pages/secure-software-development/threat-modeling-secure-design-principles.mdx
@@ -6,7 +6,7 @@ tags:
   - Security Specialist
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked


### PR DESCRIPTION
## Scope

Normalize **Secure Software Development** (`docs/pages/secure-software-development/`).

## Why

Thin overview; missing KT/contributors/page map; grammar issues; truncated sentence on threat-modeling page (“T”).

## Content model applied

Framework overview + conceptual/procedure hybrid children; related routing to threat-modeling, DevSecOps, supply-chain.

## Substantive security changes

**None.** Editorial/structural only.

## Intentionally unchanged

- Sidebar (`dev: true`)
- Generated `index.mdx`

## Validation

- [x] cspell
- [x] markdownlint-cli2
- [x] signed commit

## Dependencies

**#561** by reference.