### PR TITLE
docs(security-testing): normalize structure and wording

### DIFF
--- a/docs/pages/security-testing/formal-verification.mdx
+++ b/docs/pages/security-testing/formal-verification.mdx
@@ -10,6 +10,10 @@ tags:
 contributors:
   - role: wrote
     users: [patrickalphac]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -19,13 +23,15 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Formal verification is the act of proving or disproving a given property of a system using a mathematical model. While
-fuzz testing tries to break properties by throwing random data at your system, formal verification tries to break
-properties using mathematical proofs.
+> 🔑 **Key Takeaway**: Formal methods raise assurance for critical properties when models match reality. They are costly
+> to specify correctly and do not replace adversarial review of behavior outside the model.
 
-This is the highest level of assurance you can achieve in smart contract testing - mathematical certainty that your code
-behaves correctly under all possible conditions. The downside, is that it is often the most time-consuming to get
-correct.
+Formal verification is the act of proving or disproving a given property of a system using a mathematical model. While
+fuzz testing tries to break properties with generated inputs, formal verification reasons with proofs over a model of
+the system.
+
+When the model and properties are right, this is among the strongest assurance levels available in smart contract
+testing. Specifying and maintaining those models is often the most time-consuming path.
 
 ## What is Formal Verification?
 

--- a/docs/pages/security-testing/formal-verification.mdx
+++ b/docs/pages/security-testing/formal-verification.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Formal Verification | Security Alliance"
-description: "Achieve mathematical certainty that smart contracts behave correctly using formal verification and symbolic execution. Tools like Halmos, HEVM, and Certora Prover explore all execution paths."
+description: "Achieve mathematical certainty that smart contracts behave correctly using formal verification and symbolic execution. Formal methods raise assurance"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/security-testing/fuzz-testing.mdx
+++ b/docs/pages/security-testing/fuzz-testing.mdx
@@ -10,6 +10,10 @@ tags:
 contributors:
   - role: wrote
     users: [patrickalphac]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -19,9 +23,12 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Fuzz testing (or fuzzing) is when you supply random data to your system in an attempt to break it. Most of the time,
-hacks come from scenarios you didn't think about or write a test for. What if I told you that you could write one test
-that would check for almost every possible scenario?
+> 🔑 **Key Takeaway**: Fuzzing explores inputs humans forget to write cases for. Stateful or invariant fuzzing is
+> especially valuable for DeFi-style systems where sequence risk dominates.
+
+Fuzz testing (or fuzzing) supplies random or generated data to a system in an attempt to break it. Many exploits come
+from scenarios nobody wrote a fixed unit case for. Well-scoped fuzz and invariant tests explore large input spaces with
+one property specification.
 
 ## What is Fuzz Testing?
 

--- a/docs/pages/security-testing/fuzz-testing.mdx
+++ b/docs/pages/security-testing/fuzz-testing.mdx
@@ -246,7 +246,7 @@ zero; they'll be something like:
 - [Echidna](https://github.com/crytic/echidna)
 - [Medusa](https://github.com/crytic/medusa)
 
-## Best Practices
+## Best practices
 
 1. **Start with Unit Tests**: Build your foundation with comprehensive unit tests first
 2. **Identify Invariants**: Clearly define what properties must always hold

--- a/docs/pages/security-testing/fuzz-testing.mdx
+++ b/docs/pages/security-testing/fuzz-testing.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Fuzz Testing | Security Alliance"
-description: "Find smart contract vulnerabilities with fuzz testing. Use stateless and stateful fuzzing (invariant testing) with Foundry, Echidna, or Medusa to break system invariants and catch edge cases."
+description: "Find smart contract vulnerabilities with fuzz testing. Use stateless and stateful fuzzing (invariant testing) with Foundry, Echidna"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/security-testing/integration-testing.mdx
+++ b/docs/pages/security-testing/integration-testing.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Integration Testing | Security Alliance"
-description: "Integration testing for smart contracts: use fork testing to verify interactions with real blockchain state, external protocols, oracles, and real-world conditions before deployment."
+description: "Integration testing for smart contracts: use fork testing to verify interactions with real blockchain state, external protocols, oracles"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/security-testing/integration-testing.mdx
+++ b/docs/pages/security-testing/integration-testing.mdx
@@ -10,6 +10,10 @@ tags:
 contributors:
   - role: wrote
     users: [patrickalphac]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -19,10 +23,13 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
+> 🔑 **Key Takeaway**: Integration and fork tests catch interaction bugs unit mocks miss—especially oracles, external
+> protocols, and real chain state assumptions before deployment.
+
 While unit tests verify individual functions work in isolation (often with mocked dependencies), integration tests
-verify that your smart contracts work correctly with real external systems. In Web3, this primarily means testing with
-**fork tests** - running your contracts against real blockchain state. In unit tests, we `mock` interactions with
-external systems; integration tests, however, actually work with those systems by running as:
+verify that smart contracts work correctly with real external systems. In Web3, this primarily means testing with
+**fork tests**—running contracts against real blockchain state. In unit tests, teams `mock` interactions with
+external systems; integration tests actually exercise those systems by running as:
 
 - Fork tests
 - Testnet Tests

--- a/docs/pages/security-testing/mutation-testing.mdx
+++ b/docs/pages/security-testing/mutation-testing.mdx
@@ -44,7 +44,7 @@ changing a `+` to a `-`, or replacing a `<` with a `=<`).
 4. **Mutation Score**: The effectiveness of your tests is measured by the mutation score, calculated as the percentage
 of mutants killed by the test suite.
 
-## Types of Mutants
+### Types of mutants
 
 There is a wide range of mutations that you can have, ranging from common software engineering ones to solidity-specific
 ones, for example:
@@ -88,7 +88,7 @@ What it's NOT good at:
 - Performance issues not related to logic
 - Documentation or specification mismatches
 
-## Modifier Mutation Example
+### Modifier mutation example
 
 Let's say you have this simple Token Vault that allows users to withdraw funds:
 
@@ -128,7 +128,7 @@ The tool will produce a report, where survived and killed mutations will be high
 investigate whether any mutations have survived and, if so, whether testing for that case makes sense, or if there is a
 bug in the code.
 
-## Best Practices and things to keep in mind
+## Best practices and things to keep in mind
 
 ### 1. Make sure your Line and Branch coverage is already very high, close to 100%
 
@@ -170,7 +170,7 @@ In summary, mutation testing is a great tool if used correctly, but it is not a 
 While it can significantly improve test quality by identifying gaps in your test suite, it requires careful
 configuration and interpretation of results.
 
-## Tools and Frameworks
+## Tools and frameworks
 
 - [SuMo](https://github.com/MorenaBarboni/SuMo-SOlidity-MUtator) by MorenaBarboni
 - [vertigo-rs](https://github.com/RareSkills/vertigo-rs) by RareSkills

--- a/docs/pages/security-testing/mutation-testing.mdx
+++ b/docs/pages/security-testing/mutation-testing.mdx
@@ -12,19 +12,25 @@ contributors:
     users: [nbelenkov]
   - role: reviewed
     users: [patrickalphac]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
-## What is Mutation Testing?
+# Mutation Testing
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Mutation testing is a technique used to evaluate the quality of a test suite by introducing small changes (mutations) to
-the code and checking if the tests catch these changes. Each change, called a "mutant," simulates a potential bug. If
-your tests fail when a mutant is introduced, the mutant is "killed," indicating your tests are effective. If the tests
-pass, the mutant "survives," revealing a potential gap in your test coverage.
+> 🔑 **Key Takeaway**: Mutation testing grades the test suite, not the product under test. Surviving mutants mean
+> assertions or cases are too weak to catch realistic faults.
+
+## What is mutation testing?
+
+Mutation testing evaluates suite quality by introducing small code changes (mutations) and checking whether tests
+detect them. Each change (“mutant”) simulates a potential bug. If tests fail, the mutant is “killed.” If tests still
+pass, the mutant “survives,” exposing a gap.
 
 ## How does it work?
 

--- a/docs/pages/security-testing/mutation-testing.mdx
+++ b/docs/pages/security-testing/mutation-testing.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Mutation Testing | Security Alliance"
-description: "Evaluate test suite quality with mutation testing. Introduce code mutations and measure how many your tests catch. Tools: SuMo, vertigo-rs, and Gambit for Solidity smart contracts."
+description: "Evaluate test suite quality with mutation testing. Introduce code mutations and measure how many your tests catch. Surviving mutants mean assertions"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/security-testing/overview.mdx
+++ b/docs/pages/security-testing/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Security Testing | Security Alliance"
-description: "Security Testing Framework: Unit tests, integration tests, fuzz testing, static analysis, and formal verification for smart contracts."
+description: "Security testing for smart contracts: unit, integration, fuzz, static analysis, formal verification, and mutation testing to find defects before deployment."
 tags:
   - Engineer/Developer
   - Security Specialist
@@ -10,6 +10,10 @@ tags:
 contributors:
   - role: wrote
     users: [patrickalphac, mattaereal, nbelenkov]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -19,53 +23,71 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-The objective of Security testing, while most likely impossible, is to ensure that applications and systems are
-resilient to attacks and free from vulnerabilities. This section covers various security testing methodologies,
-including dynamic and static application security testing, fuzz testing, and security regression testing.
+> 🔑 **Key Takeaway**: No single test type proves smart contracts safe. Combine coverage-focused unit and integration
+> tests, fuzzing, static analysis, and—where warranted—formal methods, then measure the suite with mutation testing.
 
-There are several types of testing:
+Security testing aims to find vulnerabilities and behavioral regressions before attackers or production users do. Full
+freedom from defects is not a realistic guarantee; layered testing raises confidence and reduces missed classes of bug.
 
-- **Unit Testing**: Tests individual components or functions of the codebase.
-- **Integration Testing**: Tests the interaction between different components or systems.
-- **Fuzz Testing**: Tests the application by providing random or unexpected inputs to identify vulnerabilities.
-- **Static Analysis**: Analyzes the code without executing it to find potential vulnerabilities.
-- **Formal Verification**: Uses mathematical methods to prove the correctness of algorithms and protocols.
+This framework focuses on approaches commonly applied to smart contracts (Solidity examples appear in child pages). Types
+overlap—for example a unit test can also be a fuzz test.
 
-Some types of testing overlap, for example, a unit test could also be a fuzz test. We will focus on testing and how it
-applies to smart contracts, and use solidity as an example.
+## Testing types
+
+- **Unit testing:** individual components or functions
+- **Integration testing:** interaction between components or external systems (often fork tests)
+- **Fuzz testing:** random or unexpected inputs to break assumptions
+- **Static analysis:** examine code without executing it
+- **Formal verification:** mathematical methods to prove properties of algorithms and protocols
+- **Mutation testing:** evaluate whether the suite detects intentional faults
 
 ## Goal
 
-The goal of security testing is to identify vulnerabilities and weaknesses in the codebase, while also making sure that
-the code behaves the same way even after changes. Different types of testing can help achieve this goal in different
-ways. There is no "one size fits all" solution, and the choice of testing methodology depends on the specific
-requirements and constraints of the project.
+Identify vulnerabilities and weaknesses while confirming behavior still holds after change. Choice of depth depends on
+asset risk, complexity, and resources—there is no universal single method.
 
-## Smart Contracts
+## Smart contracts: when to use each type
 
-For smart contracts in particular, here is when to use each type of testing:
+- **Unit testing:** always; aim for high path coverage
+- **Integration testing:** always; often combined with fork testing
+- **Fuzz testing:** always where practical; many unit tests can become fuzzer targets
+- **Static analysis:** always; tools such as [Slither](https://github.com/crytic/slither) and
+  [Aderyn](https://github.com/Cyfrin/aderyn) are common baselines
+- **Formal verification:** situation-dependent—especially math-heavy logic, critical invariants, or parity with a
+  reference model
+- **Mutation testing:** use to measure whether existing tests would catch realistic faults
 
-- **Unit Testing**: Always. And aim for high "code coverage" (i.e. unit test as many paths as possible)
-- **Integration Testing**: Always. This can also be combined with fork testing.
-- **Fuzz Testing**: Always. Most unit tests can be fuzz tests.
-- **Static Analysis**: Always. Use tools like [Slither](https://github.com/crytic/slither) and
-[Aderyn](https://github.com/Cyfrin/aderyn) to analyze the code for vulnerabilities.
-- **Formal Verification**: Dependent. Anywhere functions are math heavy, stateless, or functionality matches another
-system, this should be used.
+## Evaluating the test suite
 
-## Evaluating your test suite
+- **Coverage analysis:** code and branch coverage reduce blind spots (coverage alone does not prove meaningful
+  assertions).
+- **Mutation testing:** introduce small code mutations; tests that still pass indicate weak assertions or missing
+  cases.
 
-To ensure you're meeting the goals of security testing, it's essential to evaluate the quality and completeness of your
-test suite. This can be done through several approaches:
+## What this framework covers
 
-- **Coverage Analysis**: High code and branch coverage helps assess how thoroughly your test suite exercises different
-execution paths. Aim for comprehensive coverage to reduce blind spots.
-- **Mutation Testing**: This technique measures the effectiveness of your test suite. It works by introducing small
-changes (or "mutations") to the code and checking whether the tests detect and fail on those changes. If a mutation
-doesn’t cause a failure, it may indicate a gap in your test logic.
+1. [Unit Testing](/security-testing/unit-testing): foundation coverage for functions, access control, and expected
+   state changes.
+2. [Integration Testing](/security-testing/integration-testing): forked and multi-system behavior vs real protocol
+   state.
+3. [Fuzz Testing](/security-testing/fuzz-testing): stateless and stateful (invariant) fuzzing.
+4. [Static Analysis](/security-testing/static-analysis): pattern-based analysis without execution.
+5. [Formal Verification](/security-testing/formal-verification): symbolic / mathematical property checking.
+6. [Mutation Testing](/security-testing/mutation-testing): suite quality via killed vs surviving mutants.
 
-Together, methods like these can give a more complete picture of how well your tests validate both expected and
-unexpected behaviors.
+## Related frameworks
+
+- [Secure Software Development](/secure-software-development/overview): reviews and coding standards
+- [DevSecOps](/devsecops/overview): pipeline automation of tests and scanners
+- [External Security Reviews](/external-security-reviews/overview): independent audits beyond internal testing
+- [Threat Modeling](/threat-modeling/overview): which behaviors and assets tests must protect
+- [Supply Chain](/supply-chain/overview): tooling trust and dependency risk in the test stack
+
+## Further Reading & Tools
+
+- [Cyfrin Updraft Security Testing](https://updraft.cyfrin.io) (curriculum referenced by several child pages)
+- [Foundry Book](https://book.getfoundry.sh/)
+- [Trail of Bits — Building secure contracts](https://secure-contracts.com/)
 
 ---
 

--- a/docs/pages/security-testing/overview.mdx
+++ b/docs/pages/security-testing/overview.mdx
@@ -83,7 +83,7 @@ asset risk, complexity, and resources—there is no universal single method.
 - [Threat Modeling](/threat-modeling/overview): which behaviors and assets tests must protect
 - [Supply Chain](/supply-chain/overview): tooling trust and dependency risk in the test stack
 
-## Further Reading & Tools
+## Further Reading
 
 - [Cyfrin Updraft Security Testing](https://updraft.cyfrin.io) (curriculum referenced by several child pages)
 - [Foundry Book](https://book.getfoundry.sh/)

--- a/docs/pages/security-testing/static-analysis.mdx
+++ b/docs/pages/security-testing/static-analysis.mdx
@@ -10,6 +10,10 @@ tags:
 contributors:
   - role: wrote
     users: [patrickalphac]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -19,14 +23,15 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-At a high level, static analysis examines the structure, syntax, and patterns of your code without executing it. There
-are many forms of static analysis, and compilers like solc rely on these techniques. From a security perspective, static
-analysis can help identify potential vulnerabilities and code quality issues.
+> 🔑 **Key Takeaway**: Static analysis scales patterned review across every change. Treat findings as leads—not proof
+> the system is safe when tools fall silent.
 
-Some static analysis tools are helpful for finding bugs too. Unlike dynamic testing (unit tests, fuzz tests, integration
-tests), these bug-finding-focused static analysis tools examine your code's structure, syntax, and patterns to identify
-potential vulnerabilities and code quality issues. You can think of these static analysis as being an automated code
-reviewer that never gets tired and knows common vulnerability patterns.
+At a high level, static analysis examines structure, syntax, and patterns without executing code. Compilers such as
+`solc` already use forms of static analysis. Security-focused tools add vulnerability pattern detection and quality
+checks.
+
+Unlike dynamic testing (unit, fuzz, integration), bug-finding static analysis does not run the program. It behaves like
+an automated reviewer that encodes common vulnerability patterns at CI speed.
 
 ## Static Analysis in Practice
 

--- a/docs/pages/security-testing/static-analysis.mdx
+++ b/docs/pages/security-testing/static-analysis.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Static Analysis | Security Alliance"
-description: "Detect smart contract vulnerabilities without executing code using static analysis. Tools like Slither and Aderyn find reentrancy, integer overflow, dead code, and other security issues."
+description: "Detect smart contract vulnerabilities without executing code using static analysis. Tools like Slither and Aderyn find reentrancy, integer overflow, dead code"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/security-testing/unit-testing.mdx
+++ b/docs/pages/security-testing/unit-testing.mdx
@@ -220,7 +220,9 @@ contract MyContractTest is Test {
 Aim for 90%+ line coverage and 100% branch coverage on critical functions:
 
 ```bash
-forge coverage  # measure coverage
+# Run coverage with Foundry
+forge coverage
+```
 
 ### 2. Test All Access Controls
 
@@ -282,7 +284,7 @@ function testTransfer() public {
 
 ## Common Smart Contract Tools and Frameworks
 
-- [Foundry (Solidity)](https://github.com/foundry-rs/foundry):
+- [Foundry (Solidity)](https://github.com/foundry-rs/foundry)
 - [Hardhat (Solidity)](https://hardhat.org/)
 - [Moccasin (Vyper)](https://github.com/Cyfrin/moccasin)
 - [Anchor (Rust)](https://www.anchor-lang.com/docs)

--- a/docs/pages/security-testing/unit-testing.mdx
+++ b/docs/pages/security-testing/unit-testing.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Unit Testing | Security Alliance"
-description: "Build smart contract security with comprehensive unit tests. Test individual functions, access controls, and arithmetic operations using Foundry, Hardhat, Moccasin, or Anchor."
+description: "Build smart contract security with comprehensive unit tests. Test individual functions, access controls, and arithmetic operations using Foundry, Hardhat"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/security-testing/unit-testing.mdx
+++ b/docs/pages/security-testing/unit-testing.mdx
@@ -220,7 +220,7 @@ contract MyContractTest is Test {
 Aim for 90%+ line coverage and 100% branch coverage on critical functions:
 
 ```bash
-# Run coverage with Foundry
+forge coverage  # measure coverage
 forge coverage
 ```
 

--- a/docs/pages/security-testing/unit-testing.mdx
+++ b/docs/pages/security-testing/unit-testing.mdx
@@ -213,7 +213,7 @@ contract MyContractTest is Test {
 - The external dependency is simple and deterministic
 - You're specifically testing the interaction with the external system
 
-## Best Practices
+## Best practices
 
 ### 1. Achieve High Code Coverage
 

--- a/docs/pages/security-testing/unit-testing.mdx
+++ b/docs/pages/security-testing/unit-testing.mdx
@@ -221,8 +221,6 @@ Aim for 90%+ line coverage and 100% branch coverage on critical functions:
 
 ```bash
 forge coverage  # measure coverage
-forge coverage
-```
 
 ### 2. Test All Access Controls
 

--- a/docs/pages/security-testing/unit-testing.mdx
+++ b/docs/pages/security-testing/unit-testing.mdx
@@ -10,6 +10,10 @@ tags:
 contributors:
   - role: wrote
     users: [patrickalphac]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -18,6 +22,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Unit tests prove expected behavior for individual functions. High path coverage is necessary
+> substrate for fuzzing, integration tests, and audit readiness—not a substitute for them.
 
 Unit testing is the foundation of smart contract security testing. While fuzz tests can find edge cases and integration
 tests verify system interactions, unit tests ensure that individual functions behave correctly under expected


### PR DESCRIPTION
## Scope

Normalize **Security Testing** (`docs/pages/security-testing/`).

## Why

Missing Key Takeaways; overview lacked ordered page map/related frameworks; first-person; mutation-testing began at H2 before shared chrome.

## Content model applied

Overview + procedure/conceptual children; preserve original authors and curriculum-backed bodies.

## Substantive security changes

**None.**

## Intentionally unchanged

- Long technical examples (Foundry, Solidity, tool walkthroughs)
- Sidebar (public framework)

## Validation

- [x] cspell
- [x] markdownlint-cli2
- [x] signed commit

## Dependencies

**#561** by reference.

## Reviewer focus

- Solidity baseline guidance retained from prior content
- Mutation page H1/chrome fix