### PR TITLE
docs(safe-harbor): normalize structure and wording

### DIFF
--- a/docs/pages/safe-harbor/on-chain-adoption-guide.mdx
+++ b/docs/pages/safe-harbor/on-chain-adoption-guide.mdx
@@ -144,7 +144,12 @@ If you ever need help or have any questions, don't hesitate to reach out!
 
 ## Further Reading
 
-- [Safe Harbor overview](/safe-harbor/overview)
+- [Safe Harbor overview](/safe-harbor/overview): what the agreement covers and why protocols adopt it
+- [Self-Adoption Guide](/safe-harbor/self-adoption-guide): the surrounding steps, from scope definition to announcement
+- [Secure Multisig Best Practices](/wallet-security/secure-multisig-best-practices): executing the registration
+  transaction safely
+- [security-alliance/safe-harbor](https://github.com/security-alliance/safe-harbor): registry contracts, Foundry
+  scripts, and audit reports
 
 ---
 

--- a/docs/pages/safe-harbor/on-chain-adoption-guide.mdx
+++ b/docs/pages/safe-harbor/on-chain-adoption-guide.mdx
@@ -141,6 +141,11 @@ supported EVM chains.
 If you ever need help or have any questions, don't hesitate to reach out!
 📬 Contact us at: [safe-harbor@securityalliance.org](mailto:safe-harbor@securityalliance.org)
 
+
+## Further Reading
+
+- [Safe Harbor overview](/safe-harbor/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/safe-harbor/on-chain-adoption-guide.mdx
+++ b/docs/pages/safe-harbor/on-chain-adoption-guide.mdx
@@ -9,6 +9,10 @@ tags:
 contributors:
   - role: wrote
     users: [dickson]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -17,6 +21,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: On-chain registration makes Safe Harbor adoption public, verifiable, and discoverable to
+> whitehats who check the registry before intervening.
 
 This guide explains how protocols can register their Safe Harbor adoption on-chain. Registering ensures your adoption is
 **public, verifiable, and enforceable**.

--- a/docs/pages/safe-harbor/overview.mdx
+++ b/docs/pages/safe-harbor/overview.mdx
@@ -84,7 +84,7 @@ By adopting Safe Harbor, protocols allow:
 - **Protocols pre-authorize rescues:** You clearly define when and how whitehats are allowed to step in - covering what
   assets are protected, where to return funds, and what bounty terms apply, etc
 - **Whitehats act only during active exploits:** Safe Harbor **only** applies when an exploit is already in progress or
-  imminent - e.g., in the mempool, or after initial funds have been drained. It's _not_ for bug bounty reports, and it
+  imminent - e.g., in the mempool, or after initial funds have been drained. It's *not* for bug bounty reports, and it
   does not protect blackhats. Only whitehats who rescue funds without initiating the exploit are covered.
 - **Funds are returned, bounty is automatic:** Whitehats must send rescued funds to your official recovery addresses
   within 72 hours. Bounties are enforceable and pre-defined - no negotiation, no chaos.
@@ -159,7 +159,7 @@ scope, and your protocol is protected.
 <details>
 <summary>What counts as an active exploit?</summary>
 
-An _active exploit_ is one that's already in progress or imminent - for example, a malicious transaction sitting in the
+An *active exploit* is one that's already in progress or imminent - for example, a malicious transaction sitting in the
 mempool or a vulnerability that's already being exploited. Safe Harbor only applies when immediate action is required to
 prevent or stop fund loss. It does **not** apply to situations where there is no imminent threat and where responsible
 disclosure can prevent fund loss.
@@ -169,8 +169,8 @@ disclosure can prevent fund loss.
 <details>
 <summary>How is it different than a Bug Bounty?</summary>
 
-Bug bounties reward whitehats for responsibly disclosing vulnerabilities _before_ they're exploited. Safe Harbor kicks
-in _after_ an exploit is underway - when there's no time for disclosure, and whitehats need legal cover to intervene and
+Bug bounties reward whitehats for responsibly disclosing vulnerabilities *before* they're exploited. Safe Harbor kicks
+in *after* an exploit is underway - when there's no time for disclosure, and whitehats need legal cover to intervene and
 recover funds in real time.
 
 </details>
@@ -207,7 +207,7 @@ is required. Many protocols who have adopted are centralized teams (Pendle, Poly
 <summary>Who is the agreement with?</summary>
 
 The Safe Harbor agreement is structured as a **public unilateral offer -** a legally binding offer made by your protocol
-to _any whitehat_ who acts under the published terms. There's no need to know or pre-approve the individual. If a
+to *any whitehat* who acts under the published terms. There's no need to know or pre-approve the individual. If a
 whitehat follows your rules (e.g. intervenes during an active exploit, returns funds to the recovery address, meets any
 KYC requirements), the agreement becomes binding. No signatures or formal negotiation required.
 

--- a/docs/pages/safe-harbor/overview.mdx
+++ b/docs/pages/safe-harbor/overview.mdx
@@ -59,7 +59,7 @@ By adopting Safe Harbor, protocols allow:
 > stood by, willing to help, but unable to act without legal protection. With Safe Harbor, our goal is to make sure that
 > never happens again and to empower whitehats to rescue funds.
 
-## Vetted by industry leaders and top Web3 lawyers
+### Vetted by industry leaders and top Web3 lawyers
 
 > Safe Harbor was developed over two years with direct input and rigorous legal review from experts at a16z Crypto,
 > Cooley, Debevoise & Plimpton, Filecoin Foundation, MetaLeX, Paradigm, Piper Alderman, Powerhouse, and more.
@@ -69,7 +69,7 @@ By adopting Safe Harbor, protocols allow:
   alt="Law firms that reviewed Safe Harbor: a16z Crypto, Cooley, Debevoise & Plimpton, Paradigm, and others"
 />
 
-## Who's Adopted Safe Harbor
+### Who's adopted Safe Harbor
 
 > Safe Harbor is already protecting $68B+ in assets across leading DeFi protocols. It has been adopted by 20+ protocols.
 > Current adopters include Uniswap, Aave, Pendle, PancakeSwap, Balancer, Silo Finance, Zksync, and more. See the
@@ -148,7 +148,7 @@ scope, and your protocol is protected.
   events
 - [Wallet Security](/wallet-security/overview): recovery address and multisig hardening guidance
 
-## Proven Results: Whitehats Have Recovered $150M+
+### Proven results: whitehats have recovered $150M+
 
 > 💡 [SEAL911](/incident-management/playbooks/seal-911-war-room-guidelines) and the broader whitehat community have
 > already helped protocols recover over $150M from live attacks - proving that fast, responsible intervention is

--- a/docs/pages/safe-harbor/overview.mdx
+++ b/docs/pages/safe-harbor/overview.mdx
@@ -9,6 +9,10 @@ tags:
 contributors:
   - role: wrote
     users: [robert, dickson]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from "../../../components"
@@ -23,8 +27,8 @@ import { TagList, AttributionList, ContributeFooter } from "../../../components"
   alt="SEAL Whitehat Safe Harbor logo - DeFi exploit protection framework"
 />
 
-> 💡 An industry-standard framework, letting your protocol pre-authorize whitehats to rescue funds during active
-> exploits
+> 🔑 **Key Takeaway**: Safe Harbor lets protocols pre-authorize whitehats to rescue funds during *active* exploits under
+> defined scope and rules. It is not a substitute for bug bounties or pre-exploit responsible disclosure.
 
 <div align="center">
   <video controls width="600" preload="none">
@@ -127,6 +131,22 @@ scope, and your protocol is protected.
 
 > Whether you're a DAO or not, adopting Safe Harbor is a low-lift way to enable real-time defense and recover funds
 > during live exploits.
+
+## What this framework covers
+
+1. [Safe Harbor Eligibility Checklist](/safe-harbor/self-checklist): decide whether adoption fits the protocol.
+2. [Self-Adoption Guide](/safe-harbor/self-adoption-guide): step-by-step self-adoption path and templates.
+3. [Safe Harbor Scope Terms](/safe-harbor/scope-terms): scope parameters whitehats and protocols rely on.
+4. [On-Chain Adoption Guide](/safe-harbor/on-chain-adoption-guide): register adoption on-chain.
+5. [Safe Harbor for Whitehats](/safe-harbor/whitehat): intervention, recovery, and whitehat-oriented guidance.
+
+## Related frameworks
+
+- [Vulnerability Disclosure](/vulnerability-disclosure/overview): contacts and bounty programs for *pre-exploit* reports
+- [Incident Management](/incident-management/overview): response operations during and after active incidents
+- [SEAL911 war room guidelines](/incident-management/playbooks/seal-911-war-room-guidelines): coordination during active
+  events
+- [Wallet Security](/wallet-security/overview): recovery address and multisig hardening guidance
 
 ## Proven Results: Whitehats Have Recovered $150M+
 

--- a/docs/pages/safe-harbor/scope-terms.mdx
+++ b/docs/pages/safe-harbor/scope-terms.mdx
@@ -157,6 +157,11 @@ If you ever need help or have any questions, don't hesitate to reach out!
 
 📬 Contact us at: [safe-harbor@securityalliance.org](mailto:safe-harbor@securityalliance.org)
 
+
+## Further Reading
+
+- [Safe Harbor overview](/safe-harbor/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/safe-harbor/scope-terms.mdx
+++ b/docs/pages/safe-harbor/scope-terms.mdx
@@ -160,7 +160,12 @@ If you ever need help or have any questions, don't hesitate to reach out!
 
 ## Further Reading
 
-- [Safe Harbor overview](/safe-harbor/overview)
+- [Safe Harbor overview](/safe-harbor/overview): what the agreement covers and why protocols adopt it
+- [Secure Multisig Best Practices](/wallet-security/secure-multisig-best-practices): hardening the asset recovery
+  address
+- [Security Contact](/vulnerability-disclosure/security-contact): publishing contacts whitehats can reach during an
+  exploit
+- [Bug Bounties](/vulnerability-disclosure/bug-bounties): aligning bounty percentage and cap with your existing program
 
 ---
 

--- a/docs/pages/safe-harbor/scope-terms.mdx
+++ b/docs/pages/safe-harbor/scope-terms.mdx
@@ -9,6 +9,10 @@ tags:
 contributors:
   - role: wrote
     users: [dickson]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -17,6 +21,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Scope terms—recovery address, contacts, assets, bounty, and identity rules—tell whitehats exactly
+> how a rescue must work for a given protocol.
 
 When adopting Safe Harbor, you'll define specific parameters that control what's covered and how whitehat rescues work.
 Below is an explanation of each term with tips and best practices.

--- a/docs/pages/safe-harbor/self-adoption-guide.mdx
+++ b/docs/pages/safe-harbor/self-adoption-guide.mdx
@@ -9,6 +9,10 @@ tags:
 contributors:
   - role: wrote
     users: [dickson]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -17,6 +21,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Self-adoption means defining scope, completing governance when required, registering on-chain,
+> updating public terms, and announcing—so whitehats can rely on clear rules.
 
 This guide walks you through the full process of self-adopting the SEAL Safe Harbor Agreement for your protocol. The
 goal is to provide whitehats with legal clarity and confidence to rescue funds when it matters most.

--- a/docs/pages/safe-harbor/self-adoption-guide.mdx
+++ b/docs/pages/safe-harbor/self-adoption-guide.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Safe Harbor Self-Adoption Guide | SEAL"
-description: "Self-adopt SEAL Safe Harbor: define scope, pass DAO governance proposal, register on-chain, update Terms of Service, and announce publicly. Templates for DAO and non-DAO protocols included."
+description: "Self-adopt SEAL Safe Harbor: define scope, pass DAO governance proposal, register on-chain, update Terms of Service, and announce publicly"
 tags:
   - SEAL/Initiative
   - Protocol

--- a/docs/pages/safe-harbor/self-adoption-guide.mdx
+++ b/docs/pages/safe-harbor/self-adoption-guide.mdx
@@ -138,6 +138,11 @@ amplify announcements, etc
 
 📬 Contact us at: [safe-harbor@securityalliance.org](mailto:safe-harbor@securityalliance.org)
 
+
+## Further Reading
+
+- [Safe Harbor overview](/safe-harbor/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/safe-harbor/self-adoption-guide.mdx
+++ b/docs/pages/safe-harbor/self-adoption-guide.mdx
@@ -141,7 +141,11 @@ amplify announcements, etc
 
 ## Further Reading
 
-- [Safe Harbor overview](/safe-harbor/overview)
+- [Safe Harbor overview](/safe-harbor/overview): what the agreement covers and why protocols adopt it
+- [Safe Harbor Scope Terms](/safe-harbor/scope-terms): detailed walkthrough of every parameter you define in step 1
+- [On-Chain Adoption Guide](/safe-harbor/on-chain-adoption-guide): contract addresses and registration methods for
+  step 3
+- [Governance Proposal Security](/devsecops/governance-proposal-security): running the DAO vote without introducing risk
 
 ---
 

--- a/docs/pages/safe-harbor/self-checklist.mdx
+++ b/docs/pages/safe-harbor/self-checklist.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Safe Harbor Self-Checklist | Security Alliance"
-description: "Safe Harbor eligibility checklist: evaluate if your protocol holds user funds, needs whitehat protection during active attacks, and has existing bug bounty programs. Three ways to adopt included."
+description: "Safe Harbor eligibility checklist: evaluate if your protocol holds user funds, needs whitehat protection during active attacks"
 tags:
   - SEAL/Initiative
   - Protocol

--- a/docs/pages/safe-harbor/self-checklist.mdx
+++ b/docs/pages/safe-harbor/self-checklist.mdx
@@ -9,6 +9,10 @@ tags:
 contributors:
   - role: wrote
     users: [dickson]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../components'
@@ -17,6 +21,9 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Use this checklist to test whether Safe Harbor fills a real gap for protocols that hold user funds
+> and want whitehats able to act during live attacks.
 
 Use this checklist to evaluate whether adopting the **SEAL Whitehat Safe Harbor Agreement** makes sense for your
 protocol.

--- a/docs/pages/safe-harbor/self-checklist.mdx
+++ b/docs/pages/safe-harbor/self-checklist.mdx
@@ -78,6 +78,11 @@ If you ever need help or have any questions, don't hesitate to reach out!
 
 Contact us at: [safe-harbor@securityalliance.org](mailto:safe-harbor@securityalliance.org)
 
+
+## Further Reading
+
+- [Safe Harbor overview](/safe-harbor/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/safe-harbor/self-checklist.mdx
+++ b/docs/pages/safe-harbor/self-checklist.mdx
@@ -81,7 +81,11 @@ Contact us at: [safe-harbor@securityalliance.org](mailto:safe-harbor@securityall
 
 ## Further Reading
 
-- [Safe Harbor overview](/safe-harbor/overview)
+- [Safe Harbor overview](/safe-harbor/overview): what the agreement covers and why protocols adopt it
+- [Self-Adoption Guide](/safe-harbor/self-adoption-guide): the full adoption path once you decide to proceed
+- [Bug Bounties](/vulnerability-disclosure/bug-bounties): the pre-exploit program Safe Harbor sits alongside
+- [SEAL Self-Adoption Tool](https://safeharbor.securityalliance.org/adoption): generate your agreement and scope
+  parameters
 
 ---
 

--- a/docs/pages/safe-harbor/whitehat.mdx
+++ b/docs/pages/safe-harbor/whitehat.mdx
@@ -100,6 +100,11 @@ fund recovery process and to assist with KYC, protocol communications, and bount
 protocol's posted security contact and return all recovered funds to the protocol's asset recovery address within 6
 hours of the event, or 48 hours if reason is provided and the protocol has been made aware.
 
+
+## Further Reading
+
+- [Safe Harbor overview](/safe-harbor/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/safe-harbor/whitehat.mdx
+++ b/docs/pages/safe-harbor/whitehat.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Whitehat Rescue Guide | Security Alliance"
-description: "Safe Harbor for whitehats: legal framework for intervening during active exploits. Pre-intervention checklist, post-intervention fund return procedures, bounty collection, and SEAL911 coordination."
+description: "Safe Harbor for whitehats: legal framework for intervening during active exploits. Pre-intervention checklist, post-intervention fund return procedures"
 tags:
   - SEAL/Initiative
   - Whitehat

--- a/docs/pages/safe-harbor/whitehat.mdx
+++ b/docs/pages/safe-harbor/whitehat.mdx
@@ -103,7 +103,13 @@ hours of the event, or 48 hours if reason is provided and the protocol has been 
 
 ## Further Reading
 
-- [Safe Harbor overview](/safe-harbor/overview)
+- [Safe Harbor overview](/safe-harbor/overview): what the agreement covers and why protocols adopt it
+- [Safe Harbor Scope Terms](/safe-harbor/scope-terms): the parameters that decide what a rescue may touch and what you
+  are paid
+- [SEAL 911 War Room Guidelines](/incident-management/playbooks/seal-911-war-room-guidelines): who to contact the moment
+  funds are recovered
+- [Safe Harbor Database](https://skylock.xyz/safeharbor/database): check whether a protocol has adopted before
+  intervening
 
 ---
 

--- a/docs/pages/safe-harbor/whitehat.mdx
+++ b/docs/pages/safe-harbor/whitehat.mdx
@@ -7,6 +7,10 @@ tags:
 contributors:
   - role: wrote
     users: [robert]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -15,6 +19,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Safe Harbor coverage applies only when whitehats follow the agreement during an active exploit—
+> independence from the attacker, timely return of funds, and protocol-defined rules all matter.
 
 ## Why You Should Care
 


### PR DESCRIPTION
## Scope

Normalize **Safe Harbor** chrome (`docs/pages/safe-harbor/`) only.

## Why

Missing Key Takeaways and overview page map/related routing; incomplete contributor role slots.

## Content model applied

Initiative/framework hybrid; **no legal text redesign**. Structural chrome + navigation only.

## Substantive security/legal changes

**None.** Existing claims, FAQ, adoption steps, whitehat procedures unchanged aside from KT + navigation sections.

## Intentionally unchanged

- Legal agreement substance, FO marketing stats, adoption FAQs
- Reviewer/legal fact-check still required for product claims

## Validation

- [x] cspell
- [x] markdownlint (touched structural edits)
- [x] signed commit

## Dependencies

**#561** by reference.

## Expert review required

**Legal / Safe Harbor stewards** for any future wording on enforceability, bounties, or adoption claims.