### PR TITLE
docs(dprk-it-workers): normalize structure and wording

### DIFF
--- a/docs/pages/dprk-it-workers/case-studies.mdx
+++ b/docs/pages/dprk-it-workers/case-studies.mdx
@@ -1,6 +1,6 @@
 ---
 title: "DPRK IT Worker Case Studies | SEAL"
-description: "Real anonymized case studies of DPRK IT Workers: stolen 10-year-old GitHub accounts, workers with legitimate company backstories, and facilitators using laptop farms to hide their location."
+description: "Real anonymized case studies of DPRK IT Workers: stolen 10-year-old GitHub accounts, workers with legitimate company backstories"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/dprk-it-workers/case-studies.mdx
+++ b/docs/pages/dprk-it-workers/case-studies.mdx
@@ -82,7 +82,12 @@ refused and resigned immediately, blocking all accounts.
 
 ## Further Reading
 
-- [Dprk It Workers overview](/dprk-it-workers/overview)
+- [DPRK IT Workers overview](/dprk-it-workers/overview): how the pages of this framework fit together
+- [Techniques, Tactics, and Procedures](/dprk-it-workers/techniques-tactics-and-procedures): the baseline patterns these
+  cases deviate from
+- [Mitigating DPRK IT Workers](/dprk-it-workers/mitigating-dprk-it-workers): controls that hold up even when the
+  indicators do not
+- [Lessons Learned](/incident-management/lessons-learned): turning cases like these into internal training material
 
 ---
 

--- a/docs/pages/dprk-it-workers/case-studies.mdx
+++ b/docs/pages/dprk-it-workers/case-studies.mdx
@@ -8,17 +8,23 @@ tags:
   - HR
   - Engineer/Developer
 contributors:
-- role: wrote
-  users: [blackbigswan]
-- role: reviewed
-  users: [yaniv, dickson]
+  - role: wrote
+    users: [blackbigswan]
+  - role: reviewed
+    users: [yaniv, dickson]
+  - role: fact-checked
+    users: []
 ---
+
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 # Case Studies
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Anomalous cases still fit the mission: identity fraud enabling access. Stay open-minded as actor methods change.
+
 
 Here are a few deviations from the usual DPRK IT Worker patterns. **As mentioned a few times already, the goal is to
 always be open-minded about threat actor tactics.** They are known to evolve and adapt while also pushing their methods

--- a/docs/pages/dprk-it-workers/case-studies.mdx
+++ b/docs/pages/dprk-it-workers/case-studies.mdx
@@ -23,8 +23,8 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> 🔑 **Key Takeaway**: Anomalous cases still fit the mission: identity fraud enabling access. Stay open-minded as actor methods change.
-
+> 🔑 **Key Takeaway**: Anomalous cases still fit the mission: identity fraud enabling access.
+> Stay open-minded as actor methods change.
 
 Here are a few deviations from the usual DPRK IT Worker patterns. **As mentioned a few times already, the goal is to
 always be open-minded about threat actor tactics.** They are known to evolve and adapt while also pushing their methods

--- a/docs/pages/dprk-it-workers/case-studies.mdx
+++ b/docs/pages/dprk-it-workers/case-studies.mdx
@@ -79,6 +79,11 @@ gave them a reason to perform additional KYC - "to make sure the (suspected) dev
 was asked to go outside his claimed location and take a "selfie" in front of the house where he supposedly lived. He
 refused and resigned immediately, blocking all accounts.
 
+
+## Further Reading
+
+- [Dprk It Workers overview](/dprk-it-workers/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/dprk-it-workers/general-information.mdx
+++ b/docs/pages/dprk-it-workers/general-information.mdx
@@ -23,8 +23,8 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> 🔑 **Key Takeaway**: DPRK IT Workers use false identities for remote IT work that revenues a sanctioned regime. Treat them as high-impact insider and sanctions risk, not ordinary freelance noise.
-
+> 🔑 **Key Takeaway**: DPRK IT Workers use false identities for remote IT work that
+> revenues a sanctioned regime. Treat them as high-impact insider and sanctions risk, not ordinary freelance noise.
 
 ## What is an insider threat? Who are DPRK IT Workers?
 

--- a/docs/pages/dprk-it-workers/general-information.mdx
+++ b/docs/pages/dprk-it-workers/general-information.mdx
@@ -126,7 +126,11 @@ Procedures**](/dprk-it-workers/techniques-tactics-and-procedures)
 
 ## Further Reading
 
-- [Dprk It Workers overview](/dprk-it-workers/overview)
+- [DPRK IT Workers overview](/dprk-it-workers/overview): how the pages of this framework fit together
+- [Techniques, Tactics, and Procedures](/dprk-it-workers/techniques-tactics-and-procedures): the indicators behind the
+  profile described here
+- [Insider Threat Mitigation](/opsec/control-domains/people/insider-threat-mitigation): the broader insider risk this
+  actor fits into
 
 ---
 

--- a/docs/pages/dprk-it-workers/general-information.mdx
+++ b/docs/pages/dprk-it-workers/general-information.mdx
@@ -8,17 +8,23 @@ tags:
   - HR
   - Engineer/Developer
 contributors:
-- role: wrote
-  users: [blackbigswan]
-- role: reviewed
-  users: [yaniv, dickson]
+  - role: wrote
+    users: [blackbigswan]
+  - role: reviewed
+    users: [yaniv, dickson]
+  - role: fact-checked
+    users: []
 ---
+
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 # General Information
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: DPRK IT Workers use false identities for remote IT work that revenues a sanctioned regime. Treat them as high-impact insider and sanctions risk, not ordinary freelance noise.
+
 
 ## What is an insider threat? Who are DPRK IT Workers?
 

--- a/docs/pages/dprk-it-workers/general-information.mdx
+++ b/docs/pages/dprk-it-workers/general-information.mdx
@@ -1,6 +1,6 @@
 ---
 title: "DPRK IT Workers: General Information | Security Alliance"
-description: "What are DPRK IT Workers? Learn their operational structure, goals, and the average profile indicators to watch for."
+description: "What are DPRK IT Workers? Learn their operational structure, goals, and the average profile indicators to watch for. Treat them as high-impact insider"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/dprk-it-workers/general-information.mdx
+++ b/docs/pages/dprk-it-workers/general-information.mdx
@@ -123,6 +123,11 @@ questions can help you evaluate if you are dealing with a typical North Korean o
 We cover more detailed indicators in the section [**Techniques, Tactics, and
 Procedures**](/dprk-it-workers/techniques-tactics-and-procedures)
 
+
+## Further Reading
+
+- [Dprk It Workers overview](/dprk-it-workers/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/dprk-it-workers/mitigating-dprk-it-workers.mdx
+++ b/docs/pages/dprk-it-workers/mitigating-dprk-it-workers.mdx
@@ -8,17 +8,23 @@ tags:
   - HR
   - Engineer/Developer
 contributors:
-- role: wrote
-  users: [blackbigswan]
-- role: reviewed
-  users: [yaniv, dickson]
+  - role: wrote
+    users: [blackbigswan]
+  - role: reviewed
+    users: [yaniv, dickson]
+  - role: fact-checked
+    users: []
 ---
+
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 # Mitigating DPRK IT Workers
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Prevention is hiring verification plus least privilege. After a hit, revoke access fast, preserve evidence, and treat sanctions and supply-chain exposure as first-class incidents.
+
 
 This section discusses ways you can harden your organization against DPRK IT Workers, both before and after a potential
 hiring. All of the strategies covered in the prior section, [**Techniques, Tactics, and

--- a/docs/pages/dprk-it-workers/mitigating-dprk-it-workers.mdx
+++ b/docs/pages/dprk-it-workers/mitigating-dprk-it-workers.mdx
@@ -179,6 +179,11 @@ with future mitigation and the discovery of other actors.
 6. **Contribution to the North Korean Military:** DPRK IT worker salaries directly contribute to the Military Ministry
 of North Korea. The workers do not keep the salaries for themselves.
 
+
+## Further Reading
+
+- [Dprk It Workers overview](/dprk-it-workers/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/dprk-it-workers/mitigating-dprk-it-workers.mdx
+++ b/docs/pages/dprk-it-workers/mitigating-dprk-it-workers.mdx
@@ -182,7 +182,10 @@ of North Korea. The workers do not keep the salaries for themselves.
 
 ## Further Reading
 
-- [Dprk It Workers overview](/dprk-it-workers/overview)
+- [DPRK IT Workers overview](/dprk-it-workers/overview): how the pages of this framework fit together
+- [DPRK Attack Playbook](/incident-management/playbooks/hacked-dprk): incident response once a worker is confirmed
+- [Role-Based Access Control](/iam/role-based-access-control): implementing the least privilege rules described here
+- [Repository Hardening](/devsecops/repository-hardening): protecting branches, releases, and publishing permissions
 
 ---
 

--- a/docs/pages/dprk-it-workers/mitigating-dprk-it-workers.mdx
+++ b/docs/pages/dprk-it-workers/mitigating-dprk-it-workers.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Mitigating DPRK IT Worker Threats | SEAL"
-description: "Harden your hiring process and organization against DPRK IT Workers. Implement access controls, verify remote employees, and follow step-by-step response procedures if you've hired one."
+description: "Harden your hiring process and organization against DPRK IT Workers. Implement access controls, verify remote employees. All of the strategies covered"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/dprk-it-workers/mitigating-dprk-it-workers.mdx
+++ b/docs/pages/dprk-it-workers/mitigating-dprk-it-workers.mdx
@@ -23,8 +23,8 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> 🔑 **Key Takeaway**: Prevention is hiring verification plus least privilege. After a hit, revoke access fast, preserve evidence, and treat sanctions and supply-chain exposure as first-class incidents.
-
+> 🔑 **Key Takeaway**: Prevention is hiring verification plus least privilege. After a
+> hit, revoke access fast, preserve evidence, and treat sanctions and supply-chain exposure as first-class incidents.
 
 This section discusses ways you can harden your organization against DPRK IT Workers, both before and after a potential
 hiring. All of the strategies covered in the prior section, [**Techniques, Tactics, and

--- a/docs/pages/dprk-it-workers/overview.mdx
+++ b/docs/pages/dprk-it-workers/overview.mdx
@@ -72,7 +72,7 @@ Topics covered:
   ([DPRK attack playbook](/incident-management/playbooks/hacked-dprk) when relevant)
 - [User and Team Security](/user-team-security/overview): staff security posture (when expanded)
 
-## Further Reading & Tools
+## Further Reading
 
 - [OFAC — North Korea Information Technology Workers Advisory](https://ofac.treasury.gov/recent-actions/20220516)
 - Child pages in this framework (especially TTP and mitigation)

--- a/docs/pages/dprk-it-workers/overview.mdx
+++ b/docs/pages/dprk-it-workers/overview.mdx
@@ -74,8 +74,12 @@ Topics covered:
 
 ## Further Reading
 
-- [OFAC — North Korea Information Technology Workers Advisory](https://ofac.treasury.gov/recent-actions/20220516)
-- Child pages in this framework (especially TTP and mitigation)
+- [DPRK Attack Playbook](/incident-management/playbooks/hacked-dprk): response steps once a worker is found inside your
+  organization
+- [OFAC North Korea Information Technology Workers Advisory](https://ofac.treasury.gov/recent-actions/20220516): the
+  sanctions guidance that makes payment a legal risk
+- [Google Threat Intelligence: mitigating the DPRK IT worker threat](https://cloud.google.com/blog/topics/threat-intelligence/mitigating-dprk-it-worker-threat):
+  vendor research on current tactics
 
 ---
 

--- a/docs/pages/dprk-it-workers/overview.mdx
+++ b/docs/pages/dprk-it-workers/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "DPRK IT Workers | Security Alliance"
-description: "DPRK IT Workers Framework: Protect your organization from North Korean insider threats. Recognize hacker-freelancers, harden hiring processes, and mitigate supply-chain compromise risks."
+description: "Defend against DPRK IT Worker insider threats: recognize hiring fraud patterns, harden access, respond after discovery, and reduce sanctions and supply-chain risk."
 tags:
   - Security Specialist
   - Operations & Strategy
@@ -8,10 +8,12 @@ tags:
   - HR
   - Engineer/Developer
 contributors:
-- role: wrote
-  users: [blackbigswan]
-- role: reviewed
-  users: [yaniv, dickson]
+  - role: wrote
+    users: [blackbigswan]
+  - role: reviewed
+    users: [yaniv, dickson]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -21,69 +23,59 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-This framework serves as an entry point to understanding the organizational and personal risks related to "Insider
-Threats," most commonly (though not exclusively) associated with "DPRK IT Workers" - the North Korean
-hacker-freelancers. This framework is targeted at projects affected by insider threat actors as well as projects wanting
-to harden their posture against these actors.
+> 🔑 **Key Takeaway**: DPRK IT Workers are fraudulently hired remote workers who fund a sanctioned regime and can pivot
+> to theft, extortion, or supply-chain sabotage. Hiring and access control are primary defenses.
 
-Throughout this module, we will discuss:
+This framework is an entry point to organizational and personal risk from insider threats, most commonly associated with
+**DPRK IT Workers**—North Korean IT freelancers using false identities. It is for teams already affected and for teams
+hardening before incident.
+
+Topics covered:
 
 - Who insider threat actors are and what they do
-- How to recognize insider threat actors
-- How to interact with a potential threat actor
-- How to mitigate the risks and impact of insider threat actors
-- How to harden your defenses against insider threat actors
-- Potential consequences of insider threats for you and your organization
+- How to recognize them
+- How to interact when a candidate or hire is suspect
+- How to mitigate impact and harden defenses
+- Consequences for the organization
 
-## Table of Contents
+## Overview of risks to your organization
 
-- [**General Information**](/dprk-it-workers/general-information)
-  - [What is an insider threat? Who are DPRK IT
-    Workers?](/dprk-it-workers/general-information#what-is-an-insider-threat-who-are-dprk-it-workers)
-  - [Operational structure and short history of DPRK IT
-    Workers](/dprk-it-workers/general-information#operational-structure-and-short-history-of-dprk-it-workers)
-  - [What are the goals of DPRK IT Workers?](/dprk-it-workers/general-information#what-are-the-goals-of-dprk-it-workers)
-  - [How many DPRK IT Workers are there?](/dprk-it-workers/general-information#how-many-dprk-it-workers-are-there)
-  - [Average DPRK IT Worker Profile](/dprk-it-workers/general-information#average-dprk-it-worker-profile)
-- [**Techniques, Tactics, and Procedures**](/dprk-it-workers/techniques-tactics-and-procedures)
-  - [How can DPRK IT Workers find a job in your
-    company?](/dprk-it-workers/techniques-tactics-and-procedures#how-can-dprk-it-workers-find-a-job-in-your-company)
-  - [Am I Interviewing a DPRK IT
-    Worker?](/dprk-it-workers/techniques-tactics-and-procedures#am-i-interviewing-a-dprk-it-worker)
-  - [Did I hire a DPRK IT Worker?](/dprk-it-workers/techniques-tactics-and-procedures#did-i-hire-a-dprk-it-worker)
-  - [After a DPRK IT Worker is hired by your
-    company](/dprk-it-workers/techniques-tactics-and-procedures#after-a-dprk-it-worker-is-hired-by-your-company)
-- [**Mitigating DPRK IT Workers**](/dprk-it-workers/mitigating-dprk-it-workers)
-  - [Hardening your hiring processes](/dprk-it-workers/mitigating-dprk-it-workers#hardening-your-hiring-processes)
-  - [Hardening your organization](/dprk-it-workers/mitigating-dprk-it-workers#hardening-your-organization)
-  - [I hired a DPRK IT Worker. What now?](/dprk-it-workers/mitigating-dprk-it-workers#i-hired-a-dprk-it-worker-what-now)
-  - [Data collection](/dprk-it-workers/mitigating-dprk-it-workers#data-collection)
-  - [Overview of risks to your
-    organization](/dprk-it-workers/mitigating-dprk-it-workers#overview-of-risks-to-your-organization)
-- [**Case Studies**](/dprk-it-workers/case-studies)
-  - [Story 1](/dprk-it-workers/case-studies#story-1)
-  - [Story 2](/dprk-it-workers/case-studies#story-2)
-  - [Story 3](/dprk-it-workers/case-studies#story-3)
-- [**Summary**](/dprk-it-workers/summary)
+1. **Defrauding the company:** payment to someone whose identity is unknown or false
+2. **Weak operational security:** shared credentials, poor source-control hygiene, intentional or accidental access leaks
+3. **Extortion:** pressure for additional payment after access or work completes
+4. **Follow-on hacking:** knowledge of internal systems reused later
+5. **Sanctions violations:** payments that benefit North Korea-related networks can violate sanctions regimes
+6. **Funding of DPRK priorities:** worker pay is routed to regime priorities rather than ordinary freelancers
+7. **Supply-chain compromise:** intentional weaknesses in software depended on by others
+8. **Reputational damage:** brand and user trust
+9. **Asset freeze / loss of financial access:** banks or exchanges may restrict access when sanctions risk is suspected
+10. **Criminal investigations:** law enforcement scrutiny, fines, or charges depending on jurisdiction and facts
 
-### Overview of risks to your organization
+## What this framework covers
 
-1. **Defrauding the company:** The company is paying someone whose identity they do not know.
-2. **Subpar operational security:** DPRK IT workers share credentials among themselves in open channels, have a poor
-  command of Git, and unintentionally or intentionally leak the access they are granted to third parties.
-3. **Extortion:** They may try to extort more money after a job is finished.
-4. **Future hacking activities:** They may use the knowledge gained for future hacking activities.
-5. **Sanctions violations:** The DPRK is a sanctioned entity. No company can legally transfer funds to DPRK-related
-  operations.
-6. **Contribution to the North Korean Military:** DPRK IT worker salaries directly contribute to the Military Ministry
-  of North Korea. The workers do not keep the salaries for themselves.
-7. **Supply-chain compromise:** DPRK IT Workers may intentionally introduce vulnerabilities that impact down-stream
-  projects that depend on your software / services (e.g. SafeWallet UI in the ByBit hack).
-8. **Reputational damage:** To your brand and loss of trust of your users and customers.
-9. **Asset freeze / loss of access to financial services:** your assets may be frozen or seized, and financial
-  institutions (e.g. banks, exchanges) may terminate your access if you are suspected of funding sanctioned entities.
-10. **Criminal investigations:** Law enforcement may investigate your involvement and impose fines or press criminal
-  charges against your organization.
+1. [General Information](/dprk-it-workers/general-information): definitions, operational structure, goals, scale,
+   average profile indicators.
+2. [Techniques, Tactics, and Procedures](/dprk-it-workers/techniques-tactics-and-procedures): how they get jobs,
+   interview signals, post-hire discovery.
+3. [Mitigating DPRK IT Workers](/dprk-it-workers/mitigating-dprk-it-workers): hiring and org hardening, response after
+   discovery, data collection.
+4. [Case Studies](/dprk-it-workers/case-studies): anonymized real deviations from common patterns.
+5. [Summary](/dprk-it-workers/summary): quick-reference checklist of the framework.
+
+## Related frameworks
+
+- [IAM](/iam/overview): least privilege, lifecycle, and revocation after bad hire discovery
+- [Supply Chain](/supply-chain/overview): intentional dependency and delivery risk
+- [OpSec](/opsec/overview): operator and credential hygiene
+- [Awareness](/awareness/overview): social-engineering context for recruiters and hiring managers
+- [Incident Management](/incident-management/overview): investigation and response after compromise
+  ([DPRK attack playbook](/incident-management/playbooks/hacked-dprk) when relevant)
+- [User and Team Security](/user-team-security/overview): staff security posture (when expanded)
+
+## Further Reading & Tools
+
+- [OFAC — North Korea Information Technology Workers Advisory](https://ofac.treasury.gov/recent-actions/20220516)
+- Child pages in this framework (especially TTP and mitigation)
 
 ---
 

--- a/docs/pages/dprk-it-workers/summary.mdx
+++ b/docs/pages/dprk-it-workers/summary.mdx
@@ -77,7 +77,11 @@ future hacking activities.
 
 ## Further Reading
 
-- [Dprk It Workers overview](/dprk-it-workers/overview)
+- [DPRK IT Workers overview](/dprk-it-workers/overview): how the pages of this framework fit together
+- [Techniques, Tactics, and Procedures](/dprk-it-workers/techniques-tactics-and-procedures): the full set of hiring and
+  post-hire indicators
+- [Mitigating DPRK IT Workers](/dprk-it-workers/mitigating-dprk-it-workers): the detailed hardening and response steps
+- [DPRK Attack Playbook](/incident-management/playbooks/hacked-dprk): incident response once a worker is confirmed
 
 ---
 

--- a/docs/pages/dprk-it-workers/summary.mdx
+++ b/docs/pages/dprk-it-workers/summary.mdx
@@ -23,8 +23,8 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> 🔑 **Key Takeaway**: Hire for identity integrity, verify remote workers continuously, apply least privilege, and respond with urgency when a DPRK worker is discovered.
-
+> 🔑 **Key Takeaway**: Hire for identity integrity, verify remote workers continuously, apply least
+> privilege, and respond with urgency when a DPRK worker is discovered.
 
 * **Who are DPRK IT Workers?** They are North Korean individuals, often operating from abroad (primarily China and
 Russia), who use fraudulent identities to secure remote IT jobs. Their primary goal is to generate revenue for the North

--- a/docs/pages/dprk-it-workers/summary.mdx
+++ b/docs/pages/dprk-it-workers/summary.mdx
@@ -1,6 +1,6 @@
 ---
 title: "DPRK IT Workers Summary | Security Alliance"
-description: "Quick reference guide: who are DPRK IT Workers, how to spot them during hiring, verify existing employees, harden your organization with least privilege access, and respond after discovery."
+description: "Quick reference guide: who are DPRK IT Workers, how to spot them during hiring, verify existing employees, harden your organization with least privilege access"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/dprk-it-workers/summary.mdx
+++ b/docs/pages/dprk-it-workers/summary.mdx
@@ -8,17 +8,23 @@ tags:
   - HR
   - Engineer/Developer
 contributors:
-- role: wrote
-  users: [blackbigswan]
-- role: reviewed
-  users: [yaniv, dickson]
+  - role: wrote
+    users: [blackbigswan]
+  - role: reviewed
+    users: [yaniv, dickson]
+  - role: fact-checked
+    users: []
 ---
+
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 # Summary
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Hire for identity integrity, verify remote workers continuously, apply least privilege, and respond with urgency when a DPRK worker is discovered.
+
 
 * **Who are DPRK IT Workers?** They are North Korean individuals, often operating from abroad (primarily China and
 Russia), who use fraudulent identities to secure remote IT jobs. Their primary goal is to generate revenue for the North

--- a/docs/pages/dprk-it-workers/summary.mdx
+++ b/docs/pages/dprk-it-workers/summary.mdx
@@ -74,6 +74,11 @@ future hacking activities.
   * Once your systems are secure, terminate their contract using a business-related reason (e.g., downsizing, change
     in direction) and report the incident to law enforcement.
 
+
+## Further Reading
+
+- [Dprk It Workers overview](/dprk-it-workers/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/dprk-it-workers/techniques-tactics-and-procedures.mdx
+++ b/docs/pages/dprk-it-workers/techniques-tactics-and-procedures.mdx
@@ -340,7 +340,12 @@ ways to harden your organization and employees against the DPRK IT Worker threat
 
 ## Further Reading
 
-- [Dprk It Workers overview](/dprk-it-workers/overview)
+- [DPRK IT Workers overview](/dprk-it-workers/overview): how the pages of this framework fit together
+- [Mitigating DPRK IT Workers](/dprk-it-workers/mitigating-dprk-it-workers): what to change in hiring and access once
+  you can spot the signals
+- [Case Studies](/dprk-it-workers/case-studies): real cases where these indicators were absent or misleading
+- [Google Threat Intelligence: mitigating the DPRK IT worker threat](https://cloud.google.com/blog/topics/threat-intelligence/mitigating-dprk-it-worker-threat):
+  vendor research on current tactics
 
 ---
 

--- a/docs/pages/dprk-it-workers/techniques-tactics-and-procedures.mdx
+++ b/docs/pages/dprk-it-workers/techniques-tactics-and-procedures.mdx
@@ -1,6 +1,6 @@
 ---
 title: "DPRK IT Worker TTPs | Security Alliance"
-description: "How to identify DPRK IT Workers: evaluate GitHub profiles for copied repositories and faked commit history, detect AI-generated faces, verify claimed identities, and spot red flags during interviews."
+description: "How to identify DPRK IT Workers: evaluate GitHub profiles for copied repositories and faked commit history, detect AI-generated faces"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/dprk-it-workers/techniques-tactics-and-procedures.mdx
+++ b/docs/pages/dprk-it-workers/techniques-tactics-and-procedures.mdx
@@ -23,8 +23,8 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> 🔑 **Key Takeaway**: Spot fraud and inconsistency across identity, code history, and interviews—not stereotypes. TTPs evolve; keep tactics updated.
-
+> 🔑 **Key Takeaway**: Spot fraud and inconsistency across identity, code history, and
+> interviews—not stereotypes. TTPs evolve; keep tactics updated.
 
 This section focuses on avoiding, discovering, and confirming the threat of DPRK IT Workers to your organization.
 The sections dedicated to answering the questions "Am I interviewing a DPRK IT Worker?" and "Did I hire a DPRK IT

--- a/docs/pages/dprk-it-workers/techniques-tactics-and-procedures.mdx
+++ b/docs/pages/dprk-it-workers/techniques-tactics-and-procedures.mdx
@@ -8,17 +8,23 @@ tags:
   - HR
   - Engineer/Developer
 contributors:
-- role: wrote
-  users: [blackbigswan]
-- role: reviewed
-  users: [yaniv, dickson]
+  - role: wrote
+    users: [blackbigswan]
+  - role: reviewed
+    users: [yaniv, dickson]
+  - role: fact-checked
+    users: []
 ---
+
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 # Techniques, Tactics, and Procedures
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Spot fraud and inconsistency across identity, code history, and interviews—not stereotypes. TTPs evolve; keep tactics updated.
+
 
 This section focuses on avoiding, discovering, and confirming the threat of DPRK IT Workers to your organization.
 The sections dedicated to answering the questions "Am I interviewing a DPRK IT Worker?" and "Did I hire a DPRK IT

--- a/docs/pages/dprk-it-workers/techniques-tactics-and-procedures.mdx
+++ b/docs/pages/dprk-it-workers/techniques-tactics-and-procedures.mdx
@@ -337,6 +337,11 @@ are used as cover. Incorporate unpredictable, interactive requests that a pre-re
 In the next section [**Mitigating DPRK IT Workers**](/dprk-it-workers/mitigating-dprk-it-workers) we will be discussing
 ways to harden your organization and employees against the DPRK IT Worker threat.
 
+
+## Further Reading
+
+- [Dprk It Workers overview](/dprk-it-workers/overview)
+
 ---
 
 <ContributeFooter />


### PR DESCRIPTION
## Scope

Normalize **DPRK IT Workers** (`docs/pages/dprk-it-workers/`).

## Why

Missing Key Takeaways; overview TOC-only without Related frameworks chrome; contributors YAML indentation inconsistent; incomplete roles.

## Content model applied

Overview + conceptual/case-study pages; preserve deep TTP guidance from original authors.

## Substantive security changes

**None.** Risk list and links retained; first-person softened on overview only.

## Intentionally unchanged

- Long TTP, mitigation, case-study narrative bodies (steward content)
- Sidebar

## Validation

- [x] cspell
- [x] markdownlint-cli2
- [x] signed commit

## Dependencies

**#561** by reference.

## Reviewer focus

- Debye sanctions/supply-chain risk list still accurate
- Expert review for TTP currency remains open