### PR TITLE
docs(ens): normalize structure and wording

### DIFF
--- a/docs/pages/ens/cross-chain-compatibility.mdx
+++ b/docs/pages/ens/cross-chain-compatibility.mdx
@@ -72,7 +72,10 @@ leading to incomplete or incorrect identity displays.
 
 ## Further Reading
 
-- [Ens overview](/ens/overview)
+- [ENS overview](/ens/overview): how the pages of this framework fit together
+- [Interface Compliance](/ens/interface-compliance): checking resolver support before calling chain-specific methods
+- [ENSIP-11: EVM Coin Types](https://docs.ens.domains/ensip/11): deriving cointypes from chain IDs
+- [EIP-3668: CCIP-Read](https://eips.ethereum.org/EIPS/eip-3668): the off-chain resolution flow and its failure modes
 
 ---
 

--- a/docs/pages/ens/cross-chain-compatibility.mdx
+++ b/docs/pages/ens/cross-chain-compatibility.mdx
@@ -7,6 +7,10 @@ tags:
 contributors:
   - role: wrote
     users: [ghadi8]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -15,6 +19,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Use the correct cointype per chain and handle CCIP-Read timeouts and fallbacks. Wrong-chain
+> resolution sends value to the wrong destination set.
 
 ## Respect Cointype for [Chain-Specific Resolution](https://docs.ens.domains/ensip/9)
 

--- a/docs/pages/ens/cross-chain-compatibility.mdx
+++ b/docs/pages/ens/cross-chain-compatibility.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ENS Cross Chain Compatibility | SEAL"
-description: "Support ENS across multiple blockchains: use correct cointype parameters per ENSIP-11, implement CCIP-Read (EIP-3668) for off-chain resolution, and handle reverse records per chain with ENSIP-19."
+description: "Support ENS across multiple blockchains: use correct cointype parameters per ENSIP-11, implement CCIP-Read (EIP-3668) for off-chain resolution"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/ens/cross-chain-compatibility.mdx
+++ b/docs/pages/ens/cross-chain-compatibility.mdx
@@ -69,6 +69,11 @@ address across different networks, enabling more contextual and chain-specific i
 only check mainnet reverse records will miss valid reverse resolutions on other chains where users are actually active,
 leading to incomplete or incorrect identity displays.
 
+
+## Further Reading
+
+- [Ens overview](/ens/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/ens/data-integrity-verification.mdx
+++ b/docs/pages/ens/data-integrity-verification.mdx
@@ -5,8 +5,12 @@ tags:
   - Engineer/Developer
   - Security Specialist
 contributors:
-- role: wrote
-  users: [ghadi8]
+  - role: wrote
+    users: [ghadi8]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -15,6 +19,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: For fund movement, resolve from Ethereum L1 (or equivalently trusted L1 RPC with
+> verified stack)—not stale indexers—and always verify reverse records with a matching forward lookup.
 
 ## Use On-chain Resolution for Financial Transactions
 

--- a/docs/pages/ens/data-integrity-verification.mdx
+++ b/docs/pages/ens/data-integrity-verification.mdx
@@ -47,6 +47,11 @@ verified. By performing forward resolution on the result of a reverse lookup and
 applications can ensure the bidirectional integrity of the ENS data, preventing potential phishing or impersonation
 attacks.
 
+
+## Further Reading
+
+- [Ens overview](/ens/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/ens/data-integrity-verification.mdx
+++ b/docs/pages/ens/data-integrity-verification.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ENS Data Integrity Verification | SEAL"
-description: "Always resolve ENS data directly from Ethereum mainnet for financial transactions. Verify forward resolution on reverse records to prevent address spoofing and impersonation attacks."
+description: "Always resolve ENS data directly from Ethereum mainnet for financial transactions. Verify forward resolution on reverse records to prevent address spoofing and"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/ens/data-integrity-verification.mdx
+++ b/docs/pages/ens/data-integrity-verification.mdx
@@ -50,7 +50,11 @@ attacks.
 
 ## Further Reading
 
-- [Ens overview](/ens/overview)
+- [ENS overview](/ens/overview): how the pages of this framework fit together
+- [Name Handling & Normalization](/ens/name-handling-normalization): normalizing a name before it is ever resolved
+- [Signing and Verification](/wallet-security/signing-and-verification/signing-verification): confirming the recipient
+  address at signing time
+- [ENSIP-3: Reverse Resolution](https://docs.ens.domains/ensip/3): why a reverse record alone proves nothing
 
 ---
 

--- a/docs/pages/ens/interface-compliance.mdx
+++ b/docs/pages/ens/interface-compliance.mdx
@@ -64,6 +64,11 @@ vulnerabilities, improve user experience, or add valuable new features that user
 track and promptly adopt new ENSIPs gain competitive advantages while contributing to the overall health and advancement
 of the ENS ecosystem.
 
+
+## Further Reading
+
+- [Ens overview](/ens/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/ens/interface-compliance.mdx
+++ b/docs/pages/ens/interface-compliance.mdx
@@ -67,7 +67,11 @@ of the ENS ecosystem.
 
 ## Further Reading
 
-- [Ens overview](/ens/overview)
+- [ENS overview](/ens/overview): how the pages of this framework fit together
+- [Cross-Chain Compatibility](/ens/cross-chain-compatibility): the resolver features most often missing on other chains
+- [EIP-165: Standard Interface Detection](https://eips.ethereum.org/EIPS/eip-165): the `supportsInterface` contract this
+  page relies on
+- [ensdomains/ensips](https://github.com/ensdomains/ensips): track new and deprecated interfaces as proposals progress
 
 ---
 

--- a/docs/pages/ens/interface-compliance.mdx
+++ b/docs/pages/ens/interface-compliance.mdx
@@ -5,8 +5,12 @@ tags:
   - Engineer/Developer
   - Security Specialist
 contributors:
-- role: wrote
-  users: [ghadi8]
+  - role: wrote
+    users: [ghadi8]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -15,6 +19,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Call EIP-165 `supportsInterface` before resolver methods. Missing checks create fragile
+> integrations and failed or unsafe calls on limited resolvers.
 
 ## Verify Resolver Interface Support
 

--- a/docs/pages/ens/interface-compliance.mdx
+++ b/docs/pages/ens/interface-compliance.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ENS Interface Compliance | Security Alliance"
-description: "Verify ENS resolver interface support with EIP-165 supportsInterface() before calling methods. Implement proper interface signaling in custom resolvers and stay updated with ENSIPs."
+description: "Verify ENS resolver interface support with EIP-165 supportsInterface() before calling methods. Implement proper interface signaling in custom resolvers and stay"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/ens/name-handling-normalization.mdx
+++ b/docs/pages/ens/name-handling-normalization.mdx
@@ -65,6 +65,11 @@ Incorrect emoji implementation can cause names to appear differently across plat
 Emoji rendering also varies significantly between operating systems and browsers, requiring thorough cross-platform
 testing to ensure consistent user experience.
 
+
+## Further Reading
+
+- [Ens overview](/ens/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/ens/name-handling-normalization.mdx
+++ b/docs/pages/ens/name-handling-normalization.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ENS Name Handling & Normalization | SEAL"
-description: "Normalize ENS names per ENSIP-15 before creating namehash. Protect users from homograph attacks with confusable character detection and proper emoji handling with UTS-51 compliance."
+description: "Normalize ENS names per ENSIP-15 before creating namehash. Protect users from homograph attacks with confusable character detection and proper emoji handling"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/ens/name-handling-normalization.mdx
+++ b/docs/pages/ens/name-handling-normalization.mdx
@@ -68,7 +68,11 @@ testing to ensure consistent user experience.
 
 ## Further Reading
 
-- [Ens overview](/ens/overview)
+- [ENS overview](/ens/overview): how the pages of this framework fit together
+- [Data Integrity & Verification](/ens/data-integrity-verification): verifying a resolved name before it is used to move
+  funds
+- [ENSIP-15: Name Normalization](https://docs.ens.domains/ensip/15): the normalization algorithm implementations must
+  follow
 
 ---
 

--- a/docs/pages/ens/name-handling-normalization.mdx
+++ b/docs/pages/ens/name-handling-normalization.mdx
@@ -5,8 +5,12 @@ tags:
   - Engineer/Developer
   - Security Specialist
 contributors:
-- role: wrote
-  users: [ghadi8]
+  - role: wrote
+    users: [ghadi8]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -15,6 +19,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Normalize with ENSIP-15 before any namehash or encoding step, and warn on confusable
+> scripts that enable homograph phishing.
 
 ## Normalize Names per [ENSIP-15](https://docs.ens.domains/ensip/15)
 

--- a/docs/pages/ens/overview.mdx
+++ b/docs/pages/ens/overview.mdx
@@ -1,12 +1,16 @@
 ---
 title: "ENS Best Practices | Security Alliance"
-description: "ENS Framework: Securely implement ENS in your applications with L1 data verification, ENSIP-15 normalization, bidirectional resolution, CCIP-Read support, and cross-chain compatibility."
+description: "Secure ENS integration: L1-backed resolution for funds, ENSIP-15 normalization, bidirectional checks, interface detection, cointype, and CCIP-Read (EIP-3668)."
 tags:
   - Engineer/Developer
   - Security Specialist
 contributors:
-- role: wrote
-  users: [ghadi8]
+  - role: wrote
+    users: [ghadi8]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -16,32 +20,41 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> 🔑 **Key Takeaway**: To securely implement ENS in your applications, prioritize direct L1 data verification, enforce
-> proper name normalization, and validate bidirectional resolution. Always verify interface support before interaction,
-> respect chain-specific cointype parameters, and implement [CCIP-Read](https://eips.ethereum.org/EIPS/eip-3668)
-> functionality correctly. These practices prevent address spoofing, ensure cross-chain compatibility, and maintain data
-> integrity throughout the ENS ecosystem.
+> 🔑 **Key Takeaway**: Secure ENS use means fresh L1-backed resolution for funds moves, correct name normalization, and
+> verified bidirectional records—plus interface checks, cointype awareness, and correct CCIP-Read handling.
 
-The Ethereum Name Service (ENS) is a distributed, open, and extensible naming system based on the Ethereum blockchain.
+The Ethereum Name Service (ENS) is a distributed, open, and extensible naming system on Ethereum. It maps human-readable
+names (for example `alice.eth`) to machine-readable identifiers such as addresses, content hashes, and metadata. ENS
+also supports reverse resolution so addresses can advertise a primary name and related metadata.
 
-ENS maps human-readable names like 'alice.eth' to machine-readable identifiers such as Ethereum addresses, other
-cryptocurrency addresses, content hashes, metadata, and more. ENS also supports 'reverse resolution', making it possible
-to associate metadata such as primary names or interface descriptions with Ethereum addresses.
+Mis-implemented ENS flows cause spoofed names, wrong-chain sends, and failed or dangerous resolutions. This framework
+collects integration practices that reduce those failures.
 
-## What This Framework Covers
+## What this framework covers
 
-This best practices framework includes guidance on:
+1. [Data Integrity and Verification](/ens/data-integrity-verification): L1 resolution for financial actions and reverse
+   record verification.
+2. [Cross-Chain Compatibility](/ens/cross-chain-compatibility): cointype (ENSIP-11), CCIP-Read (EIP-3668), reverse
+   records per chain (ENSIP-19 context on the first-party docs).
+3. [Smart Contract Integration](/ens/smart-contract-integration): naming contracts and using ENS as infrastructure.
+4. [Interface Compliance](/ens/interface-compliance): EIP-165 `supportsInterface` before method calls and custom resolver
+   signaling.
+5. [Name Handling and Normalization](/ens/name-handling-normalization): ENSIP-15 normalization and homograph defenses.
 
-* **[Data Integrity & Verification](/ens/data-integrity-verification)** - Ensuring reliable and secure name resolution
-* **[Cross-Chain Compatibility](/ens/cross-chain-compatibility)** - Supporting ENS across multiple blockchain networks
-* **[Smart Contract Integration](/ens/smart-contract-integration)** - Leveraging ENS in smart contract systems
-* **[Interface Compliance](/ens/interface-compliance)** - Correctly implementing and [verifying ENS
-  interfaces](https://eips.ethereum.org/EIPS/eip-165)
-* **[Name Handling & Normalization](/ens/name-handling-normalization)** - Properly processing and displaying ENS names
+## Related frameworks
 
-These recommendations are designed for developers integrating ENS into applications, wallets, smart contracts, or other
-blockchain systems. Following these practices will help create more secure, reliable, and user-friendly ENS
-implementations.
+- [Front-End / Web App](/front-end-web-app/overview): client surfaces that display and resolve names
+- [Wallet Security](/wallet-security/overview): confirmation UX when resolving to send destinations
+- [Smart contract external reviews](/external-security-reviews/smart-contracts/overview): when contracts embed resolvers
+- [Infrastructure](/infrastructure/overview): RPC and node trust assumptions for resolution
+- [Secure Software Development](/secure-software-development/overview): reviews and standards for resolver-using code
+
+## Further Reading & Tools
+
+- [ENS documentation](https://docs.ens.domains/)
+- [ENSIP index](https://docs.ens.domains/ensip/)
+- [EIP-3668 (CCIP-Read)](https://eips.ethereum.org/EIPS/eip-3668)
+- [EIP-165](https://eips.ethereum.org/EIPS/eip-165)
 
 ---
 

--- a/docs/pages/ens/overview.mdx
+++ b/docs/pages/ens/overview.mdx
@@ -49,7 +49,7 @@ collects integration practices that reduce those failures.
 - [Infrastructure](/infrastructure/overview): RPC and node trust assumptions for resolution
 - [Secure Software Development](/secure-software-development/overview): reviews and standards for resolver-using code
 
-## Further Reading & Tools
+## Further Reading
 
 - [ENS documentation](https://docs.ens.domains/)
 - [ENSIP index](https://docs.ens.domains/ensip/)

--- a/docs/pages/ens/smart-contract-integration.mdx
+++ b/docs/pages/ens/smart-contract-integration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ENS Smart Contract Integration | SEAL"
-description: "Register ENS names for smart contracts to improve user experience and reduce address errors. Use ENS for service discovery, upgradeability mechanisms, and protocol metadata storage."
+description: "Register ENS names for smart contracts to improve user experience and reduce address errors. Use ENS for service discovery, upgradeability mechanisms"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/ens/smart-contract-integration.mdx
+++ b/docs/pages/ens/smart-contract-integration.mdx
@@ -52,6 +52,11 @@ robust governance models while maintaining a consistent user interface. Addition
 extensions creates a trust layer that helps users identify legitimate protocol integrations, while storing protocol
 metadata in ENS records improves discoverability and system documentation.
 
+
+## Further Reading
+
+- [Ens overview](/ens/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/ens/smart-contract-integration.mdx
+++ b/docs/pages/ens/smart-contract-integration.mdx
@@ -7,6 +7,10 @@ tags:
 contributors:
   - role: wrote
     users: [ghadi8]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -15,6 +19,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Name protocol contracts in ENS and treat those names as operator and user trust anchors—
+> document reverse records and naming patterns.
 
 ## Name Your Smart Contracts
 

--- a/docs/pages/ens/smart-contract-integration.mdx
+++ b/docs/pages/ens/smart-contract-integration.mdx
@@ -55,7 +55,13 @@ metadata in ENS records improves discoverability and system documentation.
 
 ## Further Reading
 
-- [Ens overview](/ens/overview)
+- [ENS overview](/ens/overview): how the pages of this framework fit together
+- [Data Integrity & Verification](/ens/data-integrity-verification): making sure a contract name resolves to what users
+  expect
+- [Smart Contract Interaction Security](/wallet-security/smart-contract-interaction-security): how users verify the
+  contract behind a name
+- [ENS docs: naming contracts](https://docs.ens.domains/web/naming-contracts): setting reverse records for deployed
+  contracts
 
 ---
 


### PR DESCRIPTION
## Scope

Normalize **ENS** (`docs/pages/ens/`).

## Why

Overview KT was long; child pages lacked Key Takeaways; contributors incomplete; missing Related frameworks.

## Content model applied

Framework overview + procedure/standards children; preserve ENSIP-sourced body guidance.

## Substantive security changes

**None.**

## Validation

- [x] cspell / markdownlint-cli3
- [x] signed commit

## Dependencies

**#561** by reference.