### PR TITLE
docs(privacy): normalize structure and wording

### DIFF
--- a/docs/pages/privacy/data-removal-services.mdx
+++ b/docs/pages/privacy/data-removal-services.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Data Removal Services | Security Alliance"
-description: "Remove personal data from online platforms: opt-out of data brokers like Spokeo and Whitepages. Services compared: DeleteMe, PrivacyDuck, OneRep, and JustDeleteMe for identity protection."
+description: "Remove personal data from online platforms: opt-out of data brokers like Spokeo and Whitepages. Services compared. Expect partial success and repeat"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/privacy/data-removal-services.mdx
+++ b/docs/pages/privacy/data-removal-services.mdx
@@ -4,6 +4,13 @@ description: "Remove personal data from online platforms: opt-out of data broker
 tags:
   - Engineer/Developer
   - Security Specialist
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -12,6 +19,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Data removal shrinks broker and search exposure over time. Expect partial success and repeat
+> audits—deletion is not instantaneous or universal.
 
 Removing your personal data from online platforms can help protect your privacy and reduce the risk of identity theft.
 Here are some steps and services to help you remove your data from the internet.

--- a/docs/pages/privacy/data-removal-services.mdx
+++ b/docs/pages/privacy/data-removal-services.mdx
@@ -63,7 +63,7 @@ Here are some steps and services to help you remove your data from the internet.
    - Pros: Free, easy to use.
    - Cons: Requires manual effort.
 
-## Best Practices
+## Best practices
 
 1. Regularly check and update the privacy settings on your online accounts.
 2. Be mindful of the information you share online and with whom.

--- a/docs/pages/privacy/data-removal-services.mdx
+++ b/docs/pages/privacy/data-removal-services.mdx
@@ -72,7 +72,11 @@ Here are some steps and services to help you remove your data from the internet.
 
 ## Further Reading
 
-- [Privacy overview](/privacy/overview)
+- [Privacy overview](/privacy/overview): how the pages of this framework fit together
+- [Digital Footprint](/privacy/digital-footprint): finding what needs removing before you pay a service to do it
+- [Personal and Family Safety](/physical-security/coercion-and-duress/personal-and-family-safety): why broker exposure
+  becomes a physical risk
+- [JustDeleteMe](https://justdeleteme.xyz/): free directory of account deletion links, sorted by difficulty
 
 ---
 

--- a/docs/pages/privacy/data-removal-services.mdx
+++ b/docs/pages/privacy/data-removal-services.mdx
@@ -69,6 +69,11 @@ Here are some steps and services to help you remove your data from the internet.
 2. Be mindful of the information you share online and with whom.
 3. Use pseudonyms for accounts that don't require your real name.
 
+
+## Further Reading
+
+- [Privacy overview](/privacy/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/privacy/data-removal-services.mdx
+++ b/docs/pages/privacy/data-removal-services.mdx
@@ -6,7 +6,7 @@ tags:
   - Security Specialist
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/privacy/digital-footprint.mdx
+++ b/docs/pages/privacy/digital-footprint.mdx
@@ -80,7 +80,10 @@ Your digital footprint is the trail of data you leave behind while using the int
 
 ## Further Reading
 
-- [Privacy overview](/privacy/overview)
+- [Privacy overview](/privacy/overview): how the pages of this framework fit together
+- [Data Removal Services](/privacy/data-removal-services): removing what an audit turns up
+- [Secure Browsing](/privacy/secure-browsing): cutting the passive footprint at the source
+- [EFF Cover Your Tracks](https://coveryourtracks.eff.org/): test how identifiable your browser is
 
 ---
 

--- a/docs/pages/privacy/digital-footprint.mdx
+++ b/docs/pages/privacy/digital-footprint.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Managing Your Digital Footprint | SEAL"
-description: "Manage your digital footprint: audit online presence, limit information sharing, use privacy settings, delete unused accounts. Tools: Privacy Badger, Ghostery, and Deseat.me for tracking protection."
+description: "Manage your digital footprint: audit online presence, limit information sharing, use privacy settings, delete unused accounts"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/privacy/digital-footprint.mdx
+++ b/docs/pages/privacy/digital-footprint.mdx
@@ -4,6 +4,13 @@ description: "Manage your digital footprint: audit online presence, limit inform
 tags:
   - Engineer/Developer
   - Security Specialist
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -12,6 +19,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Active posts and passive tracking both form a footprint attackers use for targeting. Audit,
+> minimize sharing, and delete unused accounts on a cadence.
 
 Your digital footprint is the trail of data you leave behind while using the internet.
 

--- a/docs/pages/privacy/digital-footprint.mdx
+++ b/docs/pages/privacy/digital-footprint.mdx
@@ -77,6 +77,11 @@ Your digital footprint is the trail of data you leave behind while using the int
 2. Protect your accounts with strong, unique passwords.
 3. Keep up-to-date with privacy news and updates to stay informed about new threats and tools.
 
+
+## Further Reading
+
+- [Privacy overview](/privacy/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/privacy/digital-footprint.mdx
+++ b/docs/pages/privacy/digital-footprint.mdx
@@ -6,7 +6,7 @@ tags:
   - Security Specialist
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/privacy/digital-footprint.mdx
+++ b/docs/pages/privacy/digital-footprint.mdx
@@ -71,7 +71,7 @@ Your digital footprint is the trail of data you leave behind while using the int
    - Pros: Simple interface, effective.
    - Cons: Requires access to your email.
 
-## Best Practices
+## Best practices
 
 1. Conduct regular audits of your online presence to identify and remove unwanted information.
 2. Protect your accounts with strong, unique passwords.

--- a/docs/pages/privacy/encrypted-communication-tools.mdx
+++ b/docs/pages/privacy/encrypted-communication-tools.mdx
@@ -87,6 +87,11 @@ ensure that your messages and calls are protected from eavesdropping and unautho
 By using encrypted communication tools and following best practices, you can significantly enhance the privacy and
 security of your digital communications.
 
+
+## Further Reading
+
+- [Privacy overview](/privacy/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/privacy/encrypted-communication-tools.mdx
+++ b/docs/pages/privacy/encrypted-communication-tools.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Encrypted Communication Tools | SEAL"
-description: "Compare encrypted messaging apps: Signal, WhatsApp, Telegram Secret Chats, Wire, and Threema. Best practices for end-to-end encryption, contact verification, and metadata protection."
+description: "Compare encrypted messaging apps: Signal, WhatsApp, Telegram Secret Chats, Wire, and Threema. Best practices for end-to-end encryption, contact verification"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/privacy/encrypted-communication-tools.mdx
+++ b/docs/pages/privacy/encrypted-communication-tools.mdx
@@ -90,7 +90,11 @@ security of your digital communications.
 
 ## Further Reading
 
-- [Privacy overview](/privacy/overview)
+- [Privacy overview](/privacy/overview): how the pages of this framework fit together
+- [Communication Encryption](/encryption/communication-encryption): the mechanics behind end-to-end encrypted messaging
+- [Signal Account Management](/guides/account-management/signal): registration lock, PIN, and linked device hygiene
+- [Privacy Guides: Real-Time Communication](https://www.privacyguides.org/en/real-time-communication/): independent
+  comparison of messengers and their metadata exposure
 
 ---
 

--- a/docs/pages/privacy/encrypted-communication-tools.mdx
+++ b/docs/pages/privacy/encrypted-communication-tools.mdx
@@ -4,6 +4,13 @@ description: "Compare encrypted messaging apps: Signal, WhatsApp, Telegram Secre
 tags:
   - Engineer/Developer
   - Security Specialist
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -12,6 +19,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Prefer apps with default end-to-end encryption and verifiable safety numbers. Metadata and
+> backup settings still leak—configure them deliberately.
 
 Encrypted communication tools are essential for maintaining privacy and security in digital communications. These tools
 ensure that your messages and calls are protected from eavesdropping and unauthorized access.

--- a/docs/pages/privacy/encrypted-communication-tools.mdx
+++ b/docs/pages/privacy/encrypted-communication-tools.mdx
@@ -6,7 +6,7 @@ tags:
   - Security Specialist
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/privacy/financial-privacy-services.mdx
+++ b/docs/pages/privacy/financial-privacy-services.mdx
@@ -64,7 +64,12 @@ prevent personal and financial information from unauthorized access and fraud.
 
 ## Further Reading
 
-- [Privacy overview](/privacy/overview)
+- [Privacy overview](/privacy/overview): how the pages of this framework fit together
+- [Digital Footprint](/privacy/digital-footprint): the public data that links an identity to a wallet
+- [Cryptocurrency Controls](/opsec/control-domains/technical/cryptocurrency-controls): operational controls around
+  on-chain activity
+- [Cold vs Hot Wallets](/wallet-security/cold-vs-hot-wallet): separating balances that are exposed from those that
+  are not
 
 ---
 

--- a/docs/pages/privacy/financial-privacy-services.mdx
+++ b/docs/pages/privacy/financial-privacy-services.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Financial Privacy Services | Security Alliance"
-description: "Maintain financial privacy in Web3: use cash, prepaid cards, and Privacy.com virtual credit cards. Strategies for limiting data sharing, monitoring accounts, and secure connections."
+description: "Maintain financial privacy in Web3: use cash, prepaid cards, and Privacy.com virtual credit cards. Strategies for limiting data sharing, monitoring accounts"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/privacy/financial-privacy-services.mdx
+++ b/docs/pages/privacy/financial-privacy-services.mdx
@@ -4,6 +4,13 @@ description: "Maintain financial privacy in Web3: use cash, prepaid cards, and P
 tags:
   - Engineer/Developer
   - Security Specialist
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -12,6 +19,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Financial privacy is data minimization around payments and on-chain identity links. Tools help;
+> they never erase all counterparties that already saw a transaction.
 
 Maintaining financial privacy is often seen as important for people in the Web3 ecosystem, and it can help
 prevent personal and financial information from unauthorized access and fraud.

--- a/docs/pages/privacy/financial-privacy-services.mdx
+++ b/docs/pages/privacy/financial-privacy-services.mdx
@@ -61,6 +61,11 @@ prevent personal and financial information from unauthorized access and fraud.
    - Shred any physical documents containing financial information before disposing of them.
    - Store important documents in a secure location.
 
+
+## Further Reading
+
+- [Privacy overview](/privacy/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/privacy/financial-privacy-services.mdx
+++ b/docs/pages/privacy/financial-privacy-services.mdx
@@ -6,7 +6,7 @@ tags:
   - Security Specialist
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/privacy/overview.mdx
+++ b/docs/pages/privacy/overview.mdx
@@ -7,7 +7,7 @@ tags:
   - DevOps
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/privacy/overview.mdx
+++ b/docs/pages/privacy/overview.mdx
@@ -59,7 +59,7 @@ Product claims for third-party tools change; verify current behavior before rely
 - [Physical Security](/physical-security/overview): physical consequence of personal data exposure
 - [Awareness](/awareness/overview): social engineering that exploits traces and OSINT
 
-## Further Reading & Tools
+## Further Reading
 
 - Child pages and vendor docs linked therein
 - [EFF Surveillance Self-Defense](https://ssd.eff.org/)

--- a/docs/pages/privacy/overview.mdx
+++ b/docs/pages/privacy/overview.mdx
@@ -1,10 +1,17 @@
 ---
 title: "Privacy | Security Alliance"
-description: "Privacy Framework: Protect personal and team information from unauthorized access. Manage your digital footprint, data removal, encrypted communication, VPNs, and privacy-focused tools."
+description: "Privacy for Web3 operators and teams: digital footprint, secure browsing, encrypted chat, VPNs, data removal, financial privacy patterns, and privacy-focused OS tools."
 tags:
   - Engineer/Developer
   - Security Specialist
   - DevOps
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -14,9 +21,49 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Privacy is a fundamental aspect of security. Protecting your personal information and your team's information from
-unauthorized access and exposure is crucial. This section provides guidelines and resources for maintaining privacy,
-managing your digital footprint, and utilizing privacy-focused tools and services.
+> 🔑 **Key Takeaway**: Privacy is security of personal and team data against unnecessary collection and exposure. Shrink
+> the footprint first; encryption and network tools then reduce residual risk.
+
+Privacy protects personal and team information from unauthorized access and exposure. For Web3 operators, leaks can
+enable physical targeting, phishing of high-value accounts, or corporate reconnaissance. This framework covers footprint
+management, browsing and messaging hygiene, VPN use, data removal, and privacy-oriented tools—without replacing OpSec or
+encryption-control deep dives.
+
+Product claims for third-party tools change; verify current behavior before relying on any vendor.
+
+## What this framework covers
+
+1. [Secure Browsing](/privacy/secure-browsing): HTTPS habits, tracking resistance, safer search baselines.
+2. [Data Removal Services](/privacy/data-removal-services): broker opt-outs and removal workflows.
+3. [Digital Footprint](/privacy/digital-footprint): active vs passive trails and reduction habits.
+4. [Encrypted Communication Tools](/privacy/encrypted-communication-tools): messaging app comparison orientation.
+5. [Financial Privacy Services](/privacy/financial-privacy-services): payment and data-minimization patterns.
+6. [Privacy-Focused Operating Systems and Tools](/privacy/privacy-focused-operating-systems-tools): Tails, Qubes, Whonix
+   and related tooling orientation.
+7. [VPNs](/privacy/vpns/overview): when VPNs help, what they do not fix, and provider selection factors.
+
+### VPN subsection
+
+1. [VPN Overview](/privacy/vpns/overview)
+2. [HTTPS vs VPN](/privacy/vpns/https-vs-vpn)
+3. [Attack Surfaces on Public Networks](/privacy/vpns/attack-surfaces-public-networks)
+4. [When to Use a VPN](/privacy/vpns/when-to-use-vpn)
+5. [VPN Limitations](/privacy/vpns/vpn-limitations)
+6. [VPN Providers and Tools](/privacy/vpns/vpn-providers-and-tools)
+
+## Related frameworks
+
+- [Encryption](/encryption/overview): cryptographic controls for data at rest and in transit
+- [OpSec](/opsec/overview): operational controls around devices and accounts
+- [Community Management](/community-management/overview): public channels as privacy and targeting surfaces
+- [Physical Security](/physical-security/overview): physical consequence of personal data exposure
+- [Awareness](/awareness/overview): social engineering that exploits traces and OSINT
+
+## Further Reading & Tools
+
+- Child pages and vendor docs linked therein
+- [EFF Surveillance Self-Defense](https://ssd.eff.org/)
+- [privacyguides.org](https://www.privacyguides.org/) (community-maintained; verify independently)
 
 ---
 

--- a/docs/pages/privacy/privacy-focused-operating-systems-tools.mdx
+++ b/docs/pages/privacy/privacy-focused-operating-systems-tools.mdx
@@ -67,7 +67,11 @@ tools are designed to protect your data and minimize your digital footprint.
 
 ## Further Reading
 
-- [Privacy overview](/privacy/overview)
+- [Privacy overview](/privacy/overview): how the pages of this framework fit together
+- [Secure Operating Systems](/opsec/secure-operating-systems): Web3 threat models and deployment configurations for
+  these systems
+- [Full Disk Encryption](/encryption/full-disk-encryption): protecting data at rest on the daily driver
+- [Qubes OS documentation](https://www.qubes-os.org/doc/): install requirements and the isolation model in practice
 
 ---
 

--- a/docs/pages/privacy/privacy-focused-operating-systems-tools.mdx
+++ b/docs/pages/privacy/privacy-focused-operating-systems-tools.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Privacy-Focused Operating Systems | SEAL"
-description: "Privacy-focused operating systems: Tails (live USB), Qubes OS (isolation), and Whonix (Tor anonymity). Tools: Tor Browser, Signal, KeePass password manager, and VeraCrypt disk encryption."
+description: "Privacy-focused operating systems: Tails (live USB), Qubes OS (isolation), and Whonix (Tor anonymity). Tools: Tor Browser, Signal, KeePass password manager"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/privacy/privacy-focused-operating-systems-tools.mdx
+++ b/docs/pages/privacy/privacy-focused-operating-systems-tools.mdx
@@ -4,6 +4,13 @@ description: "Privacy-focused operating systems: Tails (live USB), Qubes OS (iso
 tags:
   - Engineer/Developer
   - Security Specialist
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -12,6 +19,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Privacy OSes (Tails, Qubes, Whonix) raise the bar when threat models justify operational cost.
+> Most teams still need ordinary baseline OpSec on daily drivers.
 
 Using privacy-focused operating systems and tools can significantly enhance your digital privacy. These systems and
 tools are designed to protect your data and minimize your digital footprint.

--- a/docs/pages/privacy/privacy-focused-operating-systems-tools.mdx
+++ b/docs/pages/privacy/privacy-focused-operating-systems-tools.mdx
@@ -6,7 +6,7 @@ tags:
   - Security Specialist
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/privacy/privacy-focused-operating-systems-tools.mdx
+++ b/docs/pages/privacy/privacy-focused-operating-systems-tools.mdx
@@ -64,6 +64,11 @@ tools are designed to protect your data and minimize your digital footprint.
    - A disk encryption software for creating secure, encrypted volumes.
    - Pros: Strong encryption, supports hidden volumes.
 
+
+## Further Reading
+
+- [Privacy overview](/privacy/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/privacy/secure-browsing.mdx
+++ b/docs/pages/privacy/secure-browsing.mdx
@@ -86,6 +86,11 @@ Secure browsing is essential to protect your privacy and personal information wh
 2. Only install trusted browser extensions and regularly review their permissions.
 3. Use a password manager to create and store strong, unique passwords for each website.
 
+
+## Further Reading
+
+- [Privacy overview](/privacy/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/privacy/secure-browsing.mdx
+++ b/docs/pages/privacy/secure-browsing.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Secure Browsing | Security Alliance"
-description: "Secure browsing best practices: use HTTPS, avoid public WiFi, disable third-party cookies. Tools: Tor Browser, Brave, uBlock Origin, Privacy Badger. Search engines: DuckDuckGo, Startpage."
+description: "Secure browsing best practices: use HTTPS, avoid public WiFi, disable third-party cookies. Tools: Tor Browser, Brave, uBlock Origin, Privacy Badger"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/privacy/secure-browsing.mdx
+++ b/docs/pages/privacy/secure-browsing.mdx
@@ -4,6 +4,13 @@ description: "Secure browsing best practices: use HTTPS, avoid public WiFi, disa
 tags:
   - Engineer/Developer
   - Security Specialist
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -12,6 +19,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Prefer HTTPS end to end, reduce trackers and third-party cookies, and treat public Wi-Fi as
+> hostile unless traffic is additionally protected (for example with a VPN).
 
 Secure browsing is essential to protect your privacy and personal information while using the internet.
 

--- a/docs/pages/privacy/secure-browsing.mdx
+++ b/docs/pages/privacy/secure-browsing.mdx
@@ -80,7 +80,7 @@ Secure browsing is essential to protect your privacy and personal information wh
    - Pros: Google search results, strong privacy.
    - Cons: Slower than Google.
 
-## Best Practices
+## Best practices
 
 1. Regularly clear your browsing history, cookies, and cache to remove any stored data.
 2. Only install trusted browser extensions and regularly review their permissions.

--- a/docs/pages/privacy/secure-browsing.mdx
+++ b/docs/pages/privacy/secure-browsing.mdx
@@ -89,7 +89,12 @@ Secure browsing is essential to protect your privacy and personal information wh
 
 ## Further Reading
 
-- [Privacy overview](/privacy/overview)
+- [Privacy overview](/privacy/overview): how the pages of this framework fit together
+- [Browser Security](/opsec/browser/overview): profile separation, extensions, and wallet-facing browser hardening
+- [Attack Surfaces on Public Networks](/privacy/vpns/attack-surfaces-public-networks): what actually goes wrong on open
+  Wi-Fi
+- [Privacy Guides: Desktop Browsers](https://www.privacyguides.org/en/desktop-browsers/): current browser and extension
+  recommendations
 
 ---
 

--- a/docs/pages/privacy/secure-browsing.mdx
+++ b/docs/pages/privacy/secure-browsing.mdx
@@ -6,7 +6,7 @@ tags:
   - Security Specialist
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/privacy/vpns/attack-surfaces-public-networks.mdx
+++ b/docs/pages/privacy/vpns/attack-surfaces-public-networks.mdx
@@ -59,7 +59,10 @@ the host app, and lack address bars for verifying origins. Both scenarios weaken
 
 ## Further Reading
 
-- [Privacy overview](/privacy/overview)
+- [VPN Services overview](/privacy/vpns/overview): how the pages in this section fit together
+- [When to Use a VPN](/privacy/vpns/when-to-use-vpn): deciding whether these risks justify a tunnel
+- [Secure Browsing](/privacy/secure-browsing): browser-side defenses against portal and WebView tricks
+- [Travel Security Guide](/opsec/travel/guide): operating on untrusted networks away from the office
 
 ---
 

--- a/docs/pages/privacy/vpns/attack-surfaces-public-networks.mdx
+++ b/docs/pages/privacy/vpns/attack-surfaces-public-networks.mdx
@@ -9,6 +9,8 @@ contributors:
     users: [mattaereal]
   - role: reviewed
     users: [scode2277]
+  - role: fact-checked
+    users: []
 outline: deep
 ---
 
@@ -18,6 +20,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Open Wi-Fi multiplies rogue AP, captive-portal, and local scanning risk. Assume the LAN is
+> adversarial and minimize sensitive work—or tunnel with a trustworthy VPN.
 
 Public and open Wi-Fi networks (airports, hotels, coffee shops) introduce specific risks:
 

--- a/docs/pages/privacy/vpns/attack-surfaces-public-networks.mdx
+++ b/docs/pages/privacy/vpns/attack-surfaces-public-networks.mdx
@@ -56,6 +56,11 @@ validation, and reduced script blocking.
 Similarly, in-app browsers (WebViews) used by social media and messaging apps can inject JavaScript, share cookies with
 the host app, and lack address bars for verifying origins. Both scenarios weaken the protection HTTPS normally provides.
 
+
+## Further Reading
+
+- [Privacy overview](/privacy/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/privacy/vpns/https-vs-vpn.mdx
+++ b/docs/pages/privacy/vpns/https-vs-vpn.mdx
@@ -71,4 +71,11 @@ location, and in many jurisdictions, your legal identity.
 If you only care about someone reading your messages, HTTPS is enough. If you care about someone knowing what you are
 doing — where you go, when, and how often — that is where a VPN earns its place.
 
+
+## Further Reading
+
+- [Privacy overview](/privacy/overview)
+
+---
+
 <ContributeFooter />

--- a/docs/pages/privacy/vpns/https-vs-vpn.mdx
+++ b/docs/pages/privacy/vpns/https-vs-vpn.mdx
@@ -9,6 +9,8 @@ contributors:
     users: [mattaereal]
   - role: reviewed
     users: [scode2277]
+  - role: fact-checked
+    users: []
 outline: deep
 ---
 
@@ -18,6 +20,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: HTTPS protects content of a site session; a VPN protects path and endpoint metadata to many
+> destinations. Each leaves a gap the other does not fill alone.
 
 A common misconception is that HTTPS makes VPNs unnecessary. They solve different problems:
 

--- a/docs/pages/privacy/vpns/https-vs-vpn.mdx
+++ b/docs/pages/privacy/vpns/https-vs-vpn.mdx
@@ -1,6 +1,6 @@
 ---
 title: "HTTPS vs VPN | Security Alliance"
-description: "Why HTTPS does not make VPNs unnecessary. How SNI leakage, DNS query exposure, traffic analysis, and IP-as-identity create a metadata gap that only a VPN can address."
+description: "Why HTTPS does not make VPNs unnecessary. How SNI leakage, DNS query exposure, traffic analysis, and IP-as-identity create a metadata gap that only a VPN can"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/privacy/vpns/https-vs-vpn.mdx
+++ b/docs/pages/privacy/vpns/https-vs-vpn.mdx
@@ -74,7 +74,11 @@ doing — where you go, when, and how often — that is where a VPN earns its pl
 
 ## Further Reading
 
-- [Privacy overview](/privacy/overview)
+- [VPN Services overview](/privacy/vpns/overview): how the pages in this section fit together
+- [VPN Limitations](/privacy/vpns/vpn-limitations): what the tunnel still fails to hide
+- [Encryption in Transit](/encryption/encryption-in-transit): TLS, DoH, and DoT in more depth
+- [Are VPNs really necessary? Is HTTPS enough?](https://blog.theredguild.org/are-vpns-really-necessary-is-https-enough/):
+  The Red Guild on metadata leakage and threat modeling
 
 ---
 

--- a/docs/pages/privacy/vpns/overview.mdx
+++ b/docs/pages/privacy/vpns/overview.mdx
@@ -32,7 +32,7 @@ providers and configuring tools that match your threat model.
 
 ---
 
-## What this section covers
+## What this framework covers
 
 - **[HTTPS vs VPN](/privacy/vpns/https-vs-vpn)** — Why HTTPS does not make VPNs unnecessary. How metadata leaks even
   with encrypted connections, and what a VPN actually hides.

--- a/docs/pages/privacy/vpns/overview.mdx
+++ b/docs/pages/privacy/vpns/overview.mdx
@@ -52,7 +52,10 @@ providers and configuring tools that match your threat model.
 
 ## Further Reading
 
-- [Privacy overview](/privacy/overview)
+- [Privacy overview](/privacy/overview): how VPNs fit into the wider privacy framework
+- [HTTPS vs VPN](/privacy/vpns/https-vs-vpn): start here if you are unsure a VPN adds anything
+- [VPN Limitations](/privacy/vpns/vpn-limitations): the residual risks a tunnel does not remove
+- [Privacy Guides: VPN Services](https://www.privacyguides.org/en/vpn/): independent provider criteria and audit status
 
 ---
 

--- a/docs/pages/privacy/vpns/overview.mdx
+++ b/docs/pages/privacy/vpns/overview.mdx
@@ -49,6 +49,11 @@ providers and configuring tools that match your threat model.
 - **[VPN Providers and Tools](/privacy/vpns/vpn-providers-and-tools)** — Recommended no-logs providers, plus tools
   organized by network, DNS, device, and browser level.
 
+
+## Further Reading
+
+- [Privacy overview](/privacy/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/privacy/vpns/overview.mdx
+++ b/docs/pages/privacy/vpns/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "VPN Services | Security Alliance"
-description: "Understand when a VPN is necessary, how it differs from HTTPS, what metadata it hides, DNS leaks, attack surfaces on public networks, threat models, and recommended providers and tools."
+description: "Understand when a VPN is necessary, how it differs from HTTPS, what metadata it hides, DNS leaks, attack surfaces on public networks, threat models"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/privacy/vpns/overview.mdx
+++ b/docs/pages/privacy/vpns/overview.mdx
@@ -9,6 +9,8 @@ contributors:
     users: [mattaereal]
   - role: reviewed
     users: [scode2277]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
@@ -17,6 +19,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: A VPN encrypts and relocates network egress for specific threat models. It is not anonymity,
+> malware defense, or a substitute for HTTPS and endpoint security.
 
 Virtual Private Networks (VPNs) encrypt your internet traffic and route it through a remote server, hiding your IP
 address from the websites you visit and shielding your activity from anyone on your local network. But a VPN is not a
@@ -27,7 +32,7 @@ providers and configuring tools that match your threat model.
 
 ---
 
-## Subtopics
+## What this section covers
 
 - **[HTTPS vs VPN](/privacy/vpns/https-vs-vpn)** — Why HTTPS does not make VPNs unnecessary. How metadata leaks even
   with encrypted connections, and what a VPN actually hides.

--- a/docs/pages/privacy/vpns/vpn-limitations.mdx
+++ b/docs/pages/privacy/vpns/vpn-limitations.mdx
@@ -9,6 +9,8 @@ contributors:
     users: [mattaereal]
   - role: reviewed
     users: [scode2277]
+  - role: fact-checked
+    users: []
 outline: deep
 ---
 
@@ -18,6 +20,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: VPNs fail open via leaks, provider trust, fingerprinting, and broken kill switches. Model those
+> residual risks before calling the tunnel "safe."
 
 A VPN is not infallible. Consider these factors in your threat model:
 

--- a/docs/pages/privacy/vpns/vpn-limitations.mdx
+++ b/docs/pages/privacy/vpns/vpn-limitations.mdx
@@ -50,6 +50,11 @@ exchanging. A DNS leak occurs when your DNS queries bypass the VPN tunnel and go
 revealing the domains you visit. You can test for DNS leaks using tools like
 [dnsleaktest.com](https://dnsleaktest.com/).
 
+
+## Further Reading
+
+- [Privacy overview](/privacy/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/privacy/vpns/vpn-limitations.mdx
+++ b/docs/pages/privacy/vpns/vpn-limitations.mdx
@@ -53,7 +53,11 @@ revealing the domains you visit. You can test for DNS leaks using tools like
 
 ## Further Reading
 
-- [Privacy overview](/privacy/overview)
+- [VPN Services overview](/privacy/vpns/overview): how the pages in this section fit together
+- [When to Use a VPN](/privacy/vpns/when-to-use-vpn): matching these residual risks to your threat model
+- [VPN Providers and Tools](/privacy/vpns/vpn-providers-and-tools): leak tests and provider selection criteria
+- [TunnelVision (CVE-2024-3661)](https://www.leviathansecurity.com/blog/tunnelvision): the DHCP route attack that
+  decloaks VPN traffic
 
 ---
 

--- a/docs/pages/privacy/vpns/vpn-providers-and-tools.mdx
+++ b/docs/pages/privacy/vpns/vpn-providers-and-tools.mdx
@@ -9,6 +9,8 @@ contributors:
     users: [mattaereal]
   - role: reviewed
     users: [scode2277]
+  - role: fact-checked
+    users: []
 outline: deep
 ---
 
@@ -18,6 +20,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Prefer audited no-logs providers and verify your own DNS/IP leaks. Free VPNs often monetize
+> users as the product.
 
 ## Recommended VPN Services
 

--- a/docs/pages/privacy/vpns/when-to-use-vpn.mdx
+++ b/docs/pages/privacy/vpns/when-to-use-vpn.mdx
@@ -9,6 +9,8 @@ contributors:
     users: [mattaereal]
   - role: reviewed
     users: [scode2277]
+  - role: fact-checked
+    users: []
 outline: deep
 ---
 
@@ -18,6 +20,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Choose VPN use from the threat model: optional on low-risk public Wi-Fi with good HTTPS, useful
+> to hide metadata from the local path, insufficient alone against a dedicated adversary.
 
 Use this mental model to decide:
 

--- a/docs/pages/privacy/vpns/when-to-use-vpn.mdx
+++ b/docs/pages/privacy/vpns/when-to-use-vpn.mdx
@@ -62,7 +62,10 @@ When selecting a VPN service, consider the following factors:
 
 ## Further Reading
 
-- [Privacy overview](/privacy/overview)
+- [VPN Services overview](/privacy/vpns/overview): how the pages in this section fit together
+- [VPN Limitations](/privacy/vpns/vpn-limitations): the failure modes to weigh against each scenario above
+- [VPN Providers and Tools](/privacy/vpns/vpn-providers-and-tools): applying these criteria to actual providers
+- [Threat Modeling overview](/threat-modeling/overview): a structured way to define what you are defending against
 
 ---
 

--- a/docs/pages/privacy/vpns/when-to-use-vpn.mdx
+++ b/docs/pages/privacy/vpns/when-to-use-vpn.mdx
@@ -59,6 +59,11 @@ When selecting a VPN service, consider the following factors:
 6. **Provider trust model** — A VPN shifts trust from your ISP to the VPN provider. Evaluate the jurisdiction, ownership
    structure, and track record of the provider.
 
+
+## Further Reading
+
+- [Privacy overview](/privacy/overview)
+
 ---
 
 <ContributeFooter />


### PR DESCRIPTION
## Scope

Normalize **Privacy** (`docs/pages/privacy/` including `vpns/`).

## Why

Thin overview; missing Key Takeaways on most pages; incomplete contributors; no related-framework routing.

## Content model applied

Framework overview + reference/catalog children; VPN nested section. Preserve existing VPN technical content and tool lists.

## Substantive security changes

**None.** Vendor/product lists retained as orientation; "verify current behavior" called out.

## Intentionally unchanged

- Generated `index.mdx` files
- Sidebar `dev: true` status

## Validation

- [x] cspell
- [x] markdownlint-cli2
- [x] signed commit

## Dependencies

**#561** by reference.

## Reviewer focus

- VPN provider recommendations remain non-exclusive
- Nested overview map vs sidebar alignment