### PR TITLE
docs(front-end-web-app): normalize structure and wording

### DIFF
--- a/docs/pages/front-end-web-app/common-vulnerabilities.mdx
+++ b/docs/pages/front-end-web-app/common-vulnerabilities.mdx
@@ -7,7 +7,7 @@ tags:
   - DevOps
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/front-end-web-app/common-vulnerabilities.mdx
+++ b/docs/pages/front-end-web-app/common-vulnerabilities.mdx
@@ -52,6 +52,11 @@ Refer to the [OWASP Top 10](https://owasp.org/www-project-top-ten/) and [OWASP M
 Project](https://owasp.org/www-project-mobile-top-10/) for more details on common vulnerabilities and mitigation
 strategies.
 
+
+## Further Reading
+
+- [Front End Web App overview](/front-end-web-app/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/front-end-web-app/common-vulnerabilities.mdx
+++ b/docs/pages/front-end-web-app/common-vulnerabilities.mdx
@@ -5,6 +5,13 @@ tags:
   - Engineer/Developer
   - Security Specialist
   - DevOps
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -13,6 +20,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Prioritize account takeover of admin surfaces, XSS/CSRF/IDOR, and mobile storage flaws. Map each
+> class to concrete mitigations, not awareness alone.
 
 Understanding and mitigating common vulnerabilities is crucial for securing your web and mobile applications. Here are
 some frequently encountered vulnerabilities:

--- a/docs/pages/front-end-web-app/common-vulnerabilities.mdx
+++ b/docs/pages/front-end-web-app/common-vulnerabilities.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Common Web Vulnerabilities | Security Alliance"
-description: "Understand common web and mobile vulnerabilities: Account Takeovers, Cross-Site Scripting (XSS), CSRF, IDOR, Insecure Data Storage, and code tampering. Reference OWASP Top 10 for mitigation."
+description: "Understand common web and mobile vulnerabilities: Account Takeovers, Cross-Site Scripting (XSS), CSRF, IDOR, Insecure Data Storage, and code tampering"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/front-end-web-app/common-vulnerabilities.mdx
+++ b/docs/pages/front-end-web-app/common-vulnerabilities.mdx
@@ -55,7 +55,11 @@ strategies.
 
 ## Further Reading
 
-- [Front End Web App overview](/front-end-web-app/overview)
+- [Front End Web App overview](/front-end-web-app/overview): how the pages of this framework fit together
+- [Web Application Security](/front-end-web-app/web-application-security): framework and deployment choices that prevent
+  these classes
+- [Secure Authentication](/iam/secure-authentication): hardware 2FA and the admin account takeover path
+- [OWASP Cheat Sheet Series](https://cheatsheetseries.owasp.org/): concrete mitigations per vulnerability class
 
 ---
 

--- a/docs/pages/front-end-web-app/mobile-application-security.mdx
+++ b/docs/pages/front-end-web-app/mobile-application-security.mdx
@@ -42,6 +42,11 @@ authorization by implementing certificate pinning to help prevent man-in-the-mid
 6. Leverage security libraries and frameworks designed for mobile application security, such as OWASP Mobile Security
 Project.
 
+
+## Further Reading
+
+- [Front End Web App overview](/front-end-web-app/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/front-end-web-app/mobile-application-security.mdx
+++ b/docs/pages/front-end-web-app/mobile-application-security.mdx
@@ -27,7 +27,7 @@ Mobile applications are increasingly used as front-ends for web3 protocols. As m
 applications, it also becomes an increasing target for threat actors. Below, you can find some suggestions to help
 protect your mobile application:
 
-## Best Practices
+## Best practices
 
 1. Follow secure coding practices to prevent common vulnerabilities such as:
    - Insecure Data Storage

--- a/docs/pages/front-end-web-app/mobile-application-security.mdx
+++ b/docs/pages/front-end-web-app/mobile-application-security.mdx
@@ -45,7 +45,10 @@ Project.
 
 ## Further Reading
 
-- [Front End Web App overview](/front-end-web-app/overview)
+- [Front End Web App overview](/front-end-web-app/overview): how the pages of this framework fit together
+- [Common Vulnerabilities](/front-end-web-app/common-vulnerabilities): the mobile flaw classes referenced above
+- [Security Testing overview](/security-testing/overview): building these checks into a testing program
+- [OWASP MASVS](https://mas.owasp.org/MASVS/): the mobile verification standard to test your app against
 
 ---
 

--- a/docs/pages/front-end-web-app/mobile-application-security.mdx
+++ b/docs/pages/front-end-web-app/mobile-application-security.mdx
@@ -4,6 +4,13 @@ description: "Secure mobile applications for web3 protocols: trusted execution e
 tags:
   - Engineer/Developer
   - Security Specialist
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -12,6 +19,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Mobile Web3 clients need secure storage, transport protection, certificate pinning, and current
+> dependencies—the device is another high-trust wallet gateway.
 
 Mobile applications are increasingly used as front-ends for web3 protocols. As more projects are using mobile
 applications, it also becomes an increasing target for threat actors. Below, you can find some suggestions to help

--- a/docs/pages/front-end-web-app/mobile-application-security.mdx
+++ b/docs/pages/front-end-web-app/mobile-application-security.mdx
@@ -6,7 +6,7 @@ tags:
   - Security Specialist
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/front-end-web-app/mobile-application-security.mdx
+++ b/docs/pages/front-end-web-app/mobile-application-security.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Mobile Application Security | Security Alliance"
-description: "Secure mobile applications for web3 protocols: trusted execution environment for secrets, certificate pinning, encrypted data storage and transmission, and OWASP Mobile Security Project guidelines."
+description: "Secure mobile applications for web3 protocols: trusted execution environment for secrets, certificate pinning, encrypted data storage and transmission"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/front-end-web-app/overview.mdx
+++ b/docs/pages/front-end-web-app/overview.mdx
@@ -7,7 +7,7 @@ tags:
   - DevOps
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/front-end-web-app/overview.mdx
+++ b/docs/pages/front-end-web-app/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Front-End Web Application Security | SEAL"
-description: "Secure Web3 frontends and mobile clients so users never interact with swapped contracts or malicious scripts; web, mobile, third-party scripts, and common vuln classes."
+description: "Secure Web3 frontends and mobile clients so users never interact with swapped contracts or malicious scripts; web, mobile, third-party scripts"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/front-end-web-app/overview.mdx
+++ b/docs/pages/front-end-web-app/overview.mdx
@@ -1,30 +1,60 @@
 ---
 title: "Front-End Web Application Security | SEAL"
-description: "Front-End Security Framework: Secure your Web3 front-end against attacks that could expose users to malicious contracts. Best practices for web and mobile application security."
+description: "Secure Web3 frontends and mobile clients so users never interact with swapped contracts or malicious scripts; web, mobile, third-party scripts, and common vuln classes."
 tags:
   - Engineer/Developer
   - Security Specialist
   - DevOps
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
-# Front-End Web Application Security Best Practices
+# Front-End Web Application Security
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Although often overlooked, ensuring the security of your front-end web and potential mobile applications is crucial
-for protecting your users. If the front-end web application is compromised, it could have severe effects on your users
-as they could, for example, start interacting with a malicious contract instead of your official contract.
+> 🔑 **Key Takeaway**: A compromised frontend can silently route wallets to attacker contracts. Treat web and mobile
+> clients as high-value control planes, not cosmetic packaging.
 
-## Contents
+Front-end and mobile surfaces of Web3 protocols are often overlooked relative to on-chain review. If a client is
+compromised—injected scripts, swapped destinations, malicious dependencies—users can interact with attacker-controlled
+contracts or leak session power without any smart-contract bug.
 
-1. [Web Application Security](/front-end-web-app/web-application-security)
-2. [Mobile Application Security](/front-end-web-app/mobile-application-security)
-3. [Third-Party Script Security](/front-end-web-app/third-party-script-security)
-4. [Common Vulnerabilities](/front-end-web-app/common-vulnerabilities)
-5. [Security Tools and Resources](/front-end-web-app/security-tools-resources)
+This framework covers baseline web app practices, third-party script controls (CSP/SRI and related), mobile notes, common
+vulnerability classes, and catalogues of tools.
+
+## What this framework covers
+
+1. [Web Application Security](/front-end-web-app/web-application-security): frameworks, OWASP-oriented defects, hosting
+   lock-down, availability patterns.
+2. [Third-Party Script Security](/front-end-web-app/third-party-script-security): CSP, SRI, Trusted Types, and incident
+   lessons for script supply chain.
+3. [Mobile Application Security](/front-end-web-app/mobile-application-security): mobile client controls for Web3 apps.
+4. [Common Vulnerabilities](/front-end-web-app/common-vulnerabilities): ATO, XSS, CSRF, IDOR, and related classes.
+5. [Security Tools and Resources](/front-end-web-app/security-tools-resources): scanners and curated tool lists.
+
+## Related frameworks
+
+- [Supply Chain](/supply-chain/overview): dependency and frontend delivery integrity
+- [ENS](/ens/overview): name resolution integrity when clients display or resolve names
+- [Infrastructure](/infrastructure/overview): hosting, DNS, CDN, DDoS
+- [Wallet Security](/wallet-security/overview): wallet UX and signing confirmation boundaries
+- [Secure Software Development](/secure-software-development/overview): reviews and coding standards
+- [Security Testing](/security-testing/overview): dynamic and static test methods
+
+## Further Reading & Tools
+
+- [OWASP Top Ten](https://owasp.org/www-project-top-ten/)
+- [OWASP Application Security Verification Standard](https://owasp.org/www-project-application-security-verification-standard/)
+- [MDN — Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
 
 ---
 

--- a/docs/pages/front-end-web-app/overview.mdx
+++ b/docs/pages/front-end-web-app/overview.mdx
@@ -50,7 +50,7 @@ vulnerability classes, and catalogues of tools.
 - [Secure Software Development](/secure-software-development/overview): reviews and coding standards
 - [Security Testing](/security-testing/overview): dynamic and static test methods
 
-## Further Reading & Tools
+## Further Reading
 
 - [OWASP Top Ten](https://owasp.org/www-project-top-ten/)
 - [OWASP Application Security Verification Standard](https://owasp.org/www-project-application-security-verification-standard/)

--- a/docs/pages/front-end-web-app/security-tools-resources.mdx
+++ b/docs/pages/front-end-web-app/security-tools-resources.mdx
@@ -4,6 +4,13 @@ description: "Security testing tools for web and mobile: OWASP ZAP, Burp Suite f
 tags:
   - Engineer/Developer
   - Security Specialist
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -12,6 +19,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Use established scanners and curated tool lists as inputs to a testing program. Tools without
+> process and owners do not equal coverage.
 
 There are a very large number of security tools and resources available, and sometimes it can feel overwhelming.
 

--- a/docs/pages/front-end-web-app/security-tools-resources.mdx
+++ b/docs/pages/front-end-web-app/security-tools-resources.mdx
@@ -37,6 +37,11 @@ repositories listing many of these tools:
 - [https://github.com/shanzson/Smart-Contract-Auditor-Tools-and-Techniques](https://github.com/shanzson/Smart-Contract-Auditor-Tools-and-Techniques)
 - [https://github.com/Anugrahsr/Awesome-web3-Security](https://github.com/Anugrahsr/Awesome-web3-Security)
 
+
+## Further Reading
+
+- [Front End Web App overview](/front-end-web-app/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/front-end-web-app/security-tools-resources.mdx
+++ b/docs/pages/front-end-web-app/security-tools-resources.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Security Tools & Resources | Security Alliance"
-description: "Security testing tools for web and mobile: OWASP ZAP, Burp Suite for vulnerability scanning, Snyk for dependencies, MobSF for Android/iOS, and curated web3 security tool repositories."
+description: "Security testing tools for web and mobile: OWASP ZAP, Burp Suite for vulnerability scanning, Snyk for dependencies, MobSF for Android/iOS"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/front-end-web-app/security-tools-resources.mdx
+++ b/docs/pages/front-end-web-app/security-tools-resources.mdx
@@ -40,7 +40,11 @@ repositories listing many of these tools:
 
 ## Further Reading
 
-- [Front End Web App overview](/front-end-web-app/overview)
+- [Front End Web App overview](/front-end-web-app/overview): how the pages of this framework fit together
+- [Security Testing overview](/security-testing/overview): the process these tools plug into
+- [Dependency Awareness](/supply-chain/dependency-awareness): what dependency scanners are actually looking for
+- [OWASP Web Security Testing Guide](https://owasp.org/www-project-web-security-testing-guide/): a test methodology to
+  run tools against
 
 ---
 

--- a/docs/pages/front-end-web-app/security-tools-resources.mdx
+++ b/docs/pages/front-end-web-app/security-tools-resources.mdx
@@ -6,7 +6,7 @@ tags:
   - Security Specialist
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/front-end-web-app/third-party-script-security.mdx
+++ b/docs/pages/front-end-web-app/third-party-script-security.mdx
@@ -293,7 +293,7 @@ Trusted Types can be disruptive to adopt because many libraries (including some 
 Trusted Types are supported across all modern browsers as of early 2026. The CSP directive degrades gracefully
 on older browsers: it is simply ignored, so it will not break your application.
 
-## Self-Hosting Critical Dependencies
+### Self-hosting critical dependencies
 
 The strongest defense against third-party script compromise is to eliminate the third party entirely by
 bundling dependencies into your own build output. CSP and SRI reduce the risk of loading external scripts;
@@ -357,7 +357,7 @@ and compares its hash to the expected value. A hash mismatch on a resource that 
 early indicator of a supply chain compromise. Integrate this into your CI pipeline and your production monitoring
 separately: CI catches changes at build time, production monitoring catches changes at serve time.
 
-## Additional Defenses
+### Additional defenses
 
 Beyond the core mechanisms above, consider these complementary measures:
 
@@ -380,7 +380,7 @@ Beyond the core mechanisms above, consider these complementary measures:
   -> API reference and browser compatibility
 - [Google: Trusted Types Adoption Guide](https://web.dev/articles/trusted-types) -> step-by-step policy implementation guide
 
-## Related Frameworks
+## Related frameworks
 
 - [Supply Chain Security](/supply-chain/overview): Dependency management, vendor risk, and incident response
   for compromised components

--- a/docs/pages/front-end-web-app/third-party-script-security.mdx
+++ b/docs/pages/front-end-web-app/third-party-script-security.mdx
@@ -7,6 +7,10 @@ tags:
 contributors:
   - role: wrote
     users: [scode2277]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -16,7 +20,7 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> 🔑 **Key Takeaway:** Every third-party script running on your frontend shares your page's origin, meaning it
+> 🔑 **Key Takeaway**: Every third-party script running on your frontend shares your page's origin, meaning it
 > can access cookies, localStorage, session tokens, and call `window.ethereum` methods directly. Use Content
 > Security Policy, Subresource Integrity, and Trusted Types to control what code executes, verify it has not
 > been tampered with, and lock down dangerous DOM APIs.

--- a/docs/pages/front-end-web-app/web-application-security.mdx
+++ b/docs/pages/front-end-web-app/web-application-security.mdx
@@ -43,7 +43,12 @@ availability of your protocol’s front-end.
 
 ## Further Reading
 
-- [Front End Web App overview](/front-end-web-app/overview)
+- [Front End Web App overview](/front-end-web-app/overview): how the pages of this framework fit together
+- [Common Vulnerabilities](/front-end-web-app/common-vulnerabilities): the specific flaw classes to design against
+- [Third-Party Script Security](/front-end-web-app/third-party-script-security): CSP, SRI, and Trusted Types for
+  external code
+- [Frontend Compromise Runbook](/incident-management/incident-response-template/runbooks/frontend-compromise): response
+  steps when the app is serving malicious code
 
 ---
 

--- a/docs/pages/front-end-web-app/web-application-security.mdx
+++ b/docs/pages/front-end-web-app/web-application-security.mdx
@@ -40,6 +40,11 @@ availability of your protocol’s front-end.
 5. Lock down access to associated back-end services, such as S3 buckets, to prevent unauthorized access.
 6. Consider deploying additional versions of your front-end on IPFS to ensure availability and resilience.
 
+
+## Further Reading
+
+- [Front End Web App overview](/front-end-web-app/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/front-end-web-app/web-application-security.mdx
+++ b/docs/pages/front-end-web-app/web-application-security.mdx
@@ -4,6 +4,13 @@ description: "Secure your web3 front-end: use well-maintained frameworks, addres
 tags:
   - Engineer/Developer
   - Security Specialist
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -12,6 +19,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Harden Web3 web apps against XSS and related OWASP classes, lock down backend storage, and plan
+> frontend availability—because client compromise steals wallet-bound actions.
 
 Providing a secure front-end (web application) for users to interact with your web3 protocol is often essential. Web
 application vulnerabilities have however been exploited in the past to steal user funds, and as such it's important to

--- a/docs/pages/front-end-web-app/web-application-security.mdx
+++ b/docs/pages/front-end-web-app/web-application-security.mdx
@@ -27,7 +27,7 @@ Providing a secure front-end (web application) for users to interact with your w
 application vulnerabilities have however been exploited in the past to steal user funds, and as such it's important to
 take web application security into consideration for your project.
 
-## Best Practices
+## Best practices
 
 1. Utilize popular and well-maintained web application frameworks when developing your application.
 2. Familiarize yourself with common web application vulnerabilities that may affect your decentralized application such

--- a/docs/pages/front-end-web-app/web-application-security.mdx
+++ b/docs/pages/front-end-web-app/web-application-security.mdx
@@ -6,7 +6,7 @@ tags:
   - Security Specialist
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked


### PR DESCRIPTION
## Scope

Normalize **Front-End / Web App** (`docs/pages/front-end-web-app/`).

## Why

Missing Key Takeaways on most pages; thin overview TOC without related frameworks; incomplete contributors.

## Substantive security changes

**None.**

## Dependencies

**#561** by reference.

## Validation

- [x] cspell / markdownlint-cli2
- [x] signed commit