### PR TITLE
docs(governance): normalize structure and wording

### DIFF
--- a/docs/pages/governance/compliance-regulatory-requirements.mdx
+++ b/docs/pages/governance/compliance-regulatory-requirements.mdx
@@ -190,7 +190,12 @@ for improving security and regulatory compliance.
 
 ## Further Reading
 
-- [Governance overview](/governance/overview)
+- [Governance overview](/governance/overview): how the pages of this framework fit together
+- [Risk Management](/governance/risk-management): prioritizing the legal and operational risk compliance reduces
+- [Compliance and Regulatory Alignment](/opsec/control-domains/organizational/compliance-regulatory-alignment): mapping
+  obligations onto operational controls
+- [Security Policies and Procedures](/external-security-reviews/security-policies-procedures): the documentation
+  auditors ask for
 
 ---
 

--- a/docs/pages/governance/compliance-regulatory-requirements.mdx
+++ b/docs/pages/governance/compliance-regulatory-requirements.mdx
@@ -8,7 +8,7 @@ tags:
   - HR
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/governance/compliance-regulatory-requirements.mdx
+++ b/docs/pages/governance/compliance-regulatory-requirements.mdx
@@ -6,6 +6,13 @@ tags:
   - Legal & Compliance
   - DevOps
   - HR
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -15,8 +22,11 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Compliance with regulatory requirements may be essential for your project. Understanding the needs and ensuring the
-necessary compliance helps protect your project from potential legal penalties.
+> 🔑 **Key Takeaway**: Map which regulations apply, then implement security controls that counsel and auditors can
+> verify. This page is orientation—not jurisdiction-specific legal advice.
+
+Compliance with regulatory requirements may be essential for a project. Understanding obligations and implementing
+needed compliance reduces legal and operational risk.
 
 ## Key Regulatory Frameworks
 
@@ -31,9 +41,7 @@ daunting, there are different levels of compliance needed depending on the proje
 
 ## Best Practices for Compliance
 
-# Best Practices for Regulatory Compliance in Terms of Security
-
-## 1. Understand Applicable Regulations
+### 1. Understand Applicable Regulations
 
 - **Identify Relevant Regulations:** Clearly identify all regulatory frameworks that apply to your organization, such as
 GDPR, HIPAA, CCPA, or PCI DSS.
@@ -42,7 +50,7 @@ compliance measures evolve accordingly.
 - **Engage Legal Counsel:** Work with legal experts to interpret regulations accurately and implement appropriate
 security controls.
 
-## 2. Develop a Robust Security Policy Framework
+### 2. Develop a Robust Security Policy Framework
 
 - **Comprehensive Security Policies:** Develop detailed security policies that align with regulatory requirements,
 covering areas like data protection, access control, and incident response.
@@ -51,7 +59,7 @@ they are easily accessible for audits and reviews.
 - **Regular Policy Updates:** Review and update security policies regularly to reflect changes in regulations and
 emerging threats.
 
-## 3. Data Protection and Privacy
+### 3. Data Protection and Privacy
 
 - **Data Classification:** Classify data based on sensitivity and regulatory requirements, ensuring appropriate
 protection levels for each category.
@@ -60,7 +68,7 @@ exposure to potential breaches.
 - **Anonymization and Pseudonymization:** Where possible, apply anonymization or pseudonymization techniques to protect
 personal data.
 
-## 4. Access Management and Control
+### 4. Access Management and Control
 
 - **Role-Based Access Control (RBAC):** Implement RBAC to ensure that employees have access only to the data and systems
 necessary for their roles.
@@ -69,7 +77,7 @@ security.
 - **Regular Access Audits:** Conduct regular audits of user access rights to ensure compliance with the principle of
 least privilege.
 
-## 5. Incident Response Planning
+### 5. Incident Response Planning
 
 - **Comprehensive Incident Response Plan:** Develop an incident response plan that aligns with regulatory requirements,
 detailing steps for identifying, responding to, and reporting security incidents.
@@ -78,7 +86,7 @@ authorities within the required timeframes.
 - **Regular Testing:** Conduct regular simulations and tabletop exercises to test the effectiveness of the incident
 response plan.
 
-## 6. Continuous Monitoring and Auditing
+### 6. Continuous Monitoring and Auditing
 
 - **Automated Monitoring Tools:** Implement automated tools to continuously monitor compliance with security regulations
 and detect potential vulnerabilities or breaches.
@@ -87,7 +95,7 @@ requirements.
 - **External Audits:** Engage third-party auditors to provide independent assessments of your security posture and
 compliance status.
 
-## 7. Employee Training and Awareness
+### 7. Employee Training and Awareness
 
 - **Regular Training Programs:** Provide regular training on regulatory requirements, data protection, and security best
 practices for all employees.
@@ -96,7 +104,7 @@ attack vectors that could lead to compliance breaches.
 - **Role-Specific Training:** Tailor training programs to address the specific regulatory and security responsibilities
 of different roles within the organization.
 
-## 8. Third-Party Risk Management
+### 8. Third-Party Risk Management
 
 - **Vendor Due Diligence:** Conduct thorough due diligence on third-party vendors to ensure they comply with relevant
 security regulations.
@@ -105,7 +113,7 @@ vendors.
 - **Continuous Monitoring:** Monitor third-party vendors’ compliance with security requirements throughout the
 relationship.
 
-## 9. Data Encryption and Secure Communication
+### 9. Data Encryption and Secure Communication
 
 - **Encryption Standards:** Use strong encryption standards for protecting data both at rest and in transit, in line
 with regulatory requirements.
@@ -113,7 +121,7 @@ with regulatory requirements.
 channels (e.g., TLS, VPN).
 - **Key Management:** Implement robust key management practices to protect encryption keys from unauthorized access.
 
-## 10. Documentation and Record-Keeping
+### 10. Documentation and Record-Keeping
 
 - **Compliance Documentation:** Maintain detailed records of compliance efforts, including audit results, incident
 reports, and training logs.
@@ -122,7 +130,7 @@ records are kept for the required duration.
 - **Audit Trails:** Ensure that all access to sensitive data is logged, creating a clear audit trail for compliance
 verification.
 
-# Useful Resources
+## Useful Resources
 
 Here are some useful resources where you can follow and learn more about the best practices mentioned:
 

--- a/docs/pages/governance/compliance-regulatory-requirements.mdx
+++ b/docs/pages/governance/compliance-regulatory-requirements.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Compliance & Regulatory Requirements | SEAL"
-description: "Navigate regulatory compliance: GDPR, MiCA, HIPAA, PCI DSS. Best practices for data protection, RBAC, incident response, third-party risk management, and alignment with NIST and ISO 27001."
+description: "Navigate regulatory compliance: GDPR, MiCA, HIPAA, PCI DSS. Best practices for data protection, RBAC, incident response, third-party risk management"
 tags:
   - Operations & Strategy
   - Legal & Compliance

--- a/docs/pages/governance/compliance-regulatory-requirements.mdx
+++ b/docs/pages/governance/compliance-regulatory-requirements.mdx
@@ -187,6 +187,11 @@ Here are some useful resources where you can follow and learn more about the bes
 for improving security and regulatory compliance.
 - URL: [https://www.sans.org/security-resources/](https://www.sans.org/security-resources/)
 
+
+## Further Reading
+
+- [Governance overview](/governance/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/governance/council-best-practices.mdx
+++ b/docs/pages/governance/council-best-practices.mdx
@@ -438,6 +438,11 @@ Security Councils can leverage existing SEAL infrastructure:
 - [Multisig for Protocols](/multisig-for-protocols/overview)
 - [Risk Management](/governance/risk-management)
 
+
+## Further Reading
+
+- [Governance overview](/governance/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/governance/council-best-practices.mdx
+++ b/docs/pages/governance/council-best-practices.mdx
@@ -441,7 +441,13 @@ Security Councils can leverage existing SEAL infrastructure:
 
 ## Further Reading
 
-- [Governance overview](/governance/overview)
+- [Governance overview](/governance/overview): how the pages of this framework fit together
+- [Multisig for Protocols](/multisig-for-protocols/overview): signer selection, thresholds, and custody for council
+  multisigs
+- [Emergency Pause Runbook](/multisig-for-protocols/runbooks/emergency-pause): a worked procedure for the powers
+  described here
+- [OpenZeppelin: Security Council Best Practices](https://www.openzeppelin.com/news/security-council-best-practices-guide):
+  the full guide this page is based on
 
 ---
 

--- a/docs/pages/governance/council-best-practices.mdx
+++ b/docs/pages/governance/council-best-practices.mdx
@@ -392,7 +392,7 @@ Security Councils should evolve through:
 - Community input on Council effectiveness
 - Benchmark comparisons with other protocols
 
-## Integration with SEAL Resources
+### Integration with SEAL resources
 
 Security Councils can leverage existing SEAL infrastructure:
 
@@ -417,7 +417,7 @@ Security Councils can leverage existing SEAL infrastructure:
 - Escalation frameworks
 - See [Incident Management](/incident-management/overview)
 
-## Best Practices Summary
+### Best practices summary
 
 1. **Establish clear prerequisites** before forming Security Councils to avoid premature overhead
 2. **Balance diverse expertise** across technical security, crisis management, and compliance domains
@@ -430,7 +430,7 @@ Security Councils can leverage existing SEAL infrastructure:
 9. **Collaborate across protocols** through shared monitoring and threat intelligence
 10. **Continuously improve** based on drills, incidents, and community feedback
 
-## Additional Resources
+### Additional resources
 
 - [OpenZeppelin Security Council Best Practices Guide](https://www.openzeppelin.com/news/security-council-best-practices-guide)
 - [Incident Management Framework](/incident-management/overview)

--- a/docs/pages/governance/council-best-practices.mdx
+++ b/docs/pages/governance/council-best-practices.mdx
@@ -430,22 +430,13 @@ Security Councils can leverage existing SEAL infrastructure:
 9. **Collaborate across protocols** through shared monitoring and threat intelligence
 10. **Continuously improve** based on drills, incidents, and community feedback
 
-### Additional resources
-
-- [OpenZeppelin Security Council Best Practices Guide](https://www.openzeppelin.com/news/security-council-best-practices-guide)
-- [Incident Management Framework](/incident-management/overview)
-- [SEAL 911 War Room Guidelines](/incident-management/playbooks/seal-911-war-room-guidelines)
-- [Multisig for Protocols](/multisig-for-protocols/overview)
-- [Risk Management](/governance/risk-management)
-
-
 ## Further Reading
 
 - [Governance overview](/governance/overview): how the pages of this framework fit together
 - [Multisig for Protocols](/multisig-for-protocols/overview): signer selection, thresholds, and custody for council
   multisigs
-- [Emergency Pause Runbook](/multisig-for-protocols/runbooks/emergency-pause): a worked procedure for the powers
-  described here
+- [SEAL 911 War Room Guidelines](/incident-management/playbooks/seal-911-war-room-guidelines): coordination during the
+  emergencies councils exist for
 - [OpenZeppelin: Security Council Best Practices](https://www.openzeppelin.com/news/security-council-best-practices-guide):
   the full guide this page is based on
 

--- a/docs/pages/governance/council-best-practices.mdx
+++ b/docs/pages/governance/council-best-practices.mdx
@@ -9,6 +9,8 @@ contributors:
     users: [michael, bram]
   - role: reviewed
     users: [mattaereal]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -16,11 +18,14 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 # Security Council Best Practices in Rollup Governance
 
 <TagList tags={frontmatter.tags} />
+<AttributionList contributors={frontmatter.contributors} />
 
-> **Attribution**: This section is based on
-> [From Stage 0 to Stage 1: Security Council Best Practices in Rollup Governance](https://www.openzeppelin.com/news/security-council-best-practices-guide)
-> by [OpenZeppelin](https://www.openzeppelin.com),
-> authored by Bram Hoogenkamp and Michael Lewellen.
+> 🔑 **Key Takeaway**: Security councils speed emergency response when membership, multisigs, drills, and governance
+> bounds are explicit—borrow proven practices; do not invent powers under pressure.
+
+**Attribution:** This section is based on
+[From Stage 0 to Stage 1: Security Council Best Practices in Rollup Governance](https://www.openzeppelin.com/news/security-council-best-practices-guide)
+by [OpenZeppelin](https://www.openzeppelin.com), authored by Bram Hoogenkamp and Michael Lewellen.
 
 Security Councils serve as specialized governance bodies that act as the final line of defense against exploits,
 governance attacks, and systemic failures in decentralized protocols. This guide focuses primarily on rollups and

--- a/docs/pages/governance/council-best-practices.mdx
+++ b/docs/pages/governance/council-best-practices.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Security Council Best Practices | Security Alliance"
-description: "Establish effective Security Councils for rollup governance with best practices covering formation, incident response, multi-sig setup, governance integration, and readiness drills."
+description: "Establish effective Security Councils for rollup governance with best practices covering formation, incident response, multi-sig setup, governance integration"
 tags:
   - Operations & Strategy
   - Legal & Compliance

--- a/docs/pages/governance/overview.mdx
+++ b/docs/pages/governance/overview.mdx
@@ -52,7 +52,7 @@ Regulatory lists are examples, not legal advice. Engage qualified counsel for ju
 
 - [NIST Cybersecurity Framework](https://www.nist.gov/cyberframework)
 - [ISO/IEC 27001 overview](https://www.iso.org/standard/27001)
-- Child pages, especially the OpenZeppelin council guide (linked on the council page)
+- [COBIT](https://www.isaca.org/resources/cobit)
 
 ---
 

--- a/docs/pages/governance/overview.mdx
+++ b/docs/pages/governance/overview.mdx
@@ -48,7 +48,7 @@ Regulatory lists are examples, not legal advice. Engage qualified counsel for ju
 - [IAM](/iam/overview): access control under policy
 - [DevSecOps — Governance proposal security](/devsecops/governance-proposal-security): proposal lifecycle controls
 
-## Further Reading & Tools
+## Further Reading
 
 - [NIST Cybersecurity Framework](https://www.nist.gov/cyberframework)
 - [ISO/IEC 27001 overview](https://www.iso.org/standard/27001)

--- a/docs/pages/governance/overview.mdx
+++ b/docs/pages/governance/overview.mdx
@@ -1,9 +1,16 @@
 ---
 title: "Governance | Security Alliance"
-description: "Governance Framework: Implement strong governance practices with clear security policies, accountability structures, and continuous monitoring for compliance and risk management."
+description: "Security governance for Web3 projects: regulatory orientation, risk management, metrics, security councils, and safe rebrand or reorganization communications."
 tags:
   - Operations & Strategy
   - Legal & Compliance
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -13,17 +20,39 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Good governance practices involve setting clear policies, establishing accountability, and continuously monitoring and
-improving security measures. This section provides some best practices and guidelines for how you could implement
-governance in your project.
+> 🔑 **Key Takeaway**: Governance turns security intent into owned policy, risk decisions, measurable outcomes, and
+> accountable emergency bodies—especially when protocols can upgrade or pause systems.
 
-## Contents
+Good security governance sets clear policies, assigns accountability, and continuously monitors and improves controls.
+This framework orients projects to regulatory awareness, risk management practice, security metrics, security council
+design for upgradeable systems, and communication safety during rebrands or reorganizations.
 
-1. [Compliance with Regulatory Requirements](/governance/compliance-regulatory-requirements)
-2. [Risk Management](/governance/risk-management)
-3. [Security Metrics and KPIs](/governance/security-metrics-kpis)
-4. [Security Council Best Practices](/governance/council-best-practices)
-5. [Rebrands & Reorgs](/governance/rebrands-and-reorgs)
+Regulatory lists are examples, not legal advice. Engage qualified counsel for jurisdiction-specific obligations.
+
+## What this framework covers
+
+1. [Compliance with Regulatory Requirements](/governance/compliance-regulatory-requirements): example frameworks and
+   security-oriented compliance practices.
+2. [Risk Management](/governance/risk-management): identify, prioritize, and iterate risks with standard references.
+3. [Security Metrics and KPIs](/governance/security-metrics-kpis): measure detection, response, patching, and training.
+4. [Security Council Best Practices](/governance/council-best-practices): emergency governance for rollups and similar
+   systems (OpenZeppelin-derived guide).
+5. [Rebrands and Reorganizations](/governance/rebrands-and-reorgs): protect communities from scams during transitions.
+
+## Related frameworks
+
+- [Incident Management](/incident-management/overview): operational response when governance triggers IR
+- [Multisig for Protocols](/multisig-for-protocols/overview): on-chain execution of governance-approved actions
+- [Safe Harbor](/safe-harbor/overview): whitehat intervention frameworks distinct from councils
+- [Community Management](/community-management/overview): channel security during transitions
+- [IAM](/iam/overview): access control under policy
+- [DevSecOps — Governance proposal security](/devsecops/governance-proposal-security): proposal lifecycle controls
+
+## Further Reading & Tools
+
+- [NIST Cybersecurity Framework](https://www.nist.gov/cyberframework)
+- [ISO/IEC 27001 overview](https://www.iso.org/standard/27001)
+- Child pages, especially the OpenZeppelin council guide (linked on the council page)
 
 ---
 

--- a/docs/pages/governance/overview.mdx
+++ b/docs/pages/governance/overview.mdx
@@ -6,7 +6,7 @@ tags:
   - Legal & Compliance
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/governance/rebrands-and-reorgs.mdx
+++ b/docs/pages/governance/rebrands-and-reorgs.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Rebrands & Reorganizations | Security Alliance"
-description: "Practical guidance and case studies on handling rebrands, acquisitions, and wind-downs to protect
-communities from scams, phishing, and impersonation during transitions."
+description: "Practical guidance and case studies on handling rebrands, acquisitions, and wind-downs to protect communities from scams, phishing, and impersonation during transitions."
 tags:
   - Operations & Strategy
   - Community & Marketing

--- a/docs/pages/governance/rebrands-and-reorgs.mdx
+++ b/docs/pages/governance/rebrands-and-reorgs.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Rebrands & Reorganizations | Security Alliance"
-description: "Practical guidance and case studies on handling rebrands, acquisitions, and wind-downs to protect communities from scams, phishing, and impersonation during transitions."
+description: "Practical guidance and case studies on handling rebrands, acquisitions, and wind-downs to protect
+communities from scams, phishing, and impersonation during transitions."
 tags:
   - Operations & Strategy
   - Community & Marketing
@@ -25,7 +26,8 @@ can create genuine safety risks for community members during the transition and 
 months afterwards. Having a clear plan and consistent communication strategy can keep
 community members safe.
 
-> 🔑 **Key Takeaway**: Rebrands and wind-downs create confusion that attackers exploit through phishing, impersonation, and fake migrations. Secure old accounts, communicate clearly, and monitor aggressively to protect your community.
+> 🔑 **Key Takeaway**: Rebrands and wind-downs create confusion attackers exploit through phishing, impersonation, and
+> fake migrations. Secure old accounts, communicate clearly, and monitor aggressively.
 
 ## Practical guidance
 
@@ -46,7 +48,7 @@ swaps, and impersonation accounts
 ### Keep Old Accounts
 
 | Asset | Risk if Abandoned | Action |
-|-------|-------------------|--------|
+| --- | --- | --- |
 | Domains | Expired domains can be re-registered by attackers to host phishing sites or impersonate the project. | Renew them, even if the project is over. It's cheap, and it blocks attackers. |
 | Social Media Handles | Abandoned handles can be claimed by impersonators who exploit the residual follower base and brand trust. | Keep them. Add a link to the new account in the bio. Or contact support to request a username change while transferring the old handle to a new account you control. |
 | Discord Vanity URL | When server Nitro boosts lapse below level 3, the vanity URL is released and can be sniped by scammers to create a fake Discord server with a drainer verification bot. | Maintain server boosts or monitor the vanity URL closely. If releasing it, warn the community and have a takedown plan ready. |
@@ -85,96 +87,121 @@ these lingering trust signals by re-claiming expired domains and inheriting thei
 
 ### Confusion Is the Primary Weapon
 
-During normal operations, community members have mental models for what's legitimate. They know the domain, the 
-Twitter handle, the contract addresses. A rebrand or acquisition shatters all of that at once. When everything is 
+During normal operations, community members have mental models for what's legitimate. They know the domain, the
+Twitter handle, the contract addresses. A rebrand or acquisition shatters all of that at once. When everything is
 "supposed to" look different, people lose their ability to distinguish real changes from fake ones.
 
 ### Urgency Is Built In
 
-Transitions naturally create time pressure. "Migrate your tokens before the deadline." "Claim your airdrop for the new token." 
-"Update your wallet connection to the new protocol." Attackers don't even need to manufacture urgency, the legitimate project 
+Transitions naturally create time pressure. "Migrate your tokens before the deadline." "Claim your airdrop for the new
+token."
+"Update your wallet connection to the new protocol." Attackers don't even need to manufacture urgency, the legitimate
+project
 is already doing it for them. They just mirror the real messaging with a malicious link swapped in.
 
 ### Bull vs. Bear Market
 
-Shutdowns and acquisitions often coincide with market trends. During the bear market, when most users are not paying attention
-is exactly when projects announce their shut downs and transitions. By the time markets swing back in the other direction and 
-"retail users" regain their interest in the projects that they engaged with before, many users have forgotten which assets they own 
-and who the authoritative sources of information are. This makes it easy for attackers to exploit and impersonate authoritative figures.
+Shutdowns and acquisitions often coincide with market trends. During the bear market, when most users are not paying
+attention
+is exactly when projects announce their shut downs and transitions. By the time markets swing back in the other
+direction and
+"retail users" regain their interest in the projects that they engaged with before, many users have forgotten which
+assets they own
+and who the authoritative sources of information are. This makes it easy for attackers to exploit and impersonate
+authoritative figures.
 
 ### Authority Structures Are Disrupted
 
-During acquisitions, community members may not know who's in charge anymore. New team members appear, old ones leave, 
-communication channels shift. This makes impersonation trivially easy since nobody knows what the "new" team sounds like yet, 
+During acquisitions, community members may not know who's in charge anymore. New team members appear, old ones leave,
+communication channels shift. This makes impersonation trivially easy since nobody knows what the "new" team sounds like
+yet,
 so a fake account claiming to be the new community lead is hard to distinguish from a real one.
 
 ### The User Base Is Pre-Qualified
 
-Wind-downs and migrations tell attackers exactly who holds assets and is motivated to act. A phishing campaign targeting 
-"all holders of token X who need to migrate" is far more effective than a generic scam, because the targets are real, 
+Wind-downs and migrations tell attackers exactly who holds assets and is motivated to act. A phishing campaign targeting
+"all holders of token X who need to migrate" is far more effective than a generic scam, because the targets are real,
 financially exposed, and expecting to take action.
 
 ### Emotional Vulnerability
 
-Wind-downs especially create frustration, fear, and desperation. People who are worried about losing their money or are 
-frustrated with the projects new direction are more likely to act impulsively, click suspicious links, and skip verification steps. 
+Wind-downs especially create frustration, fear, and desperation. People who are worried about losing their money or are
+frustrated with the projects new direction are more likely to act impulsively, click suspicious links, and skip
+verification steps.
 
 ### Information Asymmetry
 
-During these transitions, insiders know details that the community doesn't yet. Attackers exploit this gap by "leaking" fake insider 
-information — fake migration addresses, fake acquisition terms, fake deadlines — and people believe it because they know real 
+During these transitions, insiders know details that the community doesn't yet. Attackers exploit this gap by "leaking"
+fake insider
+information — fake migration addresses, fake acquisition terms, fake deadlines — and people believe it because they know
+real
 information is being withheld or rolled out gradually.
 
 ## Common pitfalls & examples
 
 ### MakerDAO → Sky Rebrand (September 2024)
 
-During the rebrand of MakerDAO to Sky, the old Twitter account handle @MakerDAO was changed and left available. Another user registered
-the username and began posting memes. It did not help that there were many questions in the community about the abrupt nature of the rebrand
+During the rebrand of MakerDAO to Sky, the old Twitter account handle @MakerDAO was changed and left available. Another
+user registered
+the username and began posting memes. It did not help that there were many questions in the community about the abrupt
+nature of the rebrand
 and confusion about the conversion of MKR governance tokens to SKY.
 
 The main mistake made by Sky was that they did not keep ownership of their original handle during the migration.
 
 **Lesson:** Never release a verified social handle before the new one is secured and announced.
 
-https://x.com/ForesightNewsEN/status/1829080229622808850
+[https://x.com/ForesightNewsEN/status/1829080229622808850](https://x.com/ForesightNewsEN/status/1829080229622808850)
 
 ### FTX Collapse & Bankruptcy (November 2022)
 
-In the weeks and months following the FTX collapse and ongoing bankruptcy proceedings, several impersonation and phishing attacks
+In the weeks and months following the FTX collapse and ongoing bankruptcy proceedings, several impersonation and
+phishing attacks
 were seen targeting former customers:
 
-- Emails saying "You have been identified as an eligible client to begin withdrawing digital assets from your FTX account" with a fake
+- Emails saying "You have been identified as an eligible client to begin withdrawing digital assets from your FTX
+  account" with a fake
 claims page.
-- SIM-swapping attacks targeting leaked customer data that was improperly obtained from a data breach of the claims administrator Kroll.
-- Advance-Fee Fraud where victims are instructed to pay a commission, legal fee, or tax upfront to expedite the release of their frozen crypto assets.
+- SIM-swapping attacks targeting leaked customer data that was improperly obtained from a data breach of the claims
+  administrator Kroll.
+- Advance-Fee Fraud where victims are instructed to pay a commission, legal fee, or tax upfront to expedite the release
+  of their frozen crypto assets.
 
-**Lesson:** During bankruptcy and claims processes, expect phishing targeting the claim process — communicate only through court-verified channels.
+**Lesson:** During bankruptcy and claims processes, expect phishing targeting the claim process — communicate only
+through court-verified channels.
 
-https://finance.yahoo.com/news/ftx-customers-hit-withdrawal-phishing-064440389.html?guccounter=1
+[https://finance.yahoo.com/news/ftx-customers-hit-withdrawal-phishing-064440389.html?guccounter=1](https://finance.yahoo.com/news/ftx-customers-hit-withdrawal-phishing-064440389.html?guccounter=1)
 
 ### OpenClaw / ClawdBot Rebrand (January 2026)
 
-When OpenClaw received a trademark notice about its original name, the team went through a rebrand. During the brief window between 
-releasing old social media handles and claiming new ones, scammers seized the abandoned accounts on X.com and GitHub. Attackers stole the 
-identity and launched a fake Solana-based token called $CLAWD that reached $16 million in market cap before crashing 90%. 
+When OpenClaw received a trademark notice about its original name, the team went through a rebrand. During the brief
+window between
+releasing old social media handles and claiming new ones, scammers seized the abandoned accounts on X.com and GitHub.
+Attackers stole the
+identity and launched a fake Solana-based token called $CLAWD that reached $16 million in market cap before crashing
+90%.
 
-The core mistake was simple: they released old handles before securing new ones, creating a window attackers were ready to exploit.
+The core mistake was simple: they released old handles before securing new ones, creating a window attackers were ready
+to exploit.
 
-**Lesson:** Secure new handles before releasing old ones, and monitor for token impersonation in the window between rebrand and community awareness.
+**Lesson:** Secure new handles before releasing old ones, and monitor for token impersonation in the window between
+rebrand and community awareness.
 
-https://www.malwarebytes.com/blog/threat-intel/2026/01/clawdbots-rename-to-moltbot-sparks-impersonation-campaign
-
+[https://www.malwarebytes.com/blog/threat-intel/2026/01/clawdbots-rename-to-moltbot-sparks-impersonation-campaign](https://www.malwarebytes.com/blog/threat-intel/2026/01/clawdbots-rename-to-moltbot-sparks-impersonation-campaign)
 
 ## Best Practices
 
-1. Announce transitions early and simultaneously across all official channels, establishing a single canonical source of truth.
-2. Warn your community in advance that scammers will exploit the transition, and teach them how to verify legitimate communications.
+1. Announce transitions early and simultaneously across all official channels, establishing a single canonical source of
+   truth.
+2. Warn your community in advance that scammers will exploit the transition, and teach them how to verify legitimate
+   communications.
 3. Keep old accounts, domains, and channels active with redirect notices rather than abandoning them to hijackers.
 4. Publish new contract addresses and official links well in advance through multiple verified channels.
-5. Never manufacture urgency. Provide long grace periods for migrations and withdrawals, extend well beyond announced end dates.
+5. Never manufacture urgency. Provide long grace periods for migrations and withdrawals, extend well beyond announced
+   end dates.
 6. Be explicit about what happens to treasury funds, user data, and any information transferring to an acquirer.
-7. Run major transitions through governance and give the community a voice, even if the project isn't fully decentralized.
+7. Run major transitions through governance and give the community a voice, even if the project isn't fully
+   decentralized.
 8. Rotate keys, revoke deprecated contract permissions, and audit access credentials as part of every transition.
 9. Archive all documentation, governance decisions, and community discussions publicly and permanently.
 10. Monitor aggressively for scam domains, fake social accounts, and phishing campaigns after every transition.
@@ -189,8 +216,10 @@ https://www.malwarebytes.com/blog/threat-intel/2026/01/clawdbots-rename-to-moltb
 ## Related Frameworks
 
 - [Risk Management](/governance/risk-management) — Assess and mitigate risks during organizational transitions.
-- [Incident Detection and Response](/incident-management/incident-detection-and-response) — Monitor for and respond to scams and phishing during and after transitions.
-- [OpSec: Endpoint Overview](/opsec/endpoint/overview) — Key rotation, credential hygiene, and endpoint security during transitions.
+- [Incident Detection and Response](/incident-management/incident-detection-and-response) — Monitor for and respond to
+  scams and phishing during and after transitions.
+- [OpSec: Endpoint Overview](/opsec/endpoint/overview) — Key rotation, credential hygiene, and endpoint security during
+  transitions.
 
 ---
 

--- a/docs/pages/governance/rebrands-and-reorgs.mdx
+++ b/docs/pages/governance/rebrands-and-reorgs.mdx
@@ -189,7 +189,7 @@ rebrand and community awareness.
 
 [https://www.malwarebytes.com/blog/threat-intel/2026/01/clawdbots-rename-to-moltbot-sparks-impersonation-campaign](https://www.malwarebytes.com/blog/threat-intel/2026/01/clawdbots-rename-to-moltbot-sparks-impersonation-campaign)
 
-## Best Practices
+## Best practices
 
 1. Announce transitions early and simultaneously across all official channels, establishing a single canonical source of
    truth.

--- a/docs/pages/governance/risk-management.mdx
+++ b/docs/pages/governance/risk-management.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Risk Management | Security Alliance"
-description: "Identify, assess, and mitigate security threats with frameworks like NIST, ISO 27001, and COBIT. Use a risk matrix to prioritize by likelihood and impact, and conduct regular assessments."
+description: "Identify, assess, and mitigate security threats with frameworks like NIST, ISO 27001, and COBIT. Use a risk matrix to prioritize by likelihood and impact"
 tags:
   - Operations & Strategy
   - Legal & Compliance

--- a/docs/pages/governance/risk-management.mdx
+++ b/docs/pages/governance/risk-management.mdx
@@ -39,7 +39,11 @@ communicating risk findings and mitigation strategies to relevant people.
 
 ## Further Reading
 
-- [Governance overview](/governance/overview)
+- [Governance overview](/governance/overview): how the pages of this framework fit together
+- [Threat Modeling overview](/threat-modeling/overview): identifying the threats a risk matrix then ranks
+- [Security Metrics and KPIs](/governance/security-metrics-kpis): measuring whether mitigations are working
+- [NIST Risk Management Framework](https://csrc.nist.gov/projects/risk-management): the reference process behind the
+  practices above
 
 ---
 

--- a/docs/pages/governance/risk-management.mdx
+++ b/docs/pages/governance/risk-management.mdx
@@ -36,6 +36,11 @@ communicating risk findings and mitigation strategies to relevant people.
 3. Conduct regular risk assessments and reviews to keep up with the rapidly evolving threat landscape.
 4. Use lessons learned from past incidents and risk assessments to continuously improve your risk management practices.
 
+
+## Further Reading
+
+- [Governance overview](/governance/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/governance/risk-management.mdx
+++ b/docs/pages/governance/risk-management.mdx
@@ -6,7 +6,7 @@ tags:
   - Legal & Compliance
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/governance/risk-management.mdx
+++ b/docs/pages/governance/risk-management.mdx
@@ -4,6 +4,13 @@ description: "Identify, assess, and mitigate security threats with frameworks li
 tags:
   - Operations & Strategy
   - Legal & Compliance
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -12,6 +19,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Risk management ranks threats by likelihood and impact so scarce security effort hits the worst
+> loss first—and re-runs as the landscape changes.
 
 If a project has effective risk management, it is also likely to be successful at identifying, assessing, and mitigating
 potential threats to the project. By utilizing risk management, you're likely to be able to prioritize security efforts

--- a/docs/pages/governance/security-metrics-kpis.mdx
+++ b/docs/pages/governance/security-metrics-kpis.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Security Metrics & KPIs | Security Alliance"
-description: "Measure security performance with KPIs: Mean Time to Detect (MTTD), Mean Time to Respond (MTTR), Patch Management Effectiveness, and Security Audit Findings resolution rates."
+description: "Measure security performance with KPIs: Mean Time to Detect (MTTD), Mean Time to Respond (MTTR), Patch Management Effectiveness"
 tags:
   - Operations & Strategy
   - Legal & Compliance

--- a/docs/pages/governance/security-metrics-kpis.mdx
+++ b/docs/pages/governance/security-metrics-kpis.mdx
@@ -48,7 +48,12 @@ specified period.
 
 ## Further Reading
 
-- [Governance overview](/governance/overview)
+- [Governance overview](/governance/overview): how the pages of this framework fit together
+- [Risk Management](/governance/risk-management): the risks these metrics are meant to track
+- [Incident Detection and Response](/incident-management/incident-detection-and-response): where MTTD and MTTR data
+  comes from
+- [NIST SP 800-55: Measurement Guide for Information Security](https://csrc.nist.gov/pubs/sp/800/55/v1/final): how to
+  build metrics that survive scrutiny
 
 ---
 

--- a/docs/pages/governance/security-metrics-kpis.mdx
+++ b/docs/pages/governance/security-metrics-kpis.mdx
@@ -4,6 +4,13 @@ description: "Measure security performance with KPIs: Mean Time to Detect (MTTD)
 tags:
   - Operations & Strategy
   - Legal & Compliance
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -12,6 +19,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Security metrics are only useful when someone owns them and acts on trends—not when dashboards
+> go unread. MTTD, MTTR, and patch lag are classic starting points.
 
 Measuring security performance through metrics and Key Performance Indicators (KPIs) can be very useful for assessing
 the effectiveness of your security program, and can allow you to make informed decisions on what actions to take with

--- a/docs/pages/governance/security-metrics-kpis.mdx
+++ b/docs/pages/governance/security-metrics-kpis.mdx
@@ -6,7 +6,7 @@ tags:
   - Legal & Compliance
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/governance/security-metrics-kpis.mdx
+++ b/docs/pages/governance/security-metrics-kpis.mdx
@@ -45,6 +45,11 @@ Some examples of what could be worth recording are:
 - **Security Audit Findings**: Number of findings from security audits and the percentage of findings resolved within a
 specified period.
 
+
+## Further Reading
+
+- [Governance overview](/governance/overview)
+
 ---
 
 <ContributeFooter />


### PR DESCRIPTION
## Scope

Normalize **Governance** (`docs/pages/governance/`).

## Why

Thin overview; missing KTs; broken H1s in compliance; council missing AttributionList; rebrands markdownlint debt.

## Substantive security/legal changes

**None.**

## Validation

- [x] cspell / markdownlint-cli2 clean
- [x] signedcommit

## Dependencies

**#561** by reference.