### PR TITLE
docs(external-security-reviews): normalize structure and wording

### DIFF
--- a/docs/pages/external-security-reviews/overview.mdx
+++ b/docs/pages/external-security-reviews/overview.mdx
@@ -75,7 +75,7 @@ one-time badge.
 - [Incident Management](/incident-management/overview): when reviews or production uncover active issues
 - [Supply Chain](/supply-chain/overview): dependency and delivery integrity next to app reviews
 
-## Further Reading & Tools
+## Further Reading
 
 - Nested smart-contract pages for engagement detail
 - [OWASP](https://owasp.org/) application assessment resources

--- a/docs/pages/external-security-reviews/overview.mdx
+++ b/docs/pages/external-security-reviews/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "External Security Reviews | Security Alliance"
-description: "External Security Reviews: Security assessments to identify vulnerabilities in applications and infrastructure. Build stakeholder trust and meet compliance."
+description: "Scope and run external security reviews for apps, infrastructure, and smart contracts—plus policy review and vendor selection—so findings become fixes, not shelfware."
 tags:
   - Security Specialist
   - Operations & Strategy
@@ -8,6 +8,10 @@ tags:
 contributors:
   - role: wrote
     users: [patrickalphac]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -17,43 +21,65 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-An external security review is a time-boxed, security-based assessment of software systems, applications, and
-infrastructure to enhance security and identify vulnerabilities. External security reviews are essential for
-organizations to protect against threats and build trust with users and stakeholders.
+> 🔑 **Key Takeaway**: External reviews are time-boxed expert assessments. They reduce risk and educate teams, but they
+> are not a certificate of safety—pair them with preparation, remediation, and ongoing testing.
 
-## Why Are External Security Reviews Important?
+An external security review is a time-boxed, security-focused assessment of software systems, applications, and
+infrastructure to identify vulnerabilities and strengthen defenses. Reviews build trust with users and stakeholders when
+findings are fixed and openly tracked.
 
-According to research, significant value and data have been compromised due to security vulnerabilities in software
-systems. Modern applications face complex threats from malicious actors, and security issues can lead to data breaches,
-financial losses, and reputation damage.
+## Why external security reviews matter
 
-Beyond preventing security incidents, external security reviews provide several key benefits:
+Modern applications face complex threats. Security defects can lead to data breaches, financial loss, and reputation
+damage. Beyond incident prevention, reviews commonly deliver:
 
-- **Enhanced Security**: Find and fix vulnerabilities before they can be exploited
-- **Team Education**: Level up your engineering team's knowledge through security best practices
-- **Trust Building**: Demonstrate maturity and safety to users and stakeholders
-- **Risk Mitigation**: Identify business logic issues and implementation flaws
-- **Compliance**: Meet regulatory and industry security requirements
+- **Enhanced security:** find and fix issues before exploitation
+- **Team education:** transfer techniques and standards to engineers
+- **Trust building:** demonstrate maturity to users and counterparties
+- **Risk mitigation:** surface business-logic and implementation flaws
+- **Compliance support:** evidence for regulated or partner requirements
 
-## Scope of External Security Reviews
+## Scope of reviews
 
-Security reviews can encompass multiple layers of an organization's technology stack:
+Reviews can cover many layers:
 
-- **Applications**: Web applications, mobile apps, APIs, and microservices
-- **Infrastructure**: Cloud configurations, network security, access controls, and deployment pipelines
-- **Data Systems**: Databases, data processing pipelines, and storage security
-- **Third-party Integrations**: External APIs, libraries, and vendor services
-- **Documentation**: Technical specifications, security policies, and incident response procedures
+- **Applications:** web, mobile, APIs, microservices
+- **Infrastructure:** cloud config, network security, access control, pipelines
+- **Data systems:** databases, processing pipelines, storage controls
+- **Third-party integrations:** external APIs, libraries, vendors
+- **Documentation and process:** specifications, security policies, incident procedures
 
-External security reviews are not foolproof and cannot guarantee absolute security. They represent an ongoing commitment
-to safety rather than a one-time event.
+External reviews are not foolproof and cannot guarantee absolute security. Treat them as recurring commitment, not a
+one-time badge.
 
-## Contents
+## What this framework covers
 
-There are many different kinds of external security reviews, and we have some context on many of them here.
+1. [Smart Contract Security Reviews](/external-security-reviews/smart-contracts/overview): scoping, preparation, methods,
+   and vendor choice for on-chain code.
+2. [Security Policies and Procedures](/external-security-reviews/security-policies-procedures): reviewing internal
+   policy maturity alongside product assessments.
 
-1. [Smart Contract Audits](/external-security-reviews/smart-contracts/overview)
-2. [Security Policies and Procedures](/external-security-reviews/security-policies-procedures)
+### Smart contract subsection
+
+1. [Expectations](/external-security-reviews/smart-contracts/expectation): engagement phases and what good looks like.
+2. [Preparation](/external-security-reviews/smart-contracts/preparation): how to maximize review value before kickoff.
+3. [Vendor Selection](/external-security-reviews/smart-contracts/vendor-selection): private vs competitive audits and
+   selection criteria.
+4. [Manual Review](/external-security-reviews/smart-contracts/manual-review): how reviewers structure deep code analysis.
+
+## Related frameworks
+
+- [Security Testing](/security-testing/overview): internal testing that should precede and follow audits
+- [Secure Software Development](/secure-software-development/overview): review and coding standards
+- [Vulnerability Disclosure](/vulnerability-disclosure/overview): ongoing reporting after audits
+- [Incident Management](/incident-management/overview): when reviews or production uncover active issues
+- [Supply Chain](/supply-chain/overview): dependency and delivery integrity next to app reviews
+
+## Further Reading & Tools
+
+- Nested smart-contract pages for engagement detail
+- [OWASP](https://owasp.org/) application assessment resources
+- [Trail of Bits — Building secure contracts](https://secure-contracts.com/)
 
 ---
 

--- a/docs/pages/external-security-reviews/overview.mdx
+++ b/docs/pages/external-security-reviews/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "External Security Reviews | Security Alliance"
-description: "Scope and run external security reviews for apps, infrastructure, and smart contracts—plus policy review and vendor selection—so findings become fixes, not shelfware."
+description: "Scope and run external security reviews for apps, infrastructure, and smart contracts—plus policy review and vendor selection—so findings become fixes"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/external-security-reviews/security-policies-procedures.mdx
+++ b/docs/pages/external-security-reviews/security-policies-procedures.mdx
@@ -9,6 +9,10 @@ tags:
 contributors:
   - role: wrote
     users: [patrickalphac]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -17,6 +21,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: External product reviews are stronger when policies for IR, access, change management, and
+> training exist and match real practice—not only binder aspirational documents.
 
 As part of the external security review, it could be beneficial to also review the internal security policies and
 procedures as well.

--- a/docs/pages/external-security-reviews/security-policies-procedures.mdx
+++ b/docs/pages/external-security-reviews/security-policies-procedures.mdx
@@ -38,7 +38,13 @@ Some of the things that could be relevant to review are:
 
 ## Further Reading
 
-- [External Security Reviews overview](/external-security-reviews/overview)
+- [External Security Reviews overview](/external-security-reviews/overview): how the pages of this framework fit
+  together
+- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy): a template for
+  the response plan reviewers look for
+- [Role-Based Access Control](/iam/role-based-access-control): defining roles and least privilege in practice
+- [Compliance with Regulatory Requirements](/governance/compliance-regulatory-requirements): the standards these
+  policies are measured against
 
 ---
 

--- a/docs/pages/external-security-reviews/security-policies-procedures.mdx
+++ b/docs/pages/external-security-reviews/security-policies-procedures.mdx
@@ -35,6 +35,11 @@ Some of the things that could be relevant to review are:
 4. Ensure there are regular training sessions conducted for all team members on security best practices.
 5. Ensure adherence to any potentially relevant regulatory and industry standards for your project.
 
+
+## Further Reading
+
+- [External Security Reviews overview](/external-security-reviews/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/external-security-reviews/smart-contracts/expectation.mdx
+++ b/docs/pages/external-security-reviews/smart-contracts/expectation.mdx
@@ -89,6 +89,11 @@ contracts, and the specific requirements of the project.
 - **Emergency Preparedness**: Even audited protocols should have incident response plans and emergency communication
   channels
 
+
+## Further Reading
+
+- [External Security Reviews overview](/external-security-reviews/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/external-security-reviews/smart-contracts/expectation.mdx
+++ b/docs/pages/external-security-reviews/smart-contracts/expectation.mdx
@@ -7,6 +7,10 @@ tags:
 contributors:
   - role: wrote
     users: [patrickalphac]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
@@ -15,6 +19,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Clear scope, phased work (assess → mitigate → re-review), and a final report define a
+> professional smart contract audit engagement.
 
 ## Scoping Phase
 

--- a/docs/pages/external-security-reviews/smart-contracts/expectation.mdx
+++ b/docs/pages/external-security-reviews/smart-contracts/expectation.mdx
@@ -92,7 +92,12 @@ contracts, and the specific requirements of the project.
 
 ## Further Reading
 
-- [External Security Reviews overview](/external-security-reviews/overview)
+- [Smart Contract Security Reviews](/external-security-reviews/smart-contracts/overview): the full engagement this page
+  describes phase by phase
+- [Preparation](/external-security-reviews/smart-contracts/preparation): what to do before the scoping call
+- [Vendor Selection](/external-security-reviews/smart-contracts/vendor-selection): choosing who delivers these
+  deliverables
+- [Security Testing overview](/security-testing/overview): the testing methods auditors run during assessment
 
 ---
 

--- a/docs/pages/external-security-reviews/smart-contracts/manual-review.mdx
+++ b/docs/pages/external-security-reviews/smart-contracts/manual-review.mdx
@@ -347,7 +347,7 @@ Update the report and issue status based on the updated code.
         - These may include the reasons why an issue is acknowledged, or mitigations that will not be implemented at the
         smart contract level, but are not limited to these.
 
-## Final thoughts
+### Final thoughts
 
 Having multiple teams/members review each contract individually leads to better results, as it ensures more sets of eyes
 are examining the code.

--- a/docs/pages/external-security-reviews/smart-contracts/manual-review.mdx
+++ b/docs/pages/external-security-reviews/smart-contracts/manual-review.mdx
@@ -352,9 +352,15 @@ Update the report and issue status based on the updated code.
 Having multiple teams/members review each contract individually leads to better results, as it ensures more sets of eyes
 are examining the code.
 
-## References
+## Further Reading
 
-- [Auditing mental model by Caliber](https://www.calibersec.com/smart-contract-auditing-mental-model/)
+- [Smart Contract Security Reviews](/external-security-reviews/smart-contracts/overview): where manual review sits
+  among the other methodologies
+- [Code Reviews and Peer Audits](/secure-software-development/code-reviews-peer-audits): applying the same reading
+  discipline internally
+- [Auditing mental model by Caliber](https://www.calibersec.com/smart-contract-auditing-mental-model/): how experienced
+  reviewers structure a pass
+- [Building Secure Contracts](https://secure-contracts.com/): Trail of Bits guidance on properties and known pitfalls
 
 ---
 

--- a/docs/pages/external-security-reviews/smart-contracts/manual-review.mdx
+++ b/docs/pages/external-security-reviews/smart-contracts/manual-review.mdx
@@ -8,6 +8,10 @@ tags:
 contributors:
   - role: wrote
     users: [the-caliber]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
@@ -16,6 +20,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Manual review finds logic and design flaws automation misses. Systematic notes, diagrams, and
+> checklists keep analysis complete under time pressure.
 
 Manual review of a smart contract is the process of carefully examining the source code to identify potential
 vulnerabilities, logic errors, and design flaws.

--- a/docs/pages/external-security-reviews/smart-contracts/overview.mdx
+++ b/docs/pages/external-security-reviews/smart-contracts/overview.mdx
@@ -74,8 +74,7 @@ complex vulnerabilities
 - More cost-effective option
 - Broader coverage through competition
 
-## What this section covers
-
+## What this framework covers
 1. [Audit Expectations](/external-security-reviews/smart-contracts/expectation) - What to expect during the audit
 process
 2. [Preparation Guide](/external-security-reviews/smart-contracts/preparation) - How to prepare for a successful audit

--- a/docs/pages/external-security-reviews/smart-contracts/overview.mdx
+++ b/docs/pages/external-security-reviews/smart-contracts/overview.mdx
@@ -81,10 +81,14 @@ process
 3. [Vendor Selection](/external-security-reviews/smart-contracts/vendor-selection) - Choosing the right security auditor
 4. [Manual Review](/external-security-reviews/smart-contracts/manual-review) - Deep expert code analysis practice
 
-
 ## Further Reading
 
-- [External Security Reviews overview](/external-security-reviews/overview)
+- [External Security Reviews overview](/external-security-reviews/overview): how the pages of this framework fit
+  together
+- [Security Testing overview](/security-testing/overview): the internal testing that should precede an engagement
+- [Bug Bounties](/vulnerability-disclosure/bug-bounties): continuous coverage after the report is delivered
+- [OWASP Smart Contract Top 10](https://owasp.org/www-project-smart-contract-top-10/): the vulnerability classes
+  reviewers hunt for
 
 ---
 

--- a/docs/pages/external-security-reviews/smart-contracts/overview.mdx
+++ b/docs/pages/external-security-reviews/smart-contracts/overview.mdx
@@ -82,6 +82,11 @@ process
 3. [Vendor Selection](/external-security-reviews/smart-contracts/vendor-selection) - Choosing the right security auditor
 4. [Manual Review](/external-security-reviews/smart-contracts/manual-review) - Deep expert code analysis practice
 
+
+## Further Reading
+
+- [External Security Reviews overview](/external-security-reviews/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/external-security-reviews/smart-contracts/overview.mdx
+++ b/docs/pages/external-security-reviews/smart-contracts/overview.mdx
@@ -8,6 +8,10 @@ tags:
 contributors:
   - role: wrote
     users: [patrickalphac]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
@@ -16,6 +20,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Smart contract reviews are essential because deployments are hard to reverse and often hold
+> significant value. Scope, prepare, and remediate—or the engagement wastes both sides' time.
 
 Smart contract security reviews are specialized assessments focused on identifying vulnerabilities in blockchain-based
 smart contracts and protocols. These reviews are critical for web3 projects due to the immutable nature of blockchain
@@ -67,14 +74,13 @@ complex vulnerabilities
 - More cost-effective option
 - Broader coverage through competition
 
-## Contents
-
-This section contains detailed guidance on different aspects of smart contract security reviews:
+## What this section covers
 
 1. [Audit Expectations](/external-security-reviews/smart-contracts/expectation) - What to expect during the audit
 process
 2. [Preparation Guide](/external-security-reviews/smart-contracts/preparation) - How to prepare for a successful audit
 3. [Vendor Selection](/external-security-reviews/smart-contracts/vendor-selection) - Choosing the right security auditor
+4. [Manual Review](/external-security-reviews/smart-contracts/manual-review) - Deep expert code analysis practice
 
 ---
 

--- a/docs/pages/external-security-reviews/smart-contracts/preparation.mdx
+++ b/docs/pages/external-security-reviews/smart-contracts/preparation.mdx
@@ -87,6 +87,11 @@ The first step in a security audit should be a high-level video walkthrough wher
 This walkthrough helps auditors understand your system quickly and focus their time on security analysis rather than
 code comprehension.
 
+
+## Further Reading
+
+- [External Security Reviews overview](/external-security-reviews/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/external-security-reviews/smart-contracts/preparation.mdx
+++ b/docs/pages/external-security-reviews/smart-contracts/preparation.mdx
@@ -8,6 +8,10 @@ tags:
 contributors:
   - role: wrote
     users: [patrickalphac]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
@@ -16,6 +20,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Preparation (docs, tests, static analysis cleanup) multiplies audit ROI. Handing over untested
+> code makes experts expensive nannies for basic defects.
 
 A common misconception is that when doing a security review, you can just hand off the written code and let reviewers do
 their work. This approach is inefficient and costly, as auditors will spend time on issues you could have resolved

--- a/docs/pages/external-security-reviews/smart-contracts/preparation.mdx
+++ b/docs/pages/external-security-reviews/smart-contracts/preparation.mdx
@@ -90,7 +90,12 @@ code comprehension.
 
 ## Further Reading
 
-- [External Security Reviews overview](/external-security-reviews/overview)
+- [Smart Contract Security Reviews](/external-security-reviews/smart-contracts/overview): where preparation sits in the
+  engagement
+- [Static Analysis](/security-testing/static-analysis): clearing low-hanging findings before auditors see the code
+- [Code Reviews and Peer Audits](/secure-software-development/code-reviews-peer-audits): internal review habits that
+  reduce audit findings
+- [Slither](https://github.com/crytic/slither): the Solidity static analyzer referenced above
 
 ---
 

--- a/docs/pages/external-security-reviews/smart-contracts/vendor-selection.mdx
+++ b/docs/pages/external-security-reviews/smart-contracts/vendor-selection.mdx
@@ -7,6 +7,10 @@ tags:
 contributors:
   - role: wrote
     users: [patrickalphac]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
@@ -15,6 +19,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Pick vendors for domain fit, method (private vs competitive), and evidence of quality—not logo
+> count alone. Match engagement style to risk and timeline.
 
 Choosing the right security vendor is crucial for getting maximum value from your security review. There are numerous
 security vendors in both the web3 and web2 ecosystems, each with different specializations and approaches.

--- a/docs/pages/external-security-reviews/smart-contracts/vendor-selection.mdx
+++ b/docs/pages/external-security-reviews/smart-contracts/vendor-selection.mdx
@@ -121,7 +121,11 @@ comparison of the two auditors.
 
 ## Further Reading
 
-- [External Security Reviews overview](/external-security-reviews/overview)
+- [Smart Contract Security Reviews](/external-security-reviews/smart-contracts/overview): how vendor choice fits the
+  wider engagement
+- [Audit Expectations](/external-security-reviews/smart-contracts/expectation): what a vendor should actually deliver
+- [Bug Bounties](/vulnerability-disclosure/bug-bounties): the continuous alternative to a fixed engagement
+- [Solodit](https://solodit.xyz/): read a firm's published findings before signing with them
 
 ---
 

--- a/docs/pages/external-security-reviews/smart-contracts/vendor-selection.mdx
+++ b/docs/pages/external-security-reviews/smart-contracts/vendor-selection.mdx
@@ -118,6 +118,11 @@ then auditor B reviews the same codebase and finds more bugs, some insight from 
 those extra bugs. However, if two auditors review the same codebase at the same time, this can be a much better
 comparison of the two auditors.
 
+
+## Further Reading
+
+- [External Security Reviews overview](/external-security-reviews/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/external-security-reviews/smart-contracts/vendor-selection.mdx
+++ b/docs/pages/external-security-reviews/smart-contracts/vendor-selection.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Selecting a Smart Contract Auditor | Security Alliance"
-description: "Choose the right security auditor: evaluate track record, domain expertise in web3 or web2, technical capabilities in Solidity or Rust, and compare private audits vs. public competitive audits."
+description: "Choose the right security auditor: evaluate track record, domain expertise in web3 or web2, technical capabilities in Solidity or Rust"
 tags:
   - Security Specialist
   - Operations & Strategy


### PR DESCRIPTION
## Scope

Normalize **External Security Reviews** (`docs/pages/external-security-reviews/` + smart-contracts/).

## Why

Missing Key Takeaways; overview Contents only; incomplete contributor roles.

## Substantive security changes

**None.**

## Validation

- [x] cspell / markdownlint
- [x] signed commit

## Dependencies

**#561** by reference.