### PR TITLE
docs(ai-security): normalize structure and wording

### DIFF
--- a/docs/pages/ai-security/ai-browsers.mdx
+++ b/docs/pages/ai-security/ai-browsers.mdx
@@ -10,6 +10,8 @@ contributors:
     users: [munamwasi, jubos, masterfung]
   - role: reviewed
     users: [mattaereal]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -18,6 +20,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: AI browsers load untrusted web content into the model context. Inspect inbound content and
+> outbound actions in real time or the open web becomes the control plane.
 
 AI browsers are interfaces that enable models to interact with external content, such as web pages, APIs, and online
 data sources. While they expand the model's context and capability, they also broaden the attack surface by introducing

--- a/docs/pages/ai-security/ai-browsers.mdx
+++ b/docs/pages/ai-security/ai-browsers.mdx
@@ -1,6 +1,6 @@
 ---
 title: "AI Browsers | SEAL"
-description: "Threat model and controls for AI browsers interacting with dynamic external web content and APIs."
+description: "Threat model and controls for AI browsers interacting with dynamic external web content and APIs. Inspect inbound content and outbound actions in real"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/ai-security/ai-browsers.mdx
+++ b/docs/pages/ai-security/ai-browsers.mdx
@@ -43,6 +43,11 @@ data sources. On-chain visibility does not guarantee safety without runtime vali
 - Akamai Firewall for AI - edge runtime inspection for prompts and responses
 - Wiz AI-SPM - posture management visibility into AI app configuration and data exposure
 
+
+## Further Reading
+
+- [Ai Security overview](/ai-security/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/ai-security/ai-browsers.mdx
+++ b/docs/pages/ai-security/ai-browsers.mdx
@@ -43,10 +43,13 @@ data sources. On-chain visibility does not guarantee safety without runtime vali
 - Akamai Firewall for AI - edge runtime inspection for prompts and responses
 - Wiz AI-SPM - posture management visibility into AI app configuration and data exposure
 
-
 ## Further Reading
 
-- [Ai Security overview](/ai-security/overview)
+- [AI Security overview](/ai-security/overview): how the pages of this framework fit together
+- [Prompt Injection Defenses](/ai-security/prompt-injection-defenses): the attack class that web content delivers
+- [Browser Security](/opsec/browser/overview): profile separation and extension hygiene for the underlying browser
+- [Brave: Comet prompt injection research](https://brave.com/blog/comet-prompt-injection/): a worked example of a page
+  hijacking an AI browser
 
 ---
 

--- a/docs/pages/ai-security/ai-workflows-developers-vs-non-developers.mdx
+++ b/docs/pages/ai-security/ai-workflows-developers-vs-non-developers.mdx
@@ -11,6 +11,8 @@ contributors:
     users: [munamwasi, jubos, masterfung]
   - role: reviewed
     users: [mattaereal]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -19,6 +21,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Developer agent stacks need tool and sandbox gates; non-developer SaaS AI needs data
+> classification, output gates, and approved-app policy—same risk theme, different controls.
 
 AI workflows differ significantly based on user intent and technical context. Developer workflows involve code, APIs,
 model orchestration, and embedded systems where execution paths are explicit and controllable. Non-developer workflows,

--- a/docs/pages/ai-security/ai-workflows-developers-vs-non-developers.mdx
+++ b/docs/pages/ai-security/ai-workflows-developers-vs-non-developers.mdx
@@ -1,6 +1,6 @@
 ---
 title: "AI Workflows: Developers vs Non-Developers | SEAL"
-description: "How AI security strategy should differ between developer and non-developer AI usage workflows."
+description: "How AI security strategy should differ between developer and non-developer AI usage workflows. non-developer SaaS AI needs data classification, output"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/ai-security/ai-workflows-developers-vs-non-developers.mdx
+++ b/docs/pages/ai-security/ai-workflows-developers-vs-non-developers.mdx
@@ -45,6 +45,11 @@ public blockchain data but still require safeguards against misinterpretation or
 - Obsidian Security - browser-level enforcement for AI data policies and prompt inspection
 - Nightfall AI - AI-native DLP across SaaS, endpoints, browsers, and AI applications
 
+
+## Further Reading
+
+- [Ai Security overview](/ai-security/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/ai-security/ai-workflows-developers-vs-non-developers.mdx
+++ b/docs/pages/ai-security/ai-workflows-developers-vs-non-developers.mdx
@@ -45,10 +45,13 @@ public blockchain data but still require safeguards against misinterpretation or
 - Obsidian Security - browser-level enforcement for AI data policies and prompt inspection
 - Nightfall AI - AI-native DLP across SaaS, endpoints, browsers, and AI applications
 
-
 ## Further Reading
 
-- [Ai Security overview](/ai-security/overview)
+- [AI Security overview](/ai-security/overview): how the pages of this framework fit together
+- [Data Exfiltration via Generative Systems](/ai-security/data-exfiltration-via-generative-systems): the shared risk
+  behind both workflow types
+- [Security Training](/user-team-security/security-training): role-based guidance for non-developer AI users
+- [OWASP GenAI Security Project](https://genai.owasp.org/): control guidance for LLM and agentic applications
 
 ---
 

--- a/docs/pages/ai-security/data-exfiltration-via-generative-systems.mdx
+++ b/docs/pages/ai-security/data-exfiltration-via-generative-systems.mdx
@@ -10,6 +10,8 @@ contributors:
     users: [munamwasi, jubos, masterfung]
   - role: reviewed
     users: [mattaereal]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -18,6 +20,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Generative systems can be coaxed to emit sensitive inputs. Block or quarantine unsafe outputs
+> before release instead of hoping post-hoc reviews catch history.
 
 AI systems that process sensitive inputs such as documents, logs, or enterprise data are vulnerable to exfiltration
 attacks. Without proper runtime controls, models can be coaxed into extracting and exporting confidential information

--- a/docs/pages/ai-security/data-exfiltration-via-generative-systems.mdx
+++ b/docs/pages/ai-security/data-exfiltration-via-generative-systems.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Data Exfiltration via Generative Systems | SEAL"
-description: "Runtime data exfiltration risk and controls for generative AI systems processing sensitive information."
+description: "Runtime data exfiltration risk and controls for generative AI systems processing sensitive information. AI systems that process sensitive inputs such"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/ai-security/data-exfiltration-via-generative-systems.mdx
+++ b/docs/pages/ai-security/data-exfiltration-via-generative-systems.mdx
@@ -43,10 +43,14 @@ operational or financial information, even when underlying blockchain data is pu
 - Proofpoint (Acuvity) - runtime inspection and enforcement across AI apps, agents, and MCP servers
 - Reco AI - SaaS AI exposure discovery, permission auditing, and exfiltration pathway detection
 
-
 ## Further Reading
 
-- [Ai Security overview](/ai-security/overview)
+- [AI Security overview](/ai-security/overview): how the pages of this framework fit together
+- [Prompt Injection Defenses](/ai-security/prompt-injection-defenses): the input-side control that prevents most
+  coerced disclosure
+- [AI Workflows: Developers vs Non-Developers](/ai-security/ai-workflows-developers-vs-non-developers): data
+  classification for SaaS AI tools
+- [MITRE ATLAS](https://atlas.mitre.org/): adversary techniques against AI systems, including exfiltration
 
 ---
 

--- a/docs/pages/ai-security/data-exfiltration-via-generative-systems.mdx
+++ b/docs/pages/ai-security/data-exfiltration-via-generative-systems.mdx
@@ -43,6 +43,11 @@ operational or financial information, even when underlying blockchain data is pu
 - Proofpoint (Acuvity) - runtime inspection and enforcement across AI apps, agents, and MCP servers
 - Reco AI - SaaS AI exposure discovery, permission auditing, and exfiltration pathway detection
 
+
+## Further Reading
+
+- [Ai Security overview](/ai-security/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/ai-security/devsecops-isolation-sandboxing-reference.mdx
+++ b/docs/pages/ai-security/devsecops-isolation-sandboxing-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: "DevSecOps Isolation & Sandboxing Reference | SEAL"
-description: "Brief AI Security takeaway with direct links to DevSecOps isolation and sandboxing guidance."
+description: "Brief AI Security takeaway with direct links to DevSecOps isolation and sandboxing guidance. Use this page as the bridge; implement containment there."
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/ai-security/devsecops-isolation-sandboxing-reference.mdx
+++ b/docs/pages/ai-security/devsecops-isolation-sandboxing-reference.mdx
@@ -9,6 +9,8 @@ tags:
 contributors:
   - role: wrote
     users: [mattaereal]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -17,6 +19,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Isolation and sandboxing for AI tool runners live primarily under DevSecOps. Use this page as
+> the bridge; implement containment there.
 
 For AI systems that execute tools, run code, or touch sensitive environments,
 strong isolation is a runtime safety baseline. Keep AI Security focused on

--- a/docs/pages/ai-security/devsecops-isolation-sandboxing-reference.mdx
+++ b/docs/pages/ai-security/devsecops-isolation-sandboxing-reference.mdx
@@ -39,6 +39,11 @@ containment patterns.
 - [Sandboxing for Tool Execution](/devsecops/isolation/sandboxing-for-tool-execution)
 - [Sandboxing & Policy Enforcement](/devsecops/isolation/sandboxing-and-policy-enforcement)
 
+
+## Further Reading
+
+- [Ai Security overview](/ai-security/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/ai-security/devsecops-isolation-sandboxing-reference.mdx
+++ b/docs/pages/ai-security/devsecops-isolation-sandboxing-reference.mdx
@@ -39,10 +39,13 @@ containment patterns.
 - [Sandboxing for Tool Execution](/devsecops/isolation/sandboxing-for-tool-execution)
 - [Sandboxing & Policy Enforcement](/devsecops/isolation/sandboxing-and-policy-enforcement)
 
-
 ## Further Reading
 
-- [Ai Security overview](/ai-security/overview)
+- [AI Security overview](/ai-security/overview): how the pages of this framework fit together
+- [Execution-Path Enforcement](/ai-security/execution-path-enforcement): the AI-side control that isolation backstops
+- [Developer Machine Sandboxing](/devsecops/isolation/developer-machine-sandboxing): containing agents running on a
+  workstation
+- [DevSecOps overview](/devsecops/overview): where these containment patterns sit in the delivery pipeline
 
 ---
 

--- a/docs/pages/ai-security/execution-path-enforcement.mdx
+++ b/docs/pages/ai-security/execution-path-enforcement.mdx
@@ -41,10 +41,15 @@ critical to prevent unintended or irreversible on-chain actions.
 - Operant AI - active trust-boundary enforcement across agent ecosystems
 - AccuKnox - eBPF and LSM-based runtime enforcement in Kubernetes AI workloads
 
-
 ## Further Reading
 
-- [Ai Security overview](/ai-security/overview)
+- [AI Security overview](/ai-security/overview): how the pages of this framework fit together
+- [DevSecOps Isolation & Sandboxing](/ai-security/devsecops-isolation-sandboxing-reference): containment for the tools
+  an agent invokes
+- [Sandboxing for Tool Execution](/devsecops/isolation/sandboxing-for-tool-execution): implementing the boundary where
+  enforcement happens
+- [NIST AI Risk Management Framework](https://www.nist.gov/itl/ai-risk-management-framework): governance context for
+  runtime controls
 
 ---
 

--- a/docs/pages/ai-security/execution-path-enforcement.mdx
+++ b/docs/pages/ai-security/execution-path-enforcement.mdx
@@ -11,6 +11,8 @@ contributors:
     users: [munamwasi, jubos, masterfung]
   - role: reviewed
     users: [mattaereal]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -19,6 +21,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Enforce allow, warn, or block where the agent is about to act (tool call, transaction, file
+> write). Monitoring after the fact is too late for irreversible actions.
 
 Execution-path enforcement is a security principle where controls are placed at the point where actions are taken, not
 where they are merely observed. In AI systems, this means intercepting and evaluating model inputs and intended outputs

--- a/docs/pages/ai-security/execution-path-enforcement.mdx
+++ b/docs/pages/ai-security/execution-path-enforcement.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Execution-Path Enforcement | SEAL"
-description: "Execution-path security controls for AI systems to gate high-risk actions at runtime."
+description: "Execution-path security controls for AI systems to gate high-risk actions at runtime. Monitoring after the fact is too late for irreversible actions."
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/ai-security/execution-path-enforcement.mdx
+++ b/docs/pages/ai-security/execution-path-enforcement.mdx
@@ -41,6 +41,11 @@ critical to prevent unintended or irreversible on-chain actions.
 - Operant AI - active trust-boundary enforcement across agent ecosystems
 - AccuKnox - eBPF and LSM-based runtime enforcement in Kubernetes AI workloads
 
+
+## Further Reading
+
+- [Ai Security overview](/ai-security/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/ai-security/overview.mdx
+++ b/docs/pages/ai-security/overview.mdx
@@ -11,6 +11,8 @@ contributors:
     users: [munamwasi, jubos, masterfung]
   - role: reviewed
     users: [mattaereal]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -19,6 +21,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Agentic AI expands instruction-following into irreversible actions. Prefer runtime
+> execution-path controls and isolation over prompt templates alone.
 
 ## The AI Security Imperative
 
@@ -106,24 +111,38 @@ Web3 ecosystems, where agents connect to wallets, DeFi protocols, and governance
 systems, a compromised prompt can initiate irreversible on-chain activity such
 as token transfers, altered governance votes, or treasury losses.
 
-## Sections in this framework
+## What this framework covers
 
-The sections that follow outline the major threat vectors facing AI-driven
-systems, including prompt injection, browser-based manipulation, data
-exfiltration, and execution path weaknesses. They also highlight established
-security providers whose tools address each category. A short cross-reference
-is included for DevSecOps isolation guidance. The objective is to clarify the
-defensive landscape so that security teams, developers, and protocol designers
-can build layered protections that fit their specific deployment models and
-risk tolerance.
+Major threat vectors for AI-driven systems—prompt injection, browser-based manipulation, data exfiltration, and
+execution-path weaknesses—and how defenses differ for developers vs non-developers. A short cross-reference points to
+DevSecOps isolation guidance. Loss figures and industry reports cited above should be treated as time-bound literature;
+verify currency before using them in decisions.
 
-- [Prompt Injection Defenses](/ai-security/prompt-injection-defenses)
-- [AI Browsers](/ai-security/ai-browsers)
-- [AI Workflows: Developers vs Non-Developers](/ai-security/ai-workflows-developers-vs-non-developers)
-- [Data Exfiltration via Generative Systems](/ai-security/data-exfiltration-via-generative-systems)
-- [Execution-Path Enforcement](/ai-security/execution-path-enforcement)
-- [DevSecOps Isolation & Sandboxing (Brief Reference)](/ai-security/devsecops-isolation-sandboxing-reference)
-- [Developer Machine Sandboxing](/devsecops/isolation/developer-machine-sandboxing)
+1. [Prompt Injection Defenses](/ai-security/prompt-injection-defenses): treat model inputs as untrusted instructions and
+   constrain before execution.
+2. [AI Browsers](/ai-security/ai-browsers): threat model when models fetch live web/API content.
+3. [AI Workflows: Developers vs Non-Developers](/ai-security/ai-workflows-developers-vs-non-developers): different
+   control surfaces by role.
+4. [Data Exfiltration via Generative Systems](/ai-security/data-exfiltration-via-generative-systems): runtime constraints
+   against leakage.
+5. [Execution-Path Enforcement](/ai-security/execution-path-enforcement): gate high-risk actions at the moment of action.
+6. [DevSecOps Isolation and Sandboxing (Brief Reference)](/ai-security/devsecops-isolation-sandboxing-reference):
+   pointers into containment patterns.
+7. [Developer Machine Sandboxing](/devsecops/isolation/developer-machine-sandboxing): related DevSecOps page.
+
+## Related frameworks
+
+- [DevSecOps](/devsecops/overview): isolation, pipeline, and sandbox depth
+- [Secure Software Development](/secure-software-development/overview): when AI code lands in production paths
+- [Supply Chain](/supply-chain/overview): model, plugin, and MCP-style tool trust
+- [OpSec](/opsec/overview): operator and key-handling next to agent tools
+- [Awareness](/awareness/overview): human misuse and social engineering with AI assistants
+- [Incident Management](/incident-management/overview): response when agentic systems cause loss
+
+## Further Reading & Tools
+
+- Citations already linked above (industry reports are secondary and time-bound—verify before relying)
+- [OWASP Top 10 for Large Language Model Applications](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
 
 ---
 

--- a/docs/pages/ai-security/overview.mdx
+++ b/docs/pages/ai-security/overview.mdx
@@ -139,7 +139,7 @@ verify currency before using them in decisions.
 - [Awareness](/awareness/overview): human misuse and social engineering with AI assistants
 - [Incident Management](/incident-management/overview): response when agentic systems cause loss
 
-## Further Reading & Tools
+## Further Reading
 
 - Citations already linked above (industry reports are secondary and time-bound—verify before relying)
 - [OWASP Top 10 for Large Language Model Applications](https://owasp.org/www-project-top-10-for-large-language-model-applications/)

--- a/docs/pages/ai-security/prompt-injection-defenses.mdx
+++ b/docs/pages/ai-security/prompt-injection-defenses.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Prompt Injection Defenses | SEAL"
-description: "Prompt injection risks in agentic AI and runtime controls for secure input interpretation."
+description: "Prompt injection risks in agentic AI and runtime controls for secure input interpretation. Constrain and classify inputs at the execution boundary—do"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/ai-security/prompt-injection-defenses.mdx
+++ b/docs/pages/ai-security/prompt-injection-defenses.mdx
@@ -45,6 +45,11 @@ proposals should be treated as untrusted by default.
 - Robust Intelligence (Cisco) - AI validation plus AI firewall guardrail enforcement
 - Imperva AI Application Security - LLM-focused protection beyond traditional WAF assumptions
 
+
+## Further Reading
+
+- [Ai Security overview](/ai-security/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/ai-security/prompt-injection-defenses.mdx
+++ b/docs/pages/ai-security/prompt-injection-defenses.mdx
@@ -45,10 +45,14 @@ proposals should be treated as untrusted by default.
 - Robust Intelligence (Cisco) - AI validation plus AI firewall guardrail enforcement
 - Imperva AI Application Security - LLM-focused protection beyond traditional WAF assumptions
 
-
 ## Further Reading
 
-- [Ai Security overview](/ai-security/overview)
+- [AI Security overview](/ai-security/overview): how the pages of this framework fit together
+- [Execution-Path Enforcement](/ai-security/execution-path-enforcement): where allow, warn, and block decisions belong
+- [Data Exfiltration via Generative Systems](/ai-security/data-exfiltration-via-generative-systems): the common payoff
+  of a successful injection
+- [The lethal trifecta](https://simonwillison.net/2025/Jun/16/the-lethal-trifecta/): why private data, untrusted
+  content, and external communication must not combine
 
 ---
 

--- a/docs/pages/ai-security/prompt-injection-defenses.mdx
+++ b/docs/pages/ai-security/prompt-injection-defenses.mdx
@@ -10,6 +10,8 @@ contributors:
     users: [munamwasi, jubos, masterfung]
   - role: reviewed
     users: [mattaereal]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -18,6 +20,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Prompt injection succeeds because models treat text as instructions. Constrain and classify
+> inputs at the execution boundary—do not rely on boilerplate system prompts alone.
 
 As LLMs execute based on statistical patterns rather than explicit checks, malicious or cleverly structured prompts can
 cause the model to ignore safety instructions, reveal sensitive data, or perform unintended actions. Effective


### PR DESCRIPTION
## Scope

Normalize **AI Security** (`docs/pages/ai-security/`).

## Why

Missing Key Takeaways on children; overview map was unnumbered list without Related frameworks chrome.

## Substantive security changes

**None.** Narrative and external citations retained; callout that loss stats are time-bound.

## Validation

- [x] cspell / markdownlint
- [x] signed commit

## Dependencies

**#561** by reference.

## Reviewer focus

- Industry report figures still fact-check candidates
- Developer Machine Sandboxing cross-link remains valid