### PR TITLE
docs(guides): normalize structure and wording

### DIFF
--- a/docs/pages/guides/account-management/discord.mdx
+++ b/docs/pages/guides/account-management/discord.mdx
@@ -463,6 +463,11 @@ dots > Select **Transfer Ownership** > Input 2FA > Confirm
 - [Four Steps for a Super Safe Server - Discord](https://discord.com/safety/360043653152-four-steps-to-a-super-safe-server)
 - [How to setup a Discord server securely - Ledger](https://www.ledger.com/academy/basic-basics/launch-a-crypto-project-securely/how-to-set-up-a-crypto-project-discord-server-securely)
 
+
+## Further Reading
+
+- [Guides overview](/guides/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/guides/account-management/discord.mdx
+++ b/docs/pages/guides/account-management/discord.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Discord Security | SEAL"
+description: "Discord Security: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Community & Marketing
   - Security Specialist

--- a/docs/pages/guides/account-management/discord.mdx
+++ b/docs/pages/guides/account-management/discord.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Discord Security"
+title: "Discord Security | SEAL"
 tags:
   - Community & Marketing
   - Security Specialist

--- a/docs/pages/guides/account-management/discord.mdx
+++ b/docs/pages/guides/account-management/discord.mdx
@@ -35,8 +35,6 @@ To enhance the security of your Discord server, take into account these suggesti
 server settings, roles and permissions, moderation, bots, channels, invites, member screening, logging, and other
 security measures.
 
----
-
 ## For Individuals
 
 These settings apply to your personal Discord account. All team members, moderators, and admins should configure these
@@ -57,8 +55,6 @@ on their own accounts.
 - [ ] User Settings > Connections: Review and remove any unnecessary connections
 </Checklist>
 
----
-
 ## For Team Members
 
 These guidelines apply to moderators and team members who help manage the server but don't have full administrative access.
@@ -69,8 +65,6 @@ Team members should:
   you to see what members with a certain role can see and access
 - Be aware of the server's AutoMod rules for: Spam, Harmful Links, Mention Spam, Inappropriate Words, and any custom
   keyword filters and exempted roles
-
----
 
 ## For Admins
 
@@ -227,8 +221,6 @@ These settings and practices apply to server administrators with elevated privil
 >   [**Security Actions**](https://support.discord.com/hc/en-us/articles/17439993574167-Activity-Alerts-Security-Actions#h_01HAD80CK67WF59GDGR7XGVAN8)
 >   for pausing invites and DMs to allow you to protect your community while responding to ongoing threats.
 
----
-
 ### Role Hierarchy Setup
 
 Roles should be structured with higher-privilege roles at the top. Go to Server Settings > Roles, create roles like
@@ -247,8 +239,6 @@ Cold Admin, Team, Moderator, & Verified, and drag to reorder (higher roles overr
 | **Members** | View Channels, Send Messages and Create Posts, Embed Links, Add Reactions, Read Message History, Request to Speak |
 
 Use **Server Settings > Roles > [Role] > View Server as Role** to see what members with a certain role can see and access.
-
----
 
 ### Channel Management
 
@@ -272,8 +262,6 @@ Use **Server Settings > Roles > [Role] > View Server as Role** to see what membe
 - [ ] Age-Restricted Channel: Enable for channels with mature content
 </Checklist>
 
----
-
 ### Member Screening Setup
 
 Beyond enabling in Safety Setup:
@@ -282,8 +270,6 @@ Beyond enabling in Safety Setup:
 - Require users to complete an in-channel captcha before accessing the server
 - Advance Settings: Have verification bot filter based on account age, PFP set, and timeout for incomplete captcha
 
----
-
 ### Invite Best Practices
 
 When creating invites:
@@ -291,16 +277,12 @@ When creating invites:
 - Set "Expire After" (recommended: 24 hours)
 - Set "Max Number of Uses" (recommended: 50-100)
 
----
-
 ### Logging Setup
 
 - Ensure admin/mod roles have "View Audit Log" permission
 - Create a private logging channel visible only to admins/mods
 - Use a logging bot like Logger or Dyno to send detailed logs
 - Configure audit log output to a private channel for easier monitoring
-
----
 
 ### Security Bots
 
@@ -337,15 +319,11 @@ up security Bots as described above.
 _The bots above are not all-inclusive but rather a recommended list of bots to help protect your Discord server in
 these categories._
 
----
-
 ### Establish Clear Server Rules
 
 - Create a #rules channel
 - Use Discord's built-in rules screening feature
 - Include sections on: Behavior, Content, Moderation Actions, Appeals Process
-
----
 
 ### Regular Reviews
 
@@ -361,8 +339,6 @@ Also regularly:
 - Review bot permissions after each significant update to avoid newly introduced vulnerabilities
 - Keep track of newly introduced features such as Threads, Scheduled Events, or Stage Channels and configure their
   permissions carefully (e.g., who can start or join a Thread) to prevent abuse by spammers or scammers
-
----
 
 ### Cold Admin Accounts
 
@@ -429,14 +405,10 @@ dots > Select **Transfer Ownership** > Input 2FA > Confirm
 - If an incident or compromise occurs, log into the Cold Admin to regain control — the server owner always maintains
   full access rights
 
----
-
 ### Backup Systems
 
 - Use a bot like ServerBackup to regularly backup your server configuration
 - Store backups securely off-platform
-
----
 
 ### Additional Recommendations
 
@@ -449,25 +421,19 @@ dots > Select **Transfer Ownership** > Input 2FA > Confirm
 > **Important:** Discord servers should not be used for any confidential communication (i.e., any admin discussions
 > beyond the scope of server moderation) — even restricted channels and DMs are not end-to-end encrypted.
 
----
-
 ### Stay Updated
 
 - Consult the official [Discord Moderator Academy](https://discord.com/moderation) for ongoing best practices and new features
 - Implement recommended strategies (e.g., improved spam filters, updated role recommendations)
 
----
-
-## Additional Resources
-
-- [Securing Your Server - Discord](https://discord.com/community/securing-your-server)
-- [Four Steps for a Super Safe Server - Discord](https://discord.com/safety/360043653152-four-steps-to-a-super-safe-server)
-- [How to setup a Discord server securely - Ledger](https://www.ledger.com/academy/basic-basics/launch-a-crypto-project-securely/how-to-set-up-a-crypto-project-discord-server-securely)
-
-
 ## Further Reading
 
-- [Guides overview](/guides/overview)
+- [Community Management: Discord](/community-management/discord): running a Discord community safely
+- [Account Management overview](/guides/account-management/overview): how these product guides fit together
+- [Discord: securing your server](https://discord.com/community/securing-your-server): vendor guidance on server-level
+  controls
+- [Discord: four steps to a super safe server](https://discord.com/safety/360043653152-four-steps-to-a-super-safe-server):
+  vendor quick-start for moderation settings
 
 ---
 

--- a/docs/pages/guides/account-management/discord.mdx
+++ b/docs/pages/guides/account-management/discord.mdx
@@ -21,7 +21,7 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 ## Summary
 
-> 🔑 **Key Takeaway for Discord:** To secure your Discord server, focus on implementing robust access controls and
+> 🔑 **Key Takeaway**: To secure your Discord server, focus on implementing robust access controls and
 > enforcing two-factor authentication for all administrators. Regularly audit roles and permissions, and maintain
 > vigilant moderation. Educate your community about security best practices to prevent unauthorized access and protect
 > against potential threats.

--- a/docs/pages/guides/account-management/github.mdx
+++ b/docs/pages/guides/account-management/github.mdx
@@ -49,8 +49,6 @@ accounts.
 
 </Checklist>
 
----
-
 ## For Team Members
 
 These guidelines apply to team members who contribute to repositories but don't have administrative access.
@@ -62,8 +60,6 @@ Team members should:
 - Be aware of branch protection rules that may require pull request approvals
 - Regularly review and rotate personal access tokens
 - Report any suspicious repository activity to organization admins
-
----
 
 ## For Admins
 
@@ -238,8 +234,6 @@ protections:
   - [ ]  **Enroll** [[3]](#3-audit-logs)
 </Checklist>
 
----
-
 ## Notes
 
 ### [1] Deploy Keys Warning
@@ -256,14 +250,15 @@ level instead.
 
 It is recommended to regularly review audit logs for your organization at Logs > Audit log.
 
----
-
 **Related**: For repository hardening guidance, see [DevSecOps - Repository Hardening](/devsecops/repository-hardening).
-
 
 ## Further Reading
 
-- [Guides overview](/guides/overview)
+- [Account Management overview](/guides/account-management/overview): how these product guides fit together
+- [Repository Hardening](/devsecops/repository-hardening): branch protection, releases, and org-level controls
+- [Hardware Security Keys](/guides/endpoint-security/hardware-security-keys): phishing-resistant 2FA for this account
+- [GitHub: securing your account with 2FA](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa):
+  vendor documentation for current UI paths
 
 ---
 

--- a/docs/pages/guides/account-management/github.mdx
+++ b/docs/pages/guides/account-management/github.mdx
@@ -260,6 +260,11 @@ It is recommended to regularly review audit logs for your organization at Logs >
 
 **Related**: For repository hardening guidance, see [DevSecOps - Repository Hardening](/devsecops/repository-hardening).
 
+
+## Further Reading
+
+- [Guides overview](/guides/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/guides/account-management/github.mdx
+++ b/docs/pages/guides/account-management/github.mdx
@@ -6,6 +6,8 @@ tags:
 contributors:
   - role: wrote
     users: [auditware]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../components'
@@ -17,7 +19,7 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 ## Summary
 
-> 🔑 **Key Takeaway for GitHub:** Secure your GitHub account with non-SMS two-factor authentication, enable push
+> 🔑 **Key Takeaway**: Secure your GitHub account with non-SMS two-factor authentication, enable push
 > protection, and regularly review connected apps and sessions. For organizations, enforce signed commits,
 > branch protection rules, and restrict member privileges to minimize supply chain attack risks.
 

--- a/docs/pages/guides/account-management/godaddy.mdx
+++ b/docs/pages/guides/account-management/godaddy.mdx
@@ -78,6 +78,11 @@ These settings and practices apply to GoDaddy account administrators who manage 
 
 **Related**: For comprehensive DNS security guidance, see [Infrastructure - Domain & DNS Security](/infrastructure/domain-and-dns-security/overview).
 
+
+## Further Reading
+
+- [Guides overview](/guides/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/guides/account-management/godaddy.mdx
+++ b/docs/pages/guides/account-management/godaddy.mdx
@@ -25,8 +25,6 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 This checklist is adapted from [Auditware's W3OSC](https://github.com/W3OSC/web3-opsec-standard) standards.
 
----
-
 ## For Individuals
 
 These settings apply to your personal GoDaddy account. All team members and admins should configure these on their own accounts.
@@ -42,8 +40,6 @@ These settings apply to your personal GoDaddy account. All team members and admi
 
 </Checklist>
 
----
-
 ## For Team Members
 
 These guidelines apply to team members who have delegate access to GoDaddy accounts but don't have full administrative control.
@@ -54,8 +50,6 @@ Team members should:
 - Understand the scope of their delegate access permissions
 - Report any suspicious domain or DNS activity to account administrators
 - Never share login credentials or delegate access with unauthorized parties
-
----
 
 ## For Admins
 
@@ -74,14 +68,16 @@ These settings and practices apply to GoDaddy account administrators who manage 
 - Use domain locking features to prevent unauthorized transfers
 - Review DNS records periodically for any unauthorized changes
 
----
-
 **Related**: For comprehensive DNS security guidance, see [Infrastructure - Domain & DNS Security](/infrastructure/domain-and-dns-security/overview).
-
 
 ## Further Reading
 
-- [Guides overview](/guides/overview)
+- [Account Management overview](/guides/account-management/overview): how these product guides fit together
+- [Registrar and Locks](/infrastructure/domain-and-dns-security/registrar-and-locks): registrar-level protections
+  beyond the account itself
+- [DNS Hijack Runbook](/incident-management/incident-response-template/runbooks/dns-hijack): response steps if the
+  registrar account is taken over
+- [Secure Authentication](/iam/secure-authentication): 2FA and recovery design for the registrar account itself
 
 ---
 

--- a/docs/pages/guides/account-management/godaddy.mdx
+++ b/docs/pages/guides/account-management/godaddy.mdx
@@ -6,6 +6,8 @@ tags:
 contributors:
   - role: wrote
     users: [auditware]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../components'
@@ -17,7 +19,7 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 ## Summary
 
-> 🔑 **Key Takeaway for GoDaddy:** Protect your domain registrar account with non-SMS two-factor authentication,
+> 🔑 **Key Takeaway**: Protect your domain registrar account with non-SMS two-factor authentication,
 > regularly review delegate access and active sessions, and enable DNSSEC on all domains to prevent DNS spoofing
 > and domain hijacking attacks.
 

--- a/docs/pages/guides/account-management/linear.mdx
+++ b/docs/pages/guides/account-management/linear.mdx
@@ -6,6 +6,8 @@ tags:
 contributors:
   - role: wrote
     users: [auditware]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../components'
@@ -17,7 +19,7 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 ## Summary
 
-> 🔑 **Key Takeaway for Linear:** Secure your Linear account with passkeys, regularly review sessions and connected
+> 🔑 **Key Takeaway**: Secure your Linear account with passkeys, regularly review sessions and connected
 > applications, and for workspaces, disable invite links, restrict approved email domains, and control
 > third-party integrations to protect sensitive project data.
 

--- a/docs/pages/guides/account-management/linear.mdx
+++ b/docs/pages/guides/account-management/linear.mdx
@@ -76,6 +76,11 @@ These settings and practices apply to Linear workspace administrators with eleva
   - [ ]  Applications > **Review and remove any unnecessary or unrecognized**
 </Checklist>
 
+
+## Further Reading
+
+- [Guides overview](/guides/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/guides/account-management/linear.mdx
+++ b/docs/pages/guides/account-management/linear.mdx
@@ -25,8 +25,6 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 This checklist is adapted from [Auditware's W3OSC](https://github.com/W3OSC/web3-opsec-standard) standards.
 
----
-
 ## For Individuals
 
 These settings apply to your personal Linear account. All team members and admins should configure these on their own accounts.
@@ -41,8 +39,6 @@ These settings apply to your personal Linear account. All team members and admin
 
 </Checklist>
 
----
-
 ## For Team Members
 
 These guidelines apply to team members who use Linear for project management but don't have administrative access.
@@ -53,8 +49,6 @@ Team members should:
 - Use passkeys for stronger authentication when available
 - Be cautious about authorizing third-party applications to access Linear
 - Report any suspicious workspace activity to administrators
-
----
 
 ## For Admins
 
@@ -76,10 +70,13 @@ These settings and practices apply to Linear workspace administrators with eleva
   - [ ]  Applications > **Review and remove any unnecessary or unrecognized**
 </Checklist>
 
-
 ## Further Reading
 
-- [Guides overview](/guides/overview)
+- [Account Management overview](/guides/account-management/overview): how these product guides fit together
+- [Secure Authentication](/iam/secure-authentication): passkeys and SSO choices behind these settings
+- [Access Management](/iam/access-management): workspace membership and offboarding
+- [Linear: security and access](https://linear.app/docs/security-and-access): vendor documentation for current UI
+  paths
 
 ---
 

--- a/docs/pages/guides/account-management/mercury.mdx
+++ b/docs/pages/guides/account-management/mercury.mdx
@@ -72,6 +72,11 @@ These settings and practices apply to Mercury account administrators with elevat
 
 </Checklist>
 
+
+## Further Reading
+
+- [Guides overview](/guides/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/guides/account-management/mercury.mdx
+++ b/docs/pages/guides/account-management/mercury.mdx
@@ -25,8 +25,6 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 This checklist is adapted from [Auditware's W3OSC](https://github.com/W3OSC/web3-opsec-standard) standards.
 
----
-
 ## For Individuals
 
 These settings apply to your personal Mercury account. All team members and admins should configure these on their own accounts.
@@ -43,8 +41,6 @@ These settings apply to your personal Mercury account. All team members and admi
 
 </Checklist>
 
----
-
 ## For Team Members
 
 These guidelines apply to team members who have access to company Mercury accounts but don't have full administrative access.
@@ -54,8 +50,6 @@ Team members should:
 - Ensure their individual account settings are configured according to the checklist above
 - Be aware of their permissions and only perform actions within their authorized scope
 - Report any suspicious activity or unrecognized transactions to admins immediately
-
----
 
 ## For Admins
 
@@ -72,10 +66,13 @@ These settings and practices apply to Mercury account administrators with elevat
 
 </Checklist>
 
-
 ## Further Reading
 
-- [Guides overview](/guides/overview)
+- [Account Management overview](/guides/account-management/overview): how these product guides fit together
+- [Treasury Operations](/treasury-operations/overview): controls around the funds this account moves
+- [Transaction Verification](/treasury-operations/transaction-verification): dual approval and payment verification
+  practice
+- [Secure Authentication](/iam/secure-authentication): 2FA, session review, and device trust for the account
 
 ---
 

--- a/docs/pages/guides/account-management/mercury.mdx
+++ b/docs/pages/guides/account-management/mercury.mdx
@@ -6,6 +6,8 @@ tags:
 contributors:
   - role: wrote
     users: [auditware]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../components'
@@ -17,7 +19,7 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 ## Summary
 
-> 🔑 **Key Takeaway for Mercury:** Secure your Mercury account by enabling two-factor authentication, regularly
+> 🔑 **Key Takeaway**: Secure your Mercury account by enabling two-factor authentication, regularly
 > reviewing active sessions and linked profiles, and for organizations, enabling ACH authorization and dual admin
 > approval to prevent unauthorized transactions.
 

--- a/docs/pages/guides/account-management/notion.mdx
+++ b/docs/pages/guides/account-management/notion.mdx
@@ -109,6 +109,11 @@ Some of these settings require an Enterprise workspace plan. These can be omitte
 upgrading your plan for the security benefits if the size and/or risk tolerance of your organization warrants the
 extra protections.
 
+
+## Further Reading
+
+- [Guides overview](/guides/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/guides/account-management/notion.mdx
+++ b/docs/pages/guides/account-management/notion.mdx
@@ -6,6 +6,8 @@ tags:
 contributors:
   - role: wrote
     users: [auditware]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../components'
@@ -17,7 +19,7 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 ## Summary
 
-> 🔑 **Key Takeaway for Notion:** Secure your Notion account by enabling 2-step verification with an authenticator app
+> 🔑 **Key Takeaway**: Secure your Notion account by enabling 2-step verification with an authenticator app
 > (not SMS), disabling support access, and for workspaces, restricting publishing, export, and guest access to
 > prevent unauthorized data exposure.
 

--- a/docs/pages/guides/account-management/notion.mdx
+++ b/docs/pages/guides/account-management/notion.mdx
@@ -25,8 +25,6 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 This checklist is adapted from [Auditware's W3OSC](https://github.com/W3OSC/web3-opsec-standard) standards.
 
----
-
 ## For Individuals
 
 These settings apply to your personal Notion account. All team members and admins should configure these on their own accounts.
@@ -46,8 +44,6 @@ These settings apply to your personal Notion account. All team members and admin
 
 </Checklist>
 
----
-
 ## For Team Members
 
 These guidelines apply to team members who have access to shared Notion workspaces but don't have full administrative access.
@@ -57,8 +53,6 @@ Team members should:
 - Ensure their individual account settings are configured according to the checklist above
 - Be mindful of page sharing settings and avoid publishing or sharing pages externally without approval
 - Report any suspicious activity or unauthorized access requests to workspace admins
-
----
 
 ## For Admins
 
@@ -99,8 +93,6 @@ These settings and practices apply to Notion workspace administrators with eleva
 
 </Checklist>
 
----
-
 ## Notes
 
 ### [1] Enterprise Features
@@ -109,10 +101,13 @@ Some of these settings require an Enterprise workspace plan. These can be omitte
 upgrading your plan for the security benefits if the size and/or risk tolerance of your organization warrants the
 extra protections.
 
-
 ## Further Reading
 
-- [Guides overview](/guides/overview)
+- [Account Management overview](/guides/account-management/overview): how these product guides fit together
+- [Role-Based Access Control](/iam/role-based-access-control): structuring workspace and page permissions
+- [Multi-Factor Authentication](/opsec/mfa/overview): choosing factors before enabling them here
+- [Notion: two-step verification](https://www.notion.com/help/two-step-verification): vendor documentation for current
+  UI paths
 
 ---
 

--- a/docs/pages/guides/account-management/overview.mdx
+++ b/docs/pages/guides/account-management/overview.mdx
@@ -27,8 +27,7 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 Practical, step-by-step guide hub for securing accounts across communication platforms, DevOps tools, and business
 applications. Most child guides include checklists for individuals, team members, and administrators.
 
-## What this section covers
-
+## What this framework covers
 ### Communication platforms
 
 1. [Discord Security](/guides/account-management/discord): server roles, raid protection, bot least privilege.

--- a/docs/pages/guides/account-management/overview.mdx
+++ b/docs/pages/guides/account-management/overview.mdx
@@ -1,11 +1,17 @@
 ---
-title: "Account Management"
+title: "Account Management | Security Alliance"
+description: "Account management security guides for Discord, Telegram, Slack, Twitter/X, GitHub, domain registrars, cloud deploy platforms, and common business tools."
 tags:
   - Community & Marketing
   - Security Specialist
+  - Engineer/Developer
 contributors:
   - role: wrote
     users: [dickson, nftdreww]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
@@ -15,38 +21,43 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-This section contains practical, step-by-step guides that help you implement security best practices across various
-platforms and tools. Each guide provides actionable instructions you can follow to secure your operations.
+> 🔑 **Key Takeaway**: High-value SaaS and community accounts need strong MFA, session hygiene, least privilege, and
+> admin separation. Compromise of one admin surface often becomes org-wide phishing scale.
 
-## Communication Platforms
+Practical, step-by-step guide hub for securing accounts across communication platforms, DevOps tools, and business
+applications. Most child guides include checklists for individuals, team members, and administrators.
 
-Guides for securing your communication and community platforms.
+## What this section covers
 
-- [**Discord Security**](/guides/account-management/discord) - Comprehensive guide to securing your Discord server
-- [**Signal Security**](/guides/account-management/signal) - Secure messaging with registration lock and privacy settings
-- [**Slack Security**](/guides/account-management/slack) - Workspace security and admin settings for teams
-- [**Telegram Security**](/guides/account-management/telegram) - Comprehensive guide to securing your Telegram account
-  and groups
-- [**Twitter/X Security**](/guides/account-management/twitter) - Comprehensive guide to securing your X (Twitter) account
+### Communication platforms
 
-## DevOps & Infrastructure
+1. [Discord Security](/guides/account-management/discord): server roles, raid protection, bot least privilege.
+2. [Signal Security](/guides/account-management/signal): registration lock and privacy settings.
+3. [Slack Security](/guides/account-management/slack): workspace admin and MFA posture.
+4. [Telegram Security](/guides/account-management/telegram): two-step verification, phone privacy, group admin rights.
+5. [Twitter/X Security](/guides/account-management/twitter): SIM-swap resistant MFA and OAuth hygiene.
 
-Guides for securing your development and infrastructure accounts.
+### DevOps and infrastructure
 
-- [**GitHub Security**](/guides/account-management/github) - Repository security, 2FA, SSH keys, and organization settings
-- [**GoDaddy Security**](/guides/account-management/godaddy) - Domain security, DNSSEC, and registrar settings
-- [**Render Security**](/guides/account-management/render) - Cloud platform security, API keys, and team management
-- [**Sentry Security**](/guides/account-management/sentry) - Error tracking platform security and access control
-- [**Vercel Security**](/guides/account-management/vercel) - Deployment platform security and team settings
+1. [GitHub Security](/guides/account-management/github): 2FA, SSH, org settings, push protection.
+2. [GoDaddy Security](/guides/account-management/godaddy): registrar and DNSSEC-oriented controls.
+3. [Render Security](/guides/account-management/render): platform access and API keys.
+4. [Sentry Security](/guides/account-management/sentry): error-tracking access control.
+5. [Vercel Security](/guides/account-management/vercel): deployment platform and team settings.
 
-## Business Tools
+### Business tools
 
-Guides for securing your productivity and business applications.
+1. [Linear Security](/guides/account-management/linear): passkeys and workspace settings.
+2. [Mercury Security](/guides/account-management/mercury): banking MFA and dual approval patterns.
+3. [Notion Security](/guides/account-management/notion): workspace access and 2-step verification.
+4. [Trello Security](/guides/account-management/trello): board and session management.
 
-- [**Linear Security**](/guides/account-management/linear) - Project management security with passkeys and workspace settings
-- [**Mercury Security**](/guides/account-management/mercury) - Banking security, ACH authorization, and dual approval
-- [**Notion Security**](/guides/account-management/notion) - Workspace security, 2-step verification, and access controls
-- [**Trello Security**](/guides/account-management/trello) - Board security and session management
+## Related frameworks
+
+- [Guides overview](/guides/overview): endpoint guides (SSH, security keys, password managers, Zoom)
+- [Community Management](/community-management/overview): community-facing channel risk
+- [OpSec](/opsec/overview): MFA and password foundations
+- [IAM](/iam/overview): org-wide access lifecycle
 
 ---
 

--- a/docs/pages/guides/account-management/overview.mdx
+++ b/docs/pages/guides/account-management/overview.mdx
@@ -58,6 +58,16 @@ applications. Most child guides include checklists for individuals, team members
 - [OpSec](/opsec/overview): MFA and password foundations
 - [IAM](/iam/overview): org-wide access lifecycle
 
+## Further Reading
+
+- [Secure Authentication](/iam/secure-authentication): the account controls these product guides configure
+- [Hardware Security Keys](/guides/endpoint-security/hardware-security-keys): the strongest second factor across every
+  product here
+- [CISA: implementing phishing-resistant MFA](https://www.cisa.gov/sites/default/files/publications/fact-sheet-implementing-phishing-resistant-mfa-508c.pdf):
+  why factor choice matters more than factor count
+- [NIST SP 800-63B: Digital Identity Guidelines](https://pages.nist.gov/800-63-3/sp800-63b.html): the standard behind
+  these authentication recommendations
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/guides/account-management/render.mdx
+++ b/docs/pages/guides/account-management/render.mdx
@@ -70,6 +70,11 @@ These settings and practices apply to Render workspace administrators with eleva
 
 </Checklist>
 
+
+## Further Reading
+
+- [Guides overview](/guides/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/guides/account-management/render.mdx
+++ b/docs/pages/guides/account-management/render.mdx
@@ -25,8 +25,6 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 This checklist is adapted from [Auditware's W3OSC](https://github.com/W3OSC/web3-opsec-standard) standards.
 
----
-
 ## For Individuals
 
 These settings apply to your personal Render account. All team members and admins should configure these on their own accounts.
@@ -42,8 +40,6 @@ These settings apply to your personal Render account. All team members and admin
 
 </Checklist>
 
----
-
 ## For Team Members
 
 These guidelines apply to team members who have access to shared Render workspaces but don't have full administrative access.
@@ -53,8 +49,6 @@ Team members should:
 - Ensure their individual account settings are configured according to the checklist above
 - Use the principle of least privilege when accessing workspace resources
 - Report any suspicious deployments or unauthorized changes to workspace admins
-
----
 
 ## For Admins
 
@@ -70,10 +64,12 @@ These settings and practices apply to Render workspace administrators with eleva
 
 </Checklist>
 
-
 ## Further Reading
 
-- [Guides overview](/guides/overview)
+- [Account Management overview](/guides/account-management/overview): how these product guides fit together
+- [Cloud Security](/infrastructure/cloud): the wider hosting posture this account controls
+- [CI/CD Security](/devsecops/continuous-integration-continuous-deployment): protecting the deploy pipeline behind it
+- [Render: organizations](https://render.com/docs/organizations): vendor documentation for members, roles, and access
 
 ---
 

--- a/docs/pages/guides/account-management/render.mdx
+++ b/docs/pages/guides/account-management/render.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Render Security | Security Alliance"
-description: "Secure your Render deployment platform with 2FA, API key management, and workspace-level team access controls and audit logging."
+description: "Secure your Render deployment platform with 2FA, API key management, and workspace-level team access controls and audit logging. This checklist is adapted"
 tags:
   - DevOps Accounts
 contributors:

--- a/docs/pages/guides/account-management/render.mdx
+++ b/docs/pages/guides/account-management/render.mdx
@@ -6,6 +6,8 @@ tags:
 contributors:
   - role: wrote
     users: [auditware]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../components'
@@ -17,7 +19,7 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 ## Summary
 
-> 🔑 **Key Takeaway for Render:** Secure your Render account by enabling two-factor authentication, regularly reviewing
+> 🔑 **Key Takeaway**: Secure your Render account by enabling two-factor authentication, regularly reviewing
 > CLI tokens, API keys, and SSH public keys, and for workspaces, maintaining strict team member access controls
 > and enabling audit logs.
 

--- a/docs/pages/guides/account-management/sentry.mdx
+++ b/docs/pages/guides/account-management/sentry.mdx
@@ -83,10 +83,13 @@ These settings and practices apply to Sentry organization administrators with el
 
 </Checklist>
 
-
 ## Further Reading
 
-- [Guides overview](/guides/overview)
+- [Account Management overview](/guides/account-management/overview): how these product guides fit together
+- [Monitoring overview](/monitoring/overview): what error and event data should feed into detection
+- [Access Management](/iam/access-management): scoping who can read production error data
+- [Sentry: authentication](https://docs.sentry.io/organization/authentication/): vendor documentation for SSO and 2FA
+  enforcement
 
 ---
 

--- a/docs/pages/guides/account-management/sentry.mdx
+++ b/docs/pages/guides/account-management/sentry.mdx
@@ -6,6 +6,8 @@ tags:
 contributors:
   - role: wrote
     users: [auditware]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../components'
@@ -17,7 +19,7 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 ## Summary
 
-> 🔑 **Key Takeaway for Sentry:** Secure your Sentry account by enabling two-factor authentication, regularly reviewing
+> 🔑 **Key Takeaway**: Secure your Sentry account by enabling two-factor authentication, regularly reviewing
 > API tokens and authorized applications, and ensuring organization-wide security policies are enforced. Remove any
 > unnecessary integrations and audit team member access to minimize attack surface.
 

--- a/docs/pages/guides/account-management/sentry.mdx
+++ b/docs/pages/guides/account-management/sentry.mdx
@@ -83,6 +83,11 @@ These settings and practices apply to Sentry organization administrators with el
 
 </Checklist>
 
+
+## Further Reading
+
+- [Guides overview](/guides/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/guides/account-management/signal.mdx
+++ b/docs/pages/guides/account-management/signal.mdx
@@ -72,6 +72,11 @@ These settings apply to your personal Signal account. You must be on the phone a
   - Verify safety numbers with contacts when they change to ensure you're communicating with the intended person.
 </Checklist>
 
+
+## Further Reading
+
+- [Guides overview](/guides/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/guides/account-management/signal.mdx
+++ b/docs/pages/guides/account-management/signal.mdx
@@ -6,6 +6,8 @@ tags:
 contributors:
   - role: wrote
     users: [auditware]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../components'
@@ -17,7 +19,7 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 ## Summary
 
-> 🔑 **Key Takeaway for Signal:** Enable registration lock to prevent SIM swap impersonation, configure privacy
+> 🔑 **Key Takeaway**: Enable registration lock to prevent SIM swap impersonation, configure privacy
 > settings to hide your phone number, and use disappearing messages. Even if you don't actively use Signal, securing
 > your account prevents attackers from impersonating you to others.
 

--- a/docs/pages/guides/account-management/signal.mdx
+++ b/docs/pages/guides/account-management/signal.mdx
@@ -27,8 +27,6 @@ Signal provides the gold standard of end-to-end encryption and privacy features,
 for truly anonymous and secure communications. Properly configuring your Signal account is essential for
 maintaining your privacy and security.
 
----
-
 ## For Individuals
 
 These settings apply to your personal Signal account. You must be on the phone app to access all of these settings.
@@ -59,8 +57,6 @@ These settings apply to your personal Signal account. You must be on the phone a
 
 </Checklist>
 
----
-
 ### Best Practices & Additional Tips
 
 <Checklist id="best-practices">
@@ -72,10 +68,12 @@ These settings apply to your personal Signal account. You must be on the phone a
   - Verify safety numbers with contacts when they change to ensure you're communicating with the intended person.
 </Checklist>
 
-
 ## Further Reading
 
-- [Guides overview](/guides/overview)
+- [Account Management overview](/guides/account-management/overview): how these product guides fit together
+- [Encrypted Communication Tools](/privacy/encrypted-communication-tools): how Signal compares to other messengers
+- [Communication Encryption](/encryption/communication-encryption): the mechanics behind end-to-end encryption
+- [Secure Authentication](/iam/secure-authentication): registration lock and PIN as account recovery controls
 
 ---
 

--- a/docs/pages/guides/account-management/signal.mdx
+++ b/docs/pages/guides/account-management/signal.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Signal Security | Security Alliance"
-description: "Secure your Signal account with registration lock, privacy settings, and disappearing messages. Protect against SIM swap impersonation and maintain truly private communications."
+description: "Secure your Signal account with registration lock, privacy settings, and disappearing messages. Protect against SIM swap impersonation and maintain truly"
 tags:
   - Communication Platforms
 contributors:

--- a/docs/pages/guides/account-management/slack.mdx
+++ b/docs/pages/guides/account-management/slack.mdx
@@ -25,8 +25,6 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 This checklist is adapted from [Auditware's W3OSC](https://github.com/W3OSC/web3-opsec-standard) standards.
 
----
-
 ## For Team Members
 
 These guidelines apply to team members who use the Slack workspace.
@@ -38,8 +36,6 @@ Team members should:
 - Report any suspicious messages or unrecognized workspace members to administrators
 - Avoid accessing the workspace from jailbroken or rooted devices
 - Be mindful of what sensitive information is shared in channels
-
----
 
 ## For Admins
 
@@ -76,10 +72,14 @@ These settings and practices apply to Slack workspace administrators with elevat
 
 </Checklist>
 
-
 ## Further Reading
 
-- [Guides overview](/guides/overview)
+- [Account Management overview](/guides/account-management/overview): how these product guides fit together
+- [Access Management](/iam/access-management): workspace membership, guests, and app approvals
+- [Encrypted Communication Tools](/privacy/encrypted-communication-tools): where to move genuinely sensitive
+  discussions
+- [Slack: set up two-factor authentication](https://slack.com/help/articles/204509068-Set-up-two-factor-authentication):
+  vendor documentation for current UI paths
 
 ---
 

--- a/docs/pages/guides/account-management/slack.mdx
+++ b/docs/pages/guides/account-management/slack.mdx
@@ -76,6 +76,11 @@ These settings and practices apply to Slack workspace administrators with elevat
 
 </Checklist>
 
+
+## Further Reading
+
+- [Guides overview](/guides/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/guides/account-management/slack.mdx
+++ b/docs/pages/guides/account-management/slack.mdx
@@ -6,6 +6,8 @@ tags:
 contributors:
   - role: wrote
     users: [auditware]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../components'
@@ -17,7 +19,7 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 ## Summary
 
-> 🔑 **Key Takeaway for Slack:** Secure your Slack workspace by enforcing two-factor authentication with authenticator
+> 🔑 **Key Takeaway**: Secure your Slack workspace by enforcing two-factor authentication with authenticator
 > apps only, requiring admin approval for invitations, regularly reviewing member access levels, and blocking jailbroken
 > or rooted devices from accessing the workspace.
 

--- a/docs/pages/guides/account-management/telegram.mdx
+++ b/docs/pages/guides/account-management/telegram.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Telegram Security | Security Alliance"
-description: "Secure Telegram against SIM swapping and Man-in-the-Group attacks. Configure passkeys, Two-Step Verification, hide your phone number, use Secret Chats with end-to-end encryption, and manage admin permissions."
+description: "Secure Telegram against SIM swapping and Man-in-the-Group attacks. Configure passkeys, Two-Step Verification, hide your phone number"
 tags:
   - Community & Marketing
 contributors:

--- a/docs/pages/guides/account-management/telegram.mdx
+++ b/docs/pages/guides/account-management/telegram.mdx
@@ -422,6 +422,11 @@ Example disclaimer: "We will NEVER message you directly to offer support or assi
 please email us at support@\<company\>.com. DO NOT interact with anyone DMing and claiming to be a \<company\> member.
 Please report scams to reports@\<company\>.com"
 
+
+## Further Reading
+
+- [Guides overview](/guides/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/guides/account-management/telegram.mdx
+++ b/docs/pages/guides/account-management/telegram.mdx
@@ -8,6 +8,8 @@ contributors:
     users: [mattaereal, zedt3ster, fredriksvantes, auditware]
   - role: reviewed
     users: [mattaereal]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../components'
@@ -19,7 +21,7 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 ## Summary
 
-> 🔑 **Key Takeaway:** Enable passkeys and Two-Step Verification, hide your phone number, and stay vigilant with group
+> 🔑 **Key Takeaway**: Enable passkeys and Two-Step Verification, hide your phone number, and stay vigilant with group
 > chats. Implement verification steps and secure communication practices to protect against interception attacks.
 
 While **Telegram** is widely used in the crypto community, it's crucial to understand its security limitations. Telegram

--- a/docs/pages/guides/account-management/telegram.mdx
+++ b/docs/pages/guides/account-management/telegram.mdx
@@ -32,8 +32,6 @@ priority, consider using [Signal](https://signal.org/).
 
 However, if you choose to use **Telegram**, the following best practices can help enhance your security.
 
----
-
 ## For Individuals
 
 These settings apply to your personal Telegram account. All team members and admins should configure these on
@@ -131,8 +129,6 @@ their own accounts.
 > attacks. You **must** confirm these details if using Telegram for private communications. That said, it is suggested
 to use a secure platform like [Signal](https://signal.org/) for confidential communication.
 
----
-
 ### Device-Level Security
 
 Securing the device you use for Telegram is crucial for preventing unauthorized access to your account and messages.
@@ -155,8 +151,6 @@ Securing the device you use for Telegram is crucial for preventing unauthorized 
   - Ensure any device backups containing Telegram data are encrypted
   - Be cautious about cloud backups that might store Telegram messages
 </Checklist>
-
----
 
 ### Advanced Privacy Measures
 
@@ -198,8 +192,6 @@ encryption**.
 - [ ]  **Suggest Frequent Contacts:** Disable (depending on use of Telegram) to avoid unsolicited contact suggestions.
 </Checklist>
 
----
-
 ### Best Practices for Safe Use
 
 <Checklist id="best-practices">
@@ -229,8 +221,6 @@ instead of just deleting chats.
 - [ ]  **Stay Vigilant Against Scam Ads:** Be aware that anyone can post ads in channels, with 99% being scam ads.
 Exercise caution when interacting with advertisements.
 </Checklist>
-
----
 
 ### Platform-Specific Risks: Man-in-the-Group Attack
 
@@ -272,8 +262,6 @@ Here's a concise example of how such an attack might occur:
 - **Alice** sends the payment to what she believes are Bob's details but are actually those of Fake Bob.
 - The attacker now controls both ends of the conversation, having successfully redirected the funds.
 
----
-
 ## For Team Members
 
 These guidelines apply to team members who help manage Telegram groups/channels but don't have full administrative
@@ -286,8 +274,6 @@ Team members should:
 - Add a suffix to your username, for example: "MyName | will never DM you"
 - Understand how to verify the authenticity of admins and official messages
 - Be aware of the Man-in-the-Group Attack scenario described above
-
----
 
 ## For Admins
 
@@ -333,8 +319,6 @@ These settings and practices apply to Telegram group/channel administrators with
 
 </Checklist>
 
----
-
 ### Admin Permissions Management
 
 If you manage Telegram groups or channels, properly configuring admin permissions is crucial for maintaining security.
@@ -363,8 +347,6 @@ If you manage Telegram groups or channels, properly configuring admin permission
 against raids.
 </Checklist>
 
----
-
 ### Additional Recommendations
 
 <Checklist id="additional-recommendations">
@@ -374,8 +356,6 @@ users, and that support will only be offered via the public channel and dedicate
 - [ ]  Add a suffix to admin usernames, for example: "MyName | will never DM you"
 - [ ]  Each admin must follow the guidance for securing their individual accounts
 </Checklist>
-
----
 
 ### Educate Community Members on Security Practices
 
@@ -404,8 +384,6 @@ If you're managing a community on Telegram, educating your members about securit
   - Create a security checklist for new community members
 </Checklist>
 
----
-
 ### Notes
 
 #### [1] Member Control
@@ -422,10 +400,13 @@ Example disclaimer: "We will NEVER message you directly to offer support or assi
 please email us at support@\<company\>.com. DO NOT interact with anyone DMing and claiming to be a \<company\> member.
 Please report scams to reports@\<company\>.com"
 
-
 ## Further Reading
 
-- [Guides overview](/guides/overview)
+- [Community Management: Telegram](/community-management/telegram): running a Telegram community safely
+- [Account Management overview](/guides/account-management/overview): how these product guides fit together
+- [Secure Authentication](/iam/secure-authentication): two-step verification and recovery design
+- [Telegram: two-step verification](https://telegram.org/faq#q-what-is-two-step-verification): vendor documentation for
+  current UI paths
 
 ---
 

--- a/docs/pages/guides/account-management/trello.mdx
+++ b/docs/pages/guides/account-management/trello.mdx
@@ -27,8 +27,6 @@ Trello is widely used for project management and collaboration, often containing
 Securing your Trello account helps protect your project data, team workflows, and any confidential information
 stored on your boards.
 
----
-
 ## For Individuals
 
 These settings apply to your personal Trello account.
@@ -43,8 +41,6 @@ These settings apply to your personal Trello account.
 
 </Checklist>
 
----
-
 ### Best Practices & Additional Tips
 
 <Checklist id="best-practices">
@@ -58,10 +54,13 @@ These settings apply to your personal Trello account.
   - Ensure notifications are enabled so you're alerted to any unexpected board activity or access changes.
 </Checklist>
 
-
 ## Further Reading
 
-- [Guides overview](/guides/overview)
+- [Account Management overview](/guides/account-management/overview): how these product guides fit together
+- [Access Management](/iam/access-management): board membership, guests, and offboarding
+- [Multi-Factor Authentication](/opsec/mfa/overview): choosing factors before enabling them here
+- [Atlassian: two-factor authentication for Trello](https://support.atlassian.com/trello/docs/enabling-two-factor-authentication-for-your-trello-account/):
+  vendor documentation for current UI paths
 
 ---
 

--- a/docs/pages/guides/account-management/trello.mdx
+++ b/docs/pages/guides/account-management/trello.mdx
@@ -6,6 +6,8 @@ tags:
 contributors:
   - role: wrote
     users: [auditware]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../components'
@@ -17,7 +19,7 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 ## Summary
 
-> 🔑 **Key Takeaway for Trello:** Enable two-step verification, review and remove unnecessary connected
+> 🔑 **Key Takeaway**: Enable two-step verification, review and remove unnecessary connected
 > applications, and regularly audit your active sessions to maintain control over your Trello boards and sensitive
 > project data.
 

--- a/docs/pages/guides/account-management/trello.mdx
+++ b/docs/pages/guides/account-management/trello.mdx
@@ -58,6 +58,11 @@ These settings apply to your personal Trello account.
   - Ensure notifications are enabled so you're alerted to any unexpected board activity or access changes.
 </Checklist>
 
+
+## Further Reading
+
+- [Guides overview](/guides/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/guides/account-management/twitter.mdx
+++ b/docs/pages/guides/account-management/twitter.mdx
@@ -163,6 +163,11 @@ If using Typefully for team collaboration:
   with a minimum amount of Publishers and Admins.
 </Checklist>
 
+
+## Further Reading
+
+- [Guides overview](/guides/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/guides/account-management/twitter.mdx
+++ b/docs/pages/guides/account-management/twitter.mdx
@@ -8,6 +8,8 @@ contributors:
     users: [mattaereal, zedt3ster, fredriksvantes, auditware]
   - role: reviewed
     users: [mattaereal]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../components'
@@ -19,7 +21,7 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 ## Summary
 
-> 🔑 **Key Takeaway for Twitter (X):** To secure your Twitter account, prioritize using an authenticator app or security
+> 🔑 **Key Takeaway**: To secure your Twitter account, prioritize using an authenticator app or security
 > key over SMS-based 2FA, remove your phone number, and regularly review third-party app permissions. Ensure your
 > recovery settings are robust and frequently monitor account activity to safeguard your online presence and maintain
 > community trust.

--- a/docs/pages/guides/account-management/twitter.mdx
+++ b/docs/pages/guides/account-management/twitter.mdx
@@ -32,8 +32,6 @@ swaps or fake login screens—to seize control of your profile. A few simple ste
 Securing your Twitter account is not particularly hard or time consuming, so consider following the best practices
 below.
 
----
-
 ## For Individuals
 
 These settings apply to your personal X (Twitter) account. All team members and admins should configure
@@ -97,8 +95,6 @@ these on their own accounts.
 
 </Checklist>
 
----
-
 ### Best Practices & Additional Tips
 
 <Checklist id="best-practices">
@@ -121,8 +117,6 @@ these on their own accounts.
     ensure the email is from "@x.com"
 </Checklist>
 
----
-
 ### Notes
 
 #### [1] Email Security
@@ -133,8 +127,6 @@ guessable.
 You can easily work around this by supplementing your email address with a "+" suffix, for example
 `myemailusername+randomcharacters@gmail.com` (works with Gmail and iCloud emails).
 
----
-
 ## For Team Members
 
 These guidelines apply to team members who help manage X (Twitter) accounts but don't have full administrative access.
@@ -144,8 +136,6 @@ Team members should:
 - Ensure their individual account settings are configured according to the checklist above
 - Understand any delegate permissions they have been granted
 - Be aware of phishing tactics—like SIM swaps or fake login screens—used to seize control of profiles
-
----
 
 ## For Admins
 
@@ -163,10 +153,12 @@ If using Typefully for team collaboration:
   with a minimum amount of Publishers and Admins.
 </Checklist>
 
-
 ## Further Reading
 
-- [Guides overview](/guides/overview)
+- [Community Management: Twitter](/community-management/twitter): running the public account safely
+- [Account Management overview](/guides/account-management/overview): how these product guides fit together
+- [Hardware Security Keys](/guides/endpoint-security/hardware-security-keys): phishing-resistant 2FA for this account
+- [Secure Authentication](/iam/secure-authentication): recovery email, phone removal, and password reset protection
 
 ---
 

--- a/docs/pages/guides/account-management/vercel.mdx
+++ b/docs/pages/guides/account-management/vercel.mdx
@@ -95,6 +95,11 @@ These settings and practices apply to Vercel team administrators with elevated p
 
 </Checklist>
 
+
+## Further Reading
+
+- [Guides overview](/guides/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/guides/account-management/vercel.mdx
+++ b/docs/pages/guides/account-management/vercel.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Vercel Security | Security Alliance"
-description: "Secure your Vercel account and team: enable 2FA, review access tokens, manage team members, configure deployment protection, and ensure sensitive environment variables are properly secured."
+description: "Secure your Vercel account and team: enable 2FA, review access tokens, manage team members, configure deployment protection"
 tags:
   - DevOps Accounts
 contributors:

--- a/docs/pages/guides/account-management/vercel.mdx
+++ b/docs/pages/guides/account-management/vercel.mdx
@@ -6,6 +6,8 @@ tags:
 contributors:
   - role: wrote
     users: [auditware]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../components'
@@ -17,7 +19,7 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 ## Summary
 
-> 🔑 **Key Takeaway for Vercel:** Secure your Vercel account by enabling two-factor authentication, reviewing personal
+> 🔑 **Key Takeaway**: Secure your Vercel account by enabling two-factor authentication, reviewing personal
 > access tokens, and ensuring team-level security policies are enforced. Configure deployment protection, mark sensitive
 > environment variables appropriately, and regularly audit team member access and integrations.
 

--- a/docs/pages/guides/account-management/vercel.mdx
+++ b/docs/pages/guides/account-management/vercel.mdx
@@ -25,8 +25,6 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 This checklist is adapted from [Auditware's W3OSC](https://github.com/W3OSC/web3-opsec-standard) standards.
 
----
-
 ## For Individuals
 
 These settings apply to your personal Vercel account. All team members and admins should configure these on their own accounts.
@@ -41,8 +39,6 @@ For individual Vercel accounts, ensure you have:
 - [ ]  Review connected Git accounts and remove any unnecessary connections
 </Checklist>
 
----
-
 ## For Team Members
 
 These guidelines apply to team members who use Vercel but don't have full administrative access.
@@ -54,8 +50,6 @@ Team members should:
 - Regularly review and remove any unnecessary personal access tokens
 - Be aware of which projects they have access to and report any unexpected access
 - Never share environment variables or secrets outside of approved channels
-
----
 
 ## For Admins
 
@@ -95,10 +89,13 @@ These settings and practices apply to Vercel team administrators with elevated p
 
 </Checklist>
 
-
 ## Further Reading
 
-- [Guides overview](/guides/overview)
+- [Account Management overview](/guides/account-management/overview): how these product guides fit together
+- [Web Application Security](/front-end-web-app/web-application-security): securing what gets deployed here
+- [CDN & Hosting Compromise Runbook](/incident-management/incident-response-template/runbooks/cdn-hosting-compromise):
+  response steps if the deployment platform is taken over
+- [Vercel: security](https://vercel.com/docs/security): vendor documentation for platform and team controls
 
 ---
 

--- a/docs/pages/guides/endpoint-security/hardware-security-keys.mdx
+++ b/docs/pages/guides/endpoint-security/hardware-security-keys.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Hardware Security Keys | Security Alliance"
-description: "Use hardware security keys on critical accounts, keep a backup enrolled, and avoid weak recovery paths."
+description: "Use hardware security keys on critical accounts, keep a backup enrolled, and avoid weak recovery paths. Use FIDO2/WebAuthn security keys on high-value"
 tags:
   - Security Specialist
 contributors:

--- a/docs/pages/guides/endpoint-security/hardware-security-keys.mdx
+++ b/docs/pages/guides/endpoint-security/hardware-security-keys.mdx
@@ -6,6 +6,8 @@ tags:
 contributors:
   - role: wrote
     users: [dickson, louis, pablo]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../components'
@@ -17,7 +19,7 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 ## Summary
 
-> 🔑 **Key Takeaway for Hardware Security Keys:** Use FIDO2/WebAuthn security keys on high-value accounts, register
+> 🔑 **Key Takeaway**: Use FIDO2/WebAuthn security keys on high-value accounts, register
 > at least two keys per critical account, disable SMS fallback where possible, and test recovery before you need it.
 
 Hardware security keys are one of the strongest practical defenses against phishing, credential stuffing, and

--- a/docs/pages/guides/endpoint-security/password-manager-endpoint-hardening.mdx
+++ b/docs/pages/guides/endpoint-security/password-manager-endpoint-hardening.mdx
@@ -8,6 +8,8 @@ tags:
 contributors:
   - role: wrote
     users: [dickson]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../components'
@@ -19,7 +21,7 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 ## Summary
 
-> 🔑 **Key Takeaway:** Encrypt every device that can unlock your vault, lock it quickly, keep it updated, use
+> 🔑 **Key Takeaway**: Encrypt every device that can unlock your vault, lock it quickly, keep it updated, use
 > phishing-resistant MFA on the password manager account, minimize browser and clipboard exposure, and rehearse
 > recovery before an incident.
 

--- a/docs/pages/guides/endpoint-security/password-manager-endpoint-hardening.mdx
+++ b/docs/pages/guides/endpoint-security/password-manager-endpoint-hardening.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Password Manager Endpoint Hardening | Security Alliance"
-description: "Reduce password manager endpoint risk with stronger device, browser, MFA, and recovery practices."
+description: "Reduce password manager endpoint risk with stronger device, browser, MFA, and recovery practices. Encrypt every device that can unlock your vault, lock"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/guides/endpoint-security/ssh-client-and-key-management-hardening.mdx
+++ b/docs/pages/guides/endpoint-security/ssh-client-and-key-management-hardening.mdx
@@ -9,6 +9,8 @@ contributors:
     users: [dickson]
   - role: reviewed
     users: [mattaereal, pinalikefruit]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../components'
@@ -20,7 +22,7 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 ## Summary
 
-> 🔑 **Key Takeaway for SSH Client and Key Management Hardening:** Use dedicated SSH keys for distinct purposes,
+> 🔑 **Key Takeaway**: Use dedicated SSH keys for distinct purposes,
 > prefer Ed25519 for new software keys, use hardware-backed `*-sk` keys for higher-risk access where practical,
 > protect keys with passphrases, keep agent forwarding off by default, and maintain a simple revoke-and-reissue plan
 > for lost devices or role changes.

--- a/docs/pages/guides/endpoint-security/ssh-client-and-key-management-hardening.mdx
+++ b/docs/pages/guides/endpoint-security/ssh-client-and-key-management-hardening.mdx
@@ -1,6 +1,6 @@
 ---
 title: "SSH Client and Key Management Hardening | Security Alliance"
-description: "Harden SSH client usage with better key handling, agent discipline, host verification, and rotation."
+description: "Harden SSH client usage with better key handling, agent discipline, host verification, and rotation. Prioritize high-impact controls, least privilege"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/guides/endpoint-security/zoom-hardening.mdx
+++ b/docs/pages/guides/endpoint-security/zoom-hardening.mdx
@@ -88,7 +88,7 @@ this down:
 If Zoom already has accessibility access, revoke it immediately:
 
 ```bash
-# Revoke Zoom's accessibility permissions via tccutil
+ # Revoke Zoom's accessibility permissions via tccutil
 tccutil reset Accessibility us.zoom.xos
 ```
 

--- a/docs/pages/guides/overview.mdx
+++ b/docs/pages/guides/overview.mdx
@@ -1,10 +1,18 @@
 ---
-title: "Guides"
+title: "Guides | Security Alliance"
+description: "Practical SEAL security guides: harden account management across platforms and endpoint controls for SSH, security keys, password managers, and Zoom."
 tags:
   - Security Specialist
+  - Engineer/Developer
+  - Operations & Strategy
+  - Community & Marketing
 contributors:
   - role: wrote
     users: [dickson, nftdreww]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -12,22 +20,42 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 # Guides
 
 <TagList tags={frontmatter.tags} />
+<AttributionList contributors={frontmatter.contributors} />
 
-This section contains practical, step-by-step guides that help you implement security best practices across various
-platforms and tools. Each guide provides actionable instructions you can follow to secure your operations.
+> 🔑 **Key Takeaway**: Guides turn framework principles into product-specific checklists. Follow the steps for each
+> tool, then keep settings reviewed as vendors change defaults.
 
-## Available Guide Categories
+This section contains practical, step-by-step guides for implementing security controls across platforms and endpoints.
+Each guide is actionable for individuals, team members, and administrators where roles differ.
 
-### [Account Management](/guides/account-management/overview)
+## What this section covers
 
-Comprehensive guides for securing your accounts across communication platforms, DevOps tools, and business applications.
-These guides cover:
+1. [Account Management](/guides/account-management/overview): secure communication platforms, DevOps/infrastructure
+   accounts, and business tools.
+2. [SSH Client and Key Management Hardening](/guides/endpoint-security/ssh-client-and-key-management-hardening): SSH key
+   hygiene, agent discipline, host verification.
+3. [Hardware Security Keys](/guides/endpoint-security/hardware-security-keys): FIDO2/WebAuthn enrollment and practices.
+4. [Password Manager Endpoint Hardening](/guides/endpoint-security/password-manager-endpoint-hardening): device and
+   endpoint controls around password vaults.
+5. [Zoom Hardening](/guides/endpoint-security/zoom-hardening): Zoom remote-control and meeting security posture.
 
-- **Communication Platforms** - Discord, Telegram, Twitter/X, Signal, Slack
-- **DevOps & Infrastructure** - GitHub, GoDaddy, Render, Sentry, Vercel
-- **Business Tools** - Linear, Mercury, Notion, Trello
+### Account management children
 
-Each account management guide includes security checklists for individuals, team members, and administrators.
+See the [Account Management overview](/guides/account-management/overview) for the full product list (Discord, Telegram,
+Twitter/X, Signal, Slack, GitHub, GoDaddy, Render, Sentry, Vercel, Linear, Mercury, Notion, Trello).
+
+## Related frameworks
+
+- [Community Management](/community-management/overview): community-facing risks tied to these account guides
+- [OpSec](/opsec/overview): broader MFA, passwords, and device controls
+- [IAM](/iam/overview): identity lifecycle and least privilege
+- [Infrastructure](/infrastructure/overview): DNS, hosting, and network context for registrar/DevOps guides
+- [User and Team Security](/user-team-security/overview): staff security posture (when expanded)
+
+## Further Reading & Tools
+
+Use the linked product guides and their in-page checklists. Prefer vendor security docs for current UI paths when
+product surfaces change.
 
 ---
 

--- a/docs/pages/guides/overview.mdx
+++ b/docs/pages/guides/overview.mdx
@@ -52,7 +52,7 @@ Twitter/X, Signal, Slack, GitHub, GoDaddy, Render, Sentry, Vercel, Linear, Mercu
 - [Infrastructure](/infrastructure/overview): DNS, hosting, and network context for registrar/DevOps guides
 - [User and Team Security](/user-team-security/overview): staff security posture (when expanded)
 
-## Further Reading & Tools
+## Further Reading
 
 Use the linked product guides and their in-page checklists. Prefer vendor security docs for current UI paths when
 product surfaces change.

--- a/docs/pages/guides/overview.mdx
+++ b/docs/pages/guides/overview.mdx
@@ -28,8 +28,7 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 This section contains practical, step-by-step guides for implementing security controls across platforms and endpoints.
 Each guide is actionable for individuals, team members, and administrators where roles differ.
 
-## What this section covers
-
+## What this framework covers
 1. [Account Management](/guides/account-management/overview): secure communication platforms, DevOps/infrastructure
    accounts, and business tools.
 2. [SSH Client and Key Management Hardening](/guides/endpoint-security/ssh-client-and-key-management-hardening): SSH key


### PR DESCRIPTION
## Scope

Normalize **Guides** (`docs/pages/guides/` including account-management and endpoint-security).

## Why

Root and account-management overviews lacked full chrome/page maps; many guides used non-canonical `Key Takeaway for X:` labels; contributor `fact-checked` roles incomplete.

## Content model applied

Section overviews + procedure guides; preserve deep product checklists.

## Substantive security changes

**None.** Product steps retained; KT label form only plus hub navigation.

## Intentionally unchanged

- Long per-product checklist bodies and `<Checklist>` usage
- Sidebar structure

## Validation

- [x] cspell
- [x] markdownlint-cli2
- [x] signed commit

## Dependencies

**#561** by reference.

## Reviewer focus

- Overview maps match sidebar children
- Canonical KT labels still capture prior product-specific advice