### PR TITLE
docs(infrastructure): normalize structure and wording

### DIFF
--- a/docs/pages/infrastructure/asset-inventory.mdx
+++ b/docs/pages/infrastructure/asset-inventory.mdx
@@ -34,6 +34,11 @@ basis. It is highly recommended to also assign ownership of each asset, so that 
 asset. Classifying them based on their criticality and sensitivity also helps you prioritize them with regards to
 security measures.
 
+
+## Further Reading
+
+- [Infrastructure overview](/infrastructure/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/infrastructure/asset-inventory.mdx
+++ b/docs/pages/infrastructure/asset-inventory.mdx
@@ -37,7 +37,11 @@ security measures.
 
 ## Further Reading
 
-- [Infrastructure overview](/infrastructure/overview)
+- [Infrastructure overview](/infrastructure/overview): how the pages of this framework fit together
+- [Cloud Infrastructure](/infrastructure/cloud): where much of the inventory actually lives
+- [Dependency Awareness](/supply-chain/dependency-awareness): inventorying the software supply chain too
+- [CIS Control 1: Inventory and Control of Enterprise Assets](https://www.cisecurity.org/controls/inventory-and-control-of-enterprise-assets):
+  a reference process for building and refreshing the list
 
 ---
 

--- a/docs/pages/infrastructure/asset-inventory.mdx
+++ b/docs/pages/infrastructure/asset-inventory.mdx
@@ -8,7 +8,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/infrastructure/asset-inventory.mdx
+++ b/docs/pages/infrastructure/asset-inventory.mdx
@@ -6,6 +6,13 @@ tags:
   - Security Specialist
   - DevOps
   - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -14,6 +21,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: You cannot protect what you do not inventory. Document assets, owners, and criticality—and refresh
+> the list on a fixed cadence.
 
 An asset inventory means having information about everything related to your project, meaning for example contracts,
 hardware, software, cloud providers, dependencies and network components. This is important, as if you don't have

--- a/docs/pages/infrastructure/asset-inventory.mdx
+++ b/docs/pages/infrastructure/asset-inventory.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Asset Inventory | Security Alliance"
-description: "Document all project assets: contracts, hardware, software, cloud providers, dependencies, and network components. Assign ownership and classify by criticality to prioritize security measures."
+description: "Document all project assets: contracts, hardware, software, cloud providers, dependencies, and network components. You cannot protect what you do not"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/infrastructure/cloud.mdx
+++ b/docs/pages/infrastructure/cloud.mdx
@@ -64,7 +64,11 @@ To aid with vulnerability detection and compliance, you could consider using the
 
 ## Further Reading
 
-- [Infrastructure overview](/infrastructure/overview)
+- [Infrastructure overview](/infrastructure/overview): how the pages of this framework fit together
+- [Access Management](/iam/access-management): the RBAC and lifecycle practice behind cloud control planes
+- [Network Security](/infrastructure/network-security): VPC boundaries, firewalls, and traffic monitoring
+- [AWS Well-Architected Security Pillar](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/welcome.html):
+  a reference model for reviewing a cloud footprint
 
 ---
 

--- a/docs/pages/infrastructure/cloud.mdx
+++ b/docs/pages/infrastructure/cloud.mdx
@@ -61,6 +61,11 @@ To aid with vulnerability detection and compliance, you could consider using the
 - **S3Scanner (AWS)**: [S3Scanner](https://github.com/sa7mon/S3Scanner)
 - **Zeus (AWS)**: [Zeus](https://github.com/DenizParlak/Zeus)
 
+
+## Further Reading
+
+- [Infrastructure overview](/infrastructure/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/infrastructure/cloud.mdx
+++ b/docs/pages/infrastructure/cloud.mdx
@@ -8,6 +8,13 @@ tags:
   - DevOps
   - Cloud
   - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -16,6 +23,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Cloud security is IAM, encryption, network boundary, and logging done consistently. Misconfigured
+> public storage and overly broad roles remain common failure modes.
 
 Securing your cloud infrastructure could be considered as important as securing your decentralized application, as a lot
 of users will be interacting with your dapp through the cloud provider. Some best practices to consider are:

--- a/docs/pages/infrastructure/cloud.mdx
+++ b/docs/pages/infrastructure/cloud.mdx
@@ -10,7 +10,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/infrastructure/cloud.mdx
+++ b/docs/pages/infrastructure/cloud.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Cloud Infrastructure | Security Alliance"
-description: "Secure cloud infrastructure with RBAC, MFA, data encryption, VPCs, and CloudTrail logging. AWS, Azure, and GCP hardening guides plus open-source tools like CloudSploit and Prowler."
+description: "Secure cloud infrastructure with RBAC, MFA, data encryption, VPCs, and CloudTrail logging. AWS, Azure, and GCP hardening guides plus open-source tools like"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/infrastructure/ddos-protection.mdx
+++ b/docs/pages/infrastructure/ddos-protection.mdx
@@ -69,7 +69,11 @@ In addition to cloud provider solutions, consider external DDoS protection servi
 
 ## Further Reading
 
-- [Infrastructure overview](/infrastructure/overview)
+- [Infrastructure overview](/infrastructure/overview): how the pages of this framework fit together
+- [Network Security](/infrastructure/network-security): the traffic controls these protections sit on top of
+- [DDoS Attack Runbook](/incident-management/incident-response-template/runbooks/ddos-attack): what to do once an
+  attack is underway
+- [Web Application Security](/front-end-web-app/web-application-security): front-end availability and IPFS fallbacks
 
 ---
 

--- a/docs/pages/infrastructure/ddos-protection.mdx
+++ b/docs/pages/infrastructure/ddos-protection.mdx
@@ -1,6 +1,6 @@
 ---
 title: "DDoS Protection | Security Alliance"
-description: "Protect against DDoS attacks with AWS Shield, Azure DDoS Protection, Google Cloud Armor, and external providers like Cloudflare, Akamai, and Imperva. Cloud-native and third-party solutions compared."
+description: "Protect against DDoS attacks with AWS Shield, Azure DDoS Protection, Google Cloud Armor, and external providers like Cloudflare, Akamai, and Imperva"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/infrastructure/ddos-protection.mdx
+++ b/docs/pages/infrastructure/ddos-protection.mdx
@@ -66,6 +66,11 @@ In addition to cloud provider solutions, consider external DDoS protection servi
 - **Akamai**: Provides scalable DDoS protection solutions.
 - **Imperva**: Specializes in DDoS protection and mitigation.
 
+
+## Further Reading
+
+- [Infrastructure overview](/infrastructure/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/infrastructure/ddos-protection.mdx
+++ b/docs/pages/infrastructure/ddos-protection.mdx
@@ -30,7 +30,7 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 Distributed Denial of Service (DDoS) attacks are a pervasive threat that can disrupt your services by overwhelming them
 with excessive traffic.
 
-## Best Practices
+## Best practices
 
 - **Use Cloud Provider Solutions**: Utilize DDoS protection services offered by your cloud provider:
 

--- a/docs/pages/infrastructure/ddos-protection.mdx
+++ b/docs/pages/infrastructure/ddos-protection.mdx
@@ -8,6 +8,13 @@ tags:
   - DevOps
   - Cloud
   - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -16,6 +23,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Plan DDoS controls before a flood, not during one. Combine provider native protections with CDN or
+> scrubbing services matched to traffic profile.
 
 Distributed Denial of Service (DDoS) attacks are a pervasive threat that can disrupt your services by overwhelming them
 with excessive traffic.

--- a/docs/pages/infrastructure/ddos-protection.mdx
+++ b/docs/pages/infrastructure/ddos-protection.mdx
@@ -10,7 +10,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/infrastructure/domain-and-dns-security/dns-basics-and-attacks.mdx
+++ b/docs/pages/infrastructure/domain-and-dns-security/dns-basics-and-attacks.mdx
@@ -1,6 +1,6 @@
 ---
 title: "DNS Basics & Common Attacks | SEAL"
-description: "Understand DNS resolution and common attack vectors: social engineering at registrars, expired domain sniping, DNS hijacking, MX tampering, DNS tunneling, and cache poisoning."
+description: "Understand DNS resolution and common attack vectors: social engineering at registrars, expired domain sniping, DNS hijacking, MX tampering, DNS tunneling"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/infrastructure/domain-and-dns-security/dns-basics-and-attacks.mdx
+++ b/docs/pages/infrastructure/domain-and-dns-security/dns-basics-and-attacks.mdx
@@ -80,6 +80,11 @@ still shows the correct domain name.
 - DNS Tunneling: Encoding data within DNS queries for covert communication channels, often used for data exfiltration
 - DNS Cache Poisoning: Injecting forged responses into a resolver's cache to redirect subsequent queries
 
+
+## Further Reading
+
+- [Infrastructure overview](/infrastructure/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/infrastructure/domain-and-dns-security/dns-basics-and-attacks.mdx
+++ b/docs/pages/infrastructure/domain-and-dns-security/dns-basics-and-attacks.mdx
@@ -9,6 +9,8 @@ contributors:
     users: [Raiders0786]
   - role: reviewed
     users: [dickson, mattaereal]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
@@ -17,6 +19,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Know how DNS resolution and common hijack paths work before layering defenses. Attackers change
+> records, not just apps.
 
 ## How DNS Resolution Works
 

--- a/docs/pages/infrastructure/domain-and-dns-security/dns-basics-and-attacks.mdx
+++ b/docs/pages/infrastructure/domain-and-dns-security/dns-basics-and-attacks.mdx
@@ -83,7 +83,13 @@ still shows the correct domain name.
 
 ## Further Reading
 
-- [Infrastructure overview](/infrastructure/overview)
+- [Domain & DNS Security overview](/infrastructure/domain-and-dns-security/overview): how this subsection fits together
+- [Registrar Security & Registry Locks](/infrastructure/domain-and-dns-security/registrar-and-locks): closing the
+  registrar path these attacks use
+- [Monitoring, Alerts, and Incident Response](/infrastructure/domain-and-dns-security/monitoring-and-alerting):
+  detecting record changes quickly
+- [DNS Hijack Runbook](/incident-management/incident-response-template/runbooks/dns-hijack): response steps once an
+  attack lands
 
 ---
 

--- a/docs/pages/infrastructure/domain-and-dns-security/dnssec-and-email.mdx
+++ b/docs/pages/infrastructure/domain-and-dns-security/dnssec-and-email.mdx
@@ -129,17 +129,17 @@ The Common CA Database also provides a
 [comprehensive collection to reference](https://ccadb.org/resources).
 
 ```
-# Allow only specific CAs to issue certificates
+ # Allow only specific CAs to issue certificates
 example.com. CAA 0 issue "letsencrypt.org"
 example.com. CAA 0 issue "digicert.com"
 
-# Send violation reports when unauthorized CAs attempt issuance
+ # Send violation reports when unauthorized CAs attempt issuance
 example.com. CAA 0 iodef "mailto:security@example.com"
 
-# Control wildcard certificate issuance separately
+ # Control wildcard certificate issuance separately
 example.com. CAA 0 issuewild "letsencrypt.org"
 
-# Completely disable all certificate issuance (useful for non-web domains)
+ # Completely disable all certificate issuance (useful for non-web domains)
 example.com. CAA 0 issue ";"
 ```
 

--- a/docs/pages/infrastructure/domain-and-dns-security/dnssec-and-email.mdx
+++ b/docs/pages/infrastructure/domain-and-dns-security/dnssec-and-email.mdx
@@ -9,6 +9,8 @@ contributors:
     users: [Raiders0786, gunnim]
   - role: reviewed
     users: [dickson, mattaereal]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
@@ -17,6 +19,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: DNSSEC, CAA, and email authentication (SPF/DKIM/DMARC, DANE where used) reduce spoofing and
+> unauthorized certificate or mail paths. Configure and monitor them as production controls.
 
 ## DNSSEC Implementation
 

--- a/docs/pages/infrastructure/domain-and-dns-security/dnssec-and-email.mdx
+++ b/docs/pages/infrastructure/domain-and-dns-security/dnssec-and-email.mdx
@@ -129,17 +129,17 @@ The Common CA Database also provides a
 [comprehensive collection to reference](https://ccadb.org/resources).
 
 ```
- # Allow only specific CAs to issue certificates
+# Allow only specific CAs to issue certificates
 example.com. CAA 0 issue "letsencrypt.org"
 example.com. CAA 0 issue "digicert.com"
 
- # Send violation reports when unauthorized CAs attempt issuance
+# Send violation reports when unauthorized CAs attempt issuance
 example.com. CAA 0 iodef "mailto:security@example.com"
 
- # Control wildcard certificate issuance separately
+# Control wildcard certificate issuance separately
 example.com. CAA 0 issuewild "letsencrypt.org"
 
- # Completely disable all certificate issuance (useful for non-web domains)
+# Completely disable all certificate issuance (useful for non-web domains)
 example.com. CAA 0 issue ";"
 ```
 
@@ -389,7 +389,11 @@ unencrypted.*
 
 ## Further Reading
 
-- [Infrastructure overview](/infrastructure/overview)
+- [Domain & DNS Security overview](/infrastructure/domain-and-dns-security/overview): how this subsection fits together
+- [DNS Basics & Common Attacks](/infrastructure/domain-and-dns-security/dns-basics-and-attacks): the spoofing paths
+  these controls close
+- [Email Encryption](/encryption/email-encryption): protecting message content alongside authentication
+- [Internet.nl](https://internet.nl/): test a domain's DNSSEC, DMARC, and STARTTLS configuration
 
 ---
 

--- a/docs/pages/infrastructure/domain-and-dns-security/dnssec-and-email.mdx
+++ b/docs/pages/infrastructure/domain-and-dns-security/dnssec-and-email.mdx
@@ -386,6 +386,11 @@ related failures and SHOULD NOT include this SMTP session in the
 next report. This may mean that the reports are delivered
 unencrypted.*
 
+
+## Further Reading
+
+- [Infrastructure overview](/infrastructure/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/infrastructure/domain-and-dns-security/dnssec-and-email.mdx
+++ b/docs/pages/infrastructure/domain-and-dns-security/dnssec-and-email.mdx
@@ -1,6 +1,6 @@
 ---
 title: "DNSSEC, CAA, SMTP DANE and Email Security | SEAL"
-description: "Implement DNSSEC for cryptographic DNS authentication, CAA records to control certificate issuance, and email security with SPF, DKIM, MTA-STS, and DMARC to prevent spoofing attacks."
+description: "Implement DNSSEC for cryptographic DNS authentication, CAA records to control certificate issuance, and email security with SPF, DKIM, MTA-STS"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/infrastructure/domain-and-dns-security/monitoring-and-alerting.mdx
+++ b/docs/pages/infrastructure/domain-and-dns-security/monitoring-and-alerting.mdx
@@ -196,6 +196,11 @@ might be missed by periodic checks.
 3. **Consider legal action** if appropriate
 4. **Publish transparency report** to rebuild trust
 
+
+## Further Reading
+
+- [Infrastructure overview](/infrastructure/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/infrastructure/domain-and-dns-security/monitoring-and-alerting.mdx
+++ b/docs/pages/infrastructure/domain-and-dns-security/monitoring-and-alerting.mdx
@@ -1,6 +1,6 @@
 ---
 title: "DNS Monitoring & Incident Response | SEAL"
-description: "Monitor DNS records for unauthorized changes. Set critical alerts for nameserver changes, DNSSEC failures, and CAA removal. Use Certificate Transparency logs and passive DNS monitoring."
+description: "Monitor DNS records for unauthorized changes. Set critical alerts for nameserver changes, DNSSEC failures, and CAA removal"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/infrastructure/domain-and-dns-security/monitoring-and-alerting.mdx
+++ b/docs/pages/infrastructure/domain-and-dns-security/monitoring-and-alerting.mdx
@@ -199,7 +199,12 @@ might be missed by periodic checks.
 
 ## Further Reading
 
-- [Infrastructure overview](/infrastructure/overview)
+- [Domain & DNS Security overview](/infrastructure/domain-and-dns-security/overview): how this subsection fits together
+- [Monitoring overview](/monitoring/overview): the wider detection and alerting practice
+- [Incident Detection and Response](/incident-management/incident-detection-and-response): what happens after an alert
+  fires
+- [DNS Hijack Runbook](/incident-management/incident-response-template/runbooks/dns-hijack): the specific response for
+  unauthorized record changes
 
 ---
 

--- a/docs/pages/infrastructure/domain-and-dns-security/monitoring-and-alerting.mdx
+++ b/docs/pages/infrastructure/domain-and-dns-security/monitoring-and-alerting.mdx
@@ -10,6 +10,8 @@ contributors:
     users: [Raiders0786]
   - role: reviewed
     users: [dickson, mattaereal]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
@@ -18,6 +20,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Detection of DNS and registrar change must be fast and owned. GitOps and continuous monitoring
+> catch silent record swaps before users do.
 
 ## DNS Record Monitoring
 

--- a/docs/pages/infrastructure/domain-and-dns-security/overview.mdx
+++ b/docs/pages/infrastructure/domain-and-dns-security/overview.mdx
@@ -47,8 +47,7 @@ characteristics of blockchain technology:
 - **Reputation damage**: One domain hijack incident can permanently destroy protocol trust, as users lose confidence in
   the project's security practices.
 
-## What this section covers
-
+## What this framework covers
 1. [DNS Basics and Common Attacks](/infrastructure/domain-and-dns-security/dns-basics-and-attacks): resolution model and
    common attack paths.
 2. [DNSSEC, CAA, SMTP DANE and Email Security](/infrastructure/domain-and-dns-security/dnssec-and-email): integrity and

--- a/docs/pages/infrastructure/domain-and-dns-security/overview.mdx
+++ b/docs/pages/infrastructure/domain-and-dns-security/overview.mdx
@@ -99,7 +99,11 @@ These incidents highlight the critical importance of proper domain security meas
 
 ## Further Reading
 
-- [Infrastructure overview](/infrastructure/overview)
+- [Infrastructure overview](/infrastructure/overview): how this subsection fits the wider framework
+- [DNS Hijack Runbook](/incident-management/incident-response-template/runbooks/dns-hijack): response steps when records
+  change without authorization
+- [GoDaddy Security](/guides/account-management/godaddy): hardening a registrar account in practice
+- [Front-End & Web App](/front-end-web-app/overview): the site users reach once DNS resolves
 
 ---
 

--- a/docs/pages/infrastructure/domain-and-dns-security/overview.mdx
+++ b/docs/pages/infrastructure/domain-and-dns-security/overview.mdx
@@ -10,6 +10,8 @@ contributors:
     users: [Raiders0786]
   - role: reviewed
     users: [dickson, mattaereal]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
@@ -18,6 +20,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Compromised DNS or registrar control can serve wallet drainers as "the real site." Lock
+> registrars, monitor changes, and treat domain security as fund security.
 
 DNS (Domain Name System) is the backbone of the internet, translating domain names into IP addresses. In Web3, domain
 security is particularly critical as compromised domains can lead to irreversible financial losses through wallet
@@ -41,6 +46,17 @@ characteristics of blockchain technology:
   to user funds without needing to compromise individual accounts.
 - **Reputation damage**: One domain hijack incident can permanently destroy protocol trust, as users lose confidence in
   the project's security practices.
+
+## What this section covers
+
+1. [DNS Basics and Common Attacks](/infrastructure/domain-and-dns-security/dns-basics-and-attacks): resolution model and
+   common attack paths.
+2. [DNSSEC, CAA, SMTP DANE and Email Security](/infrastructure/domain-and-dns-security/dnssec-and-email): integrity and
+   email authentication controls.
+3. [Registrar Security and Registry Locks](/infrastructure/domain-and-dns-security/registrar-and-locks): account and lock
+   controls that stop many seizures.
+4. [Monitoring, Alerts, and GitOps](/infrastructure/domain-and-dns-security/monitoring-and-alerting): detect and revert
+   hostile changes quickly.
 
 ## Historical Context
 

--- a/docs/pages/infrastructure/domain-and-dns-security/overview.mdx
+++ b/docs/pages/infrastructure/domain-and-dns-security/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Domain & DNS Security | SEAL"
-description: "Protect Web3 domains from hijacking and wallet drainer attacks. Learn from Curve Finance and Galxe incidents. Prevent irreversible financial losses with DNS security best practices."
+description: "Protect Web3 domains from hijacking and wallet drainer attacks. Learn from Curve Finance and Galxe incidents. Prevent irreversible financial losses with DNS"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/infrastructure/domain-and-dns-security/overview.mdx
+++ b/docs/pages/infrastructure/domain-and-dns-security/overview.mdx
@@ -97,6 +97,11 @@ These incidents highlight the critical importance of proper domain security meas
   Explained](https://web3secnews.substack.com/p/the-hidden-dns-threats-that-could) - Comprehensive Web3 DNS security
   guide
 
+
+## Further Reading
+
+- [Infrastructure overview](/infrastructure/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/infrastructure/domain-and-dns-security/registrar-and-locks.mdx
+++ b/docs/pages/infrastructure/domain-and-dns-security/registrar-and-locks.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Registrar Security & Registry Locks | SEAL"
-description: "Choose enterprise registrars like MarkMonitor over GoDaddy. Enable Registry Lock (EPP Lock), hardware security keys for MFA, WHOIS privacy, and RDAP for domain security audits."
+description: "Choose enterprise registrars like MarkMonitor over GoDaddy. Enable Registry Lock (EPP Lock), hardware security keys for MFA, WHOIS privacy"
 tags:
   - Operations & Strategy
   - Security Specialist

--- a/docs/pages/infrastructure/domain-and-dns-security/registrar-and-locks.mdx
+++ b/docs/pages/infrastructure/domain-and-dns-security/registrar-and-locks.mdx
@@ -274,7 +274,7 @@ should be preferred for domain information lookups.
 nameserver configurations, and validate expiration dates. The structured output makes it ideal for automated monitoring
 and compliance checks.
 
-### Domain Expiration Protection
+## Domain Expiration Protection
 
 Domain expiration is a critical yet often overlooked security risk. When domains expire, they enter a grace period
 before becoming publicly available, creating an opportunity for attackers to snipe your domain.
@@ -306,7 +306,12 @@ respective registries. Always verify your specific TLD's expiration policy with 
 
 ## Further Reading
 
-- [Infrastructure overview](/infrastructure/overview)
+- [Domain & DNS Security overview](/infrastructure/domain-and-dns-security/overview): how this subsection fits together
+- [GoDaddy Security](/guides/account-management/godaddy): a worked example of hardening a registrar account
+- [DNS Hijack Runbook](/incident-management/incident-response-template/runbooks/dns-hijack): response steps if a
+  transfer or seizure succeeds
+- [ICANN: EPP status codes](https://www.icann.org/resources/pages/epp-status-codes-2014-06-16-en): what each lock status
+  actually prevents
 
 ---
 

--- a/docs/pages/infrastructure/domain-and-dns-security/registrar-and-locks.mdx
+++ b/docs/pages/infrastructure/domain-and-dns-security/registrar-and-locks.mdx
@@ -303,6 +303,11 @@ respective registries. Always verify your specific TLD's expiration policy with 
 
 **Pro tip**: Set calendar reminders to check auto-renewal status quarterly - don't assume it's working until you verify.
 
+
+## Further Reading
+
+- [Infrastructure overview](/infrastructure/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/infrastructure/domain-and-dns-security/registrar-and-locks.mdx
+++ b/docs/pages/infrastructure/domain-and-dns-security/registrar-and-locks.mdx
@@ -274,7 +274,7 @@ should be preferred for domain information lookups.
 nameserver configurations, and validate expiration dates. The structured output makes it ideal for automated monitoring
 and compliance checks.
 
-## Domain Expiration Protection
+### Domain Expiration Protection
 
 Domain expiration is a critical yet often overlooked security risk. When domains expire, they enter a grace period
 before becoming publicly available, creating an opportunity for attackers to snipe your domain.

--- a/docs/pages/infrastructure/domain-and-dns-security/registrar-and-locks.mdx
+++ b/docs/pages/infrastructure/domain-and-dns-security/registrar-and-locks.mdx
@@ -9,6 +9,8 @@ contributors:
     users: [Raiders0786]
   - role: reviewed
     users: [dickson, mattaereal]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
@@ -17,6 +19,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Registrar locks and hardened registrar accounts stop many domain seizures. Treat registrar access
+> like a root prod credential.
 
 ## Choosing a Secure Registrar
 

--- a/docs/pages/infrastructure/identity-and-access-management.mdx
+++ b/docs/pages/infrastructure/identity-and-access-management.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Identity And Access Management | SEAL"
-description: "Infrastructure IAM pointer: comprehensive RBAC, authentication, and access lifecycle guidance lives in the dedicated IAM framework."
+description: "Infrastructure IAM pointer: comprehensive RBAC, authentication, and access lifecycle guidance lives in the dedicated IAM framework. Use that for RBAC"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/infrastructure/identity-and-access-management.mdx
+++ b/docs/pages/infrastructure/identity-and-access-management.mdx
@@ -31,7 +31,10 @@ practices that apply to cloud and infrastructure control planes.
 
 ## Further Reading
 
-- [Infrastructure overview](/infrastructure/overview)
+- [IAM overview](/iam/overview): the dedicated framework this page defers to
+- [Access Management](/iam/access-management): provisioning, review, and offboarding for control planes
+- [Role-Based Access Control](/iam/role-based-access-control): structuring roles across infrastructure
+- [Infrastructure overview](/infrastructure/overview): how the pages of this framework fit together
 
 ---
 

--- a/docs/pages/infrastructure/identity-and-access-management.mdx
+++ b/docs/pages/infrastructure/identity-and-access-management.mdx
@@ -28,6 +28,11 @@ This infrastructure subsection is covered by a dedicated framework. See
 [Access Management](/iam/access-management) for role-based access control, authentication, lifecycle, and review
 practices that apply to cloud and infrastructure control planes.
 
+
+## Further Reading
+
+- [Infrastructure overview](/infrastructure/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/infrastructure/identity-and-access-management.mdx
+++ b/docs/pages/infrastructure/identity-and-access-management.mdx
@@ -1,9 +1,16 @@
 ---
 title: "Identity And Access Management | SEAL"
-description: "Infrastructure Identity and Access Management (IAM) best practices. For comprehensive IAM guidance including RBAC, secure authentication, and access management, see the dedicated IAM framework."
+description: "Infrastructure IAM pointer: comprehensive RBAC, authentication, and access lifecycle guidance lives in the dedicated IAM framework."
 tags:
   - Engineer/Developer
   - Security Specialist
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -13,8 +20,13 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Right now, this subsection has an entire category of its own. Please refer to [Incident and Access Management
-(IAM)](/iam/access-management)
+> 🔑 **Key Takeaway**: Infrastructure IAM details live in the dedicated IAM framework. Use that for RBAC, authentication,
+> and access lifecycle; keep this page as the cross-link.
+
+This infrastructure subsection is covered by a dedicated framework. See
+[Identity and Access Management (IAM)](/iam/overview) and especially
+[Access Management](/iam/access-management) for role-based access control, authentication, lifecycle, and review
+practices that apply to cloud and infrastructure control planes.
 
 ---
 

--- a/docs/pages/infrastructure/identity-and-access-management.mdx
+++ b/docs/pages/infrastructure/identity-and-access-management.mdx
@@ -6,7 +6,7 @@ tags:
   - Security Specialist
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/infrastructure/network-security.mdx
+++ b/docs/pages/infrastructure/network-security.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Network Security | Security Alliance"
-description: "Network security primer for Web3: default-deny firewalls, segmentation, IDS/IPS, VPNs for remote access, encrypted transit, ACLs, and audit cadence. Cross-references DDoS, DNS, and privacy VPN guidance."
+description: "Network security primer for Web3: default-deny firewalls, segmentation, IDS/IPS, VPNs for remote access, encrypted transit, ACLs, and audit cadence"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/infrastructure/network-security.mdx
+++ b/docs/pages/infrastructure/network-security.mdx
@@ -170,7 +170,7 @@ management ports), not smart contract bugs.
 | Flow logging | Enabled | Centralized + alerts on anomalies |
 | Audit cadence | Quarterly | Continuous automated + quarterly manual review |
 
-## Further Reading & Tools
+## Further Reading
 
 - [NIST SP 800-41 Rev. 1](https://csrc.nist.gov/publications/detail/sp/800-41/rev-1/final)
   — Guidelines for Firewalls and Firewall Policy

--- a/docs/pages/infrastructure/network-security.mdx
+++ b/docs/pages/infrastructure/network-security.mdx
@@ -13,6 +13,8 @@ contributors:
     users: [mattaereal]
   - role: reviewed
     users: [scode2277]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -22,9 +24,8 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> 🔑 **Key Takeaway**: Default-deny ingress, segment everything, encrypt in transit,
-> log and audit continuously. Network security is not a single tool but a layered posture —
-> each layer assumes the one below it may fail.
+> 🔑 **Key Takeaway**: Default-deny ingress, segment everything, encrypt in transit, log and audit continuously. Network
+> security is not a single tool but a layered posture — each layer assumes the one below it may fail.
 
 Network security spans every boundary where your infrastructure touches the internet or other
 untrusted networks. In Web3, the stakes are higher than typical SaaS: a compromised frontend

--- a/docs/pages/infrastructure/operating-system-security.mdx
+++ b/docs/pages/infrastructure/operating-system-security.mdx
@@ -30,7 +30,7 @@ This document outlines some general best practices one should follow with regard
 if you're interested in a much more comprehensive guide you could look at [NIST
 800-123](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-123.pdf).
 
-## Best Practices
+## Best practices
 
 1. Keep your operating systems updated with the latest security patches and updates.
 2. Block the remote shell port from all but required IPs.

--- a/docs/pages/infrastructure/operating-system-security.mdx
+++ b/docs/pages/infrastructure/operating-system-security.mdx
@@ -44,6 +44,11 @@ if you're interested in a much more comprehensive guide you could look at [NIST
 10. Implement host-based intrusion detection and prevention systems (HIDS/HIPS).
 11. Follow secure configuration guides, such as the NIST 800-123 guidelines, to harden your operating systems.
 
+
+## Further Reading
+
+- [Infrastructure overview](/infrastructure/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/infrastructure/operating-system-security.mdx
+++ b/docs/pages/infrastructure/operating-system-security.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Operating System Security | Security Alliance"
-description: "Harden operating systems with security patches, fail2ban, SSH key authentication, MFA, RBAC, and host-based firewalls. Follow NIST 800-123 guidelines for comprehensive OS security."
+description: "Harden operating systems with security patches, fail2ban, SSH key authentication, MFA, RBAC, and host-based firewalls. Covers Operating System Security"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/infrastructure/operating-system-security.mdx
+++ b/docs/pages/infrastructure/operating-system-security.mdx
@@ -7,6 +7,13 @@ tags:
   - Operations & Strategy
   - DevOps
   - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -15,6 +22,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Patch early, prefer key-based SSH with MFA where supported, and keep host firewalls default-deny.
+> OS hardening is table stakes under every higher control.
 
 This document outlines some general best practices one should follow with regards to operating system security, however
 if you're interested in a much more comprehensive guide you could look at [NIST

--- a/docs/pages/infrastructure/operating-system-security.mdx
+++ b/docs/pages/infrastructure/operating-system-security.mdx
@@ -9,7 +9,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/infrastructure/operating-system-security.mdx
+++ b/docs/pages/infrastructure/operating-system-security.mdx
@@ -47,7 +47,10 @@ if you're interested in a much more comprehensive guide you could look at [NIST
 
 ## Further Reading
 
-- [Infrastructure overview](/infrastructure/overview)
+- [Infrastructure overview](/infrastructure/overview): how the pages of this framework fit together
+- [Secure Operating Systems](/opsec/secure-operating-systems): hardened OS choices for high-risk operator machines
+- [Network Security](/infrastructure/network-security): the firewall and segmentation layer around these hosts
+- [CIS Benchmarks](https://www.cisecurity.org/cis-benchmarks): per-OS hardening baselines you can audit against
 
 ---
 

--- a/docs/pages/infrastructure/overview.mdx
+++ b/docs/pages/infrastructure/overview.mdx
@@ -1,12 +1,19 @@
 ---
 title: "Infrastructure | Security Alliance"
-description: "Infrastructure Framework: Secure Web3 infrastructure including cloud providers, DNS security, domain registrars, DDoS protection, network security, and zero-trust principles."
+description: "Secure Web3 infrastructure: asset inventory, cloud, DDoS, domain and DNS, network, OS hardening, zero trust, and a pointer to the dedicated IAM framework."
 tags:
   - Engineer/Developer
   - Security Specialist
   - DevOps
   - Cloud
   - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -16,26 +23,55 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Infrastructure can often be overlooked in web3, but it's often a very important area given that most front-end web
-applications are running on centralized infrastructure. This section focuses on Infrastructure Security, encompassing
-critical aspects such as cloud infrastructure, DNS providers, domain registrars, and DDoS (Distributed Denial of
-Service) protection.
+> 🔑 **Key Takeaway**: Web3 frontends and ops still run on centralized infrastructure. Inventory it, harden cloud and
+> DNS, and weigh single-provider simplicity against multi-provider blast-radius reduction.
 
-When designing your architecture, it may be worth considering how many different providers you rely on. Are you going to
-use different providers for infrastructure, DDoS protection, domain registration, and DNS, or will you choose a
-provider that provides all of these? On one hand, putting all your eggs in one basket means a failure of that service
-would cause downtime. On the other hand, using a single service and ensuring it follows all best practices with regard
-to security measures means a lower risk surface.
+Infrastructure is often underrated relative to smart contracts, yet most front-end applications and operator tooling run
+on centralized systems. This framework covers cloud posture, DNS and domain registration, DDoS protection, network and
+OS hardening, asset inventory, and zero-trust principles.
 
-## Contents
+When designing architecture, weigh provider concentration: one vendor for hosting, DDoS, registrar, and DNS lowers
+integration cost but creates a shared failure domain; decoupling raises complexity but can limit blast radius. Apply
+strong security practice either way.
 
-1. [Asset Inventory](/infrastructure/asset-inventory)
-2. [Cloud Infrastructure](/infrastructure/cloud)
-3. [DDoS Protection](/infrastructure/ddos-protection)
-4. [DNS and Domain Registration](/infrastructure/domain-and-dns-security/overview)
-5. [Network Security](/infrastructure/network-security)
-6. [Operating System Security](/infrastructure/operating-system-security)
-7. [Zero-Trust Principles](/infrastructure/zero-trust-principles)
+Identity and access lifecycle for people is primarily covered in the dedicated [IAM](/iam/overview) framework; the
+infrastructure IAM page is a pointer.
+
+## What this framework covers
+
+1. [Asset Inventory](/infrastructure/asset-inventory): know what to protect and who owns it.
+2. [Cloud Infrastructure](/infrastructure/cloud): RBAC, encryption, network boundaries, logging.
+3. [DDoS Protection](/infrastructure/ddos-protection): cloud-native and third-party mitigation options.
+4. [Domain and DNS Security](/infrastructure/domain-and-dns-security/overview): registrar locks, DNSSEC and email
+   security, monitoring.
+5. [Identity and Access Management (pointer)](/infrastructure/identity-and-access-management): routes to the IAM
+   framework.
+6. [Network Security](/infrastructure/network-security): default-deny, segmentation, transit encryption.
+7. [Operating System Security](/infrastructure/operating-system-security): patching, SSH, host firewall baselines.
+8. [Zero-Trust Principles](/infrastructure/zero-trust-principles): verify continuously; least privilege access.
+
+### Domain and DNS subsection
+
+1. [DNS Overview](/infrastructure/domain-and-dns-security/overview)
+2. [DNS Basics and Common Attacks](/infrastructure/domain-and-dns-security/dns-basics-and-attacks)
+3. [DNSSEC, CAA, SMTP DANE and Email Security](/infrastructure/domain-and-dns-security/dnssec-and-email)
+4. [Registrar Security and Registry Locks](/infrastructure/domain-and-dns-security/registrar-and-locks)
+5. [Monitoring, Alerts, and GitOps](/infrastructure/domain-and-dns-security/monitoring-and-alerting)
+
+## Related frameworks
+
+- [IAM](/iam/overview): org identity, MFA, RBAC lifecycle
+- [Front-End Web App](/front-end-web-app/overview): client delivery over infrastructure
+- [DevSecOps](/devsecops/overview): pipeline and isolation
+- [Privacy — VPNs](/privacy/vpns/overview): operator path privacy complementary to network controls
+- [Monitoring](/monitoring/overview): on-chain signals complementary to infra telemetry
+- [Guides — Account Management](/guides/account-management/overview): product account hardening for common stacks
+
+## Further Reading & Tools
+
+- Nested DNS pages and [NIST SP 800-123](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-123.pdf)
+  for OS baselines
+- Cloud provider security benchmarks for your stack
 
 ---
 

--- a/docs/pages/infrastructure/overview.mdx
+++ b/docs/pages/infrastructure/overview.mdx
@@ -9,7 +9,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/infrastructure/overview.mdx
+++ b/docs/pages/infrastructure/overview.mdx
@@ -67,7 +67,7 @@ infrastructure IAM page is a pointer.
 - [Monitoring](/monitoring/overview): on-chain signals complementary to infra telemetry
 - [Guides — Account Management](/guides/account-management/overview): product account hardening for common stacks
 
-## Further Reading & Tools
+## Further Reading
 
 - Nested DNS pages and [NIST SP 800-123](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-123.pdf)
   for OS baselines

--- a/docs/pages/infrastructure/zero-trust-principles.mdx
+++ b/docs/pages/infrastructure/zero-trust-principles.mdx
@@ -7,7 +7,7 @@ tags:
   - Operations & Strategy
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/infrastructure/zero-trust-principles.mdx
+++ b/docs/pages/infrastructure/zero-trust-principles.mdx
@@ -43,6 +43,11 @@ protection.
 4. Implement continuous monitoring and analytics to detect and respond to anomalies in real-time.
 5. Use automation to enforce security policies consistently across the network.
 
+
+## Further Reading
+
+- [Infrastructure overview](/infrastructure/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/infrastructure/zero-trust-principles.mdx
+++ b/docs/pages/infrastructure/zero-trust-principles.mdx
@@ -46,7 +46,11 @@ protection.
 
 ## Further Reading
 
-- [Infrastructure overview](/infrastructure/overview)
+- [Infrastructure overview](/infrastructure/overview): how the pages of this framework fit together
+- [Access Management](/iam/access-management): the identity controls zero trust depends on
+- [Network Security](/infrastructure/network-security): segmentation and encryption between workloads
+- [NIST SP 800-207: Zero Trust Architecture](https://csrc.nist.gov/pubs/sp/800/207/final): the reference definition and
+  deployment models
 
 ---
 

--- a/docs/pages/infrastructure/zero-trust-principles.mdx
+++ b/docs/pages/infrastructure/zero-trust-principles.mdx
@@ -5,6 +5,13 @@ tags:
   - Engineer/Developer
   - Security Specialist
   - Operations & Strategy
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -13,6 +20,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Zero trust means authenticate and authorize every request with least privilege—location on the LAN
+> is not a trust signal.
 
 The Zero-Trust security model assumes that threats can exist both inside and outside the network. It requires strict
 verification for every user and device attempting to access resources, regardless of their location.

--- a/docs/pages/infrastructure/zero-trust-principles.mdx
+++ b/docs/pages/infrastructure/zero-trust-principles.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Zero Trust Principles | Security Alliance"
-description: "Implement Zero-Trust security: verify every user and device regardless of location. Use MFA, micro-segmentation, just-in-time access, and continuous monitoring for breach prevention."
+description: "Implement Zero-Trust security: verify every user and device regardless of location. Use MFA, micro-segmentation, just-in-time access"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/infrastructure/zero-trust-principles.mdx
+++ b/docs/pages/infrastructure/zero-trust-principles.mdx
@@ -27,7 +27,7 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 The Zero-Trust security model assumes that threats can exist both inside and outside the network. It requires strict
 verification for every user and device attempting to access resources, regardless of their location.
 
-## Key Principles
+## Key principles
 
 1. Always authenticate and authorize based on all available data points, including user identity, location, device
 health, and service or workload.


### PR DESCRIPTION
## Scope

Normalize **Infrastructure** (`docs/pages/infrastructure/` including domain-and-dns-security/).

## Why

Thin overview TOC; missing Key Takeaways; IAM page linked incorrectly to a mangled path (“Incident and Access Management”); DNS overview lacked child page map.

## Substantive security changes

**None** beyond correcting the broken IAM internal link to `/iam/overview` and `/iam/access-management`.

## Validation

- [x] cspell
- [x] markdownlint-cli2 clean
- [x] signed commit

## Dependencies

**#561** by reference.

## Reviewer focus

- Provider concentration wording remains balanced
- DNS overview map vs sidebar
- IAM pointer accuracy