### PR TITLE
docs(treasury-operations): normalize structure and wording

### DIFF
--- a/docs/pages/treasury-operations/classification.mdx
+++ b/docs/pages/treasury-operations/classification.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Treasury Security Classification | SEAL"
-description: "Classify custodial treasury accounts by financial impact and operational urgency. Apply a control matrix for approvers, MFA, whitelist delays, and monitoring by risk."
+description: "Classify custodial treasury accounts by financial impact and operational urgency. Apply a control matrix for approvers, MFA, whitelist delays"
 tags:
   - Treasury Ops
   - Operations

--- a/docs/pages/treasury-operations/classification.mdx
+++ b/docs/pages/treasury-operations/classification.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Treasury Security Classification | SEAL"
-description: "Classify custodial treasury accounts by financial impact and operational requirements. Security control matrix for determining approvers, MFA requirements, and whitelist delays based on risk level."
+description: "Classify custodial treasury accounts by financial impact and operational urgency. Apply a control matrix for approvers, MFA, whitelist delays, and monitoring by risk."
 tags:
   - Treasury Ops
   - Operations
@@ -10,20 +10,26 @@ contributors:
     users: [dickson]
   - role: reviewed
     users: [relotnek, bsamuels453, ElliotFriedman]
+  - role: fact-checked
+    users: []
 ---
 
-import { TagList, AttributionList, ContributeFooter } from "../../../components"
+import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 # Custodial Treasury Security: Classification Framework
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
+> 🔑 **Key Takeaway**: Size controls to impact and access urgency. High financial concentration or time-critical access
+> without matching approvers, MFA, and delays is misclassification risk.
+
 Proper documentation and classification of custodial accounts is essential for institutional treasury security. This
 guide focuses on the security assessment and classification framework for crypto assets held with third-party
 custodians.
 
-> See also: [Registration Documents](./registration-documents) and [Enhanced Controls for High-Risk Accounts](./enhanced-controls)
+See also: [Registration Documents](/treasury-operations/registration-documents) and
+[Enhanced Controls for High-Risk Accounts](/treasury-operations/enhanced-controls).
 
 ## Classification Process
 
@@ -59,12 +65,12 @@ Evaluate regulatory and compliance consequences:
 
 #### Impact Classification
 
-| Level        | Financial Exposure (% of Total Assets) | Operational Dependency                       | Regulatory Impact                                    |
-| ------------ | -------------------------------------- | -------------------------------------------- | ---------------------------------------------------- |
-| **Low**      | \<1%                                   | No critical operations depend on it          | No regulatory reporting tied to this account         |
-| **Medium**   | 1% - 10%                               | Important but alternative funding available  | Periodic reporting; delays manageable                |
-| **High**     | 10% - 25%                              | Critical operations, limited alternatives    | Regular regulatory filings; delays cause violations  |
-| **Critical** | \>25%                                  | Business-critical, no alternatives for weeks | Real-time reporting requirements; SEC filings; audit |
+| Level | Financial Exposure (% of Total Assets) | Operational Dependency | Regulatory Impact |
+| --- | --- | --- | --- |
+| **Low** | \<1% | No critical operations depend on it | No regulatory reporting tied to this account |
+| **Medium** | 1% - 10% | Important but alternative funding available | Periodic reporting; delays manageable |
+| **High** | 10% - 25% | Critical operations, limited alternatives | Regular regulatory filings; delays cause violations |
+| **Critical** | \>25% | Business-critical, no alternatives for weeks | Real-time reporting requirements; SEC filings; audit |
 
 ### Step 2: Operational Assessment
 
@@ -99,12 +105,12 @@ compensating controls like strict spending limits and daily reconciliation.
 
 #### Operational Classification
 
-| Type                  | Frequency     | Response Window | Example Use Cases                                  |
-| --------------------- | ------------- | --------------- | -------------------------------------------------- |
-| **Cold Vault**        | \<5 tx/month  | 48-72 hours     | Long-term reserves, infrequent rebalancing         |
-| **Warm Storage**      | 5-50 tx/month | 4-24 hours      | Scheduled payments, planned operations             |
-| **Active Operations** | \>50 tx/month | \<4 hours       | Trading capital, frequent operational expenses     |
-| **Time-Critical**     | Unpredictable | \<2 hours       | Collateral management, market-sensitive operations |
+| Type | Frequency | Response Window | Example Use Cases |
+| --- | --- | --- | --- |
+| **Cold Vault** | \<5 tx/month | 48-72 hours | Long-term reserves, infrequent rebalancing |
+| **Warm Storage** | 5-50 tx/month | 4-24 hours | Scheduled payments, planned operations |
+| **Active Operations** | \>50 tx/month | \<4 hours | Trading capital, frequent operational expenses |
+| **Time-Critical** | Unpredictable | \<2 hours | Collateral management, market-sensitive operations |
 
 ### Step 3: Security Control Matrix
 
@@ -127,8 +133,18 @@ Combine impact and operational assessments to determine required controls.
 - Capture approver thresholds and required controls
 - Store links to relevant custody accounts and addresses
 
-Proceed to: [Registration Documents](./registration-documents)
+Proceed to: [Registration Documents](/treasury-operations/registration-documents).
 
-For Critical/High accounts, ensure you also review: [Enhanced Controls for High-Risk Accounts](./enhanced-controls)
+For Critical/High accounts, also review:
+[Enhanced Controls for High-Risk Accounts](/treasury-operations/enhanced-controls).
+
+## Further reading
+
+- [Registration Documents](/treasury-operations/registration-documents)
+- [Enhanced Controls for High-Risk Accounts](/treasury-operations/enhanced-controls)
+- [Treasury Operations overview](/treasury-operations/overview)
+- [Transaction Verification](/treasury-operations/transaction-verification)
+
+---
 
 <ContributeFooter />

--- a/docs/pages/treasury-operations/enhanced-controls.mdx
+++ b/docs/pages/treasury-operations/enhanced-controls.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Enhanced Controls for High-Risk Accounts | SEAL"
-description: "Enhanced controls for high-risk custodial accounts: MPC thresholds, zero-trust access paths, hardware keys, dedicated devices, SIEM monitoring, and custody policy-engine rules."
+description: "Enhanced controls for high-risk custodial accounts: MPC thresholds, zero-trust access paths, hardware keys, dedicated devices, SIEM monitoring"
 tags:
   - Treasury Ops
   - Operations

--- a/docs/pages/treasury-operations/enhanced-controls.mdx
+++ b/docs/pages/treasury-operations/enhanced-controls.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Enhanced Controls for High-Risk Accounts | SEAL"
-description: "Enhanced security controls for high-risk custodial accounts: MPC custody recommendations, zero-trust architecture, hardware security keys, dedicated devices, SIEM monitoring, and policy engine rules."
+description: "Enhanced controls for high-risk custodial accounts: MPC thresholds, zero-trust access paths, hardware keys, dedicated devices, SIEM monitoring, and custody policy-engine rules."
 tags:
   - Treasury Ops
   - Operations
@@ -10,16 +10,22 @@ contributors:
     users: [dickson]
   - role: reviewed
     users: [relotnek, bsamuels453, ElliotFriedman]
+  - role: fact-checked
+    users: []
 ---
 
-import { TagList, AttributionList, ContributeFooter } from "../../../components"
+import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 # Enhanced Controls for High-Risk Accounts
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-For Critical and High impact custodial accounts, implement the following controls in addition to baseline measures.
+> 🔑 **Key Takeaway**: High and Critical impact accounts need more than baseline MFA: dedicated devices, stronger
+> quorum/MPC patterns, policy-engine gates, and monitored access paths.
+
+For Critical and High impact custodial accounts, implement the following controls in addition to baseline measures from
+the [Classification Framework](/treasury-operations/classification).
 
 ---
 
@@ -32,6 +38,8 @@ For Critical and High impact custodial accounts, implement the following control
 
 For DeFi interactions: refer to the [DeFi Risk Assessment Guide](https://entethalliance.org/specs/defi-risks/v1/) for
 recommended procedures.
+
+Large receive/send ceremonies: [Guide: Large Cryptocurrency Transfers](/treasury-operations/transaction-verification).
 
 ## Access Security
 
@@ -86,14 +94,14 @@ Policy scope definitions (examples):
 
 Suggested approver thresholds (treasury contexts):
 
-| Operation            | Impact   | Urgency        | Approver Threshold            |
-| -------------------- | -------- | -------------- | ----------------------------- |
-| Emergency Freeze     | Critical | Emergency      | 2/4                           |
-| Protocol Parameters  | High     | Routine        | 4/7 (7/9+ for upgrades)       |
-| Capital Allocation   | High     | Time-Sensitive | 3/5                           |
-| Treasury - Large     | High     | Routine        | 4/7                           |
-| Treasury - Small     | Medium   | Routine        | 3/5                           |
-| Constrained DeFi     | Medium   | Time-Sensitive | 2/3                           |
+| Operation | Impact | Urgency | Approver Threshold |
+| --- | --- | --- | --- |
+| Emergency Freeze | Critical | Emergency | 2/4 |
+| Protocol Parameters | High | Routine | 4/7 (7/9+ for upgrades) |
+| Capital Allocation | High | Time-Sensitive | 3/5 |
+| Treasury - Large | High | Routine | 4/7 |
+| Treasury - Small | Medium | Routine | 3/5 |
+| Constrained DeFi | Medium | Time-Sensitive | 2/3 |
 
 ## Custody Policy Engine Rules
 
@@ -122,7 +130,7 @@ enforcement.
   - Bastion enforces MFA, device posture checks, and approved software versions
   - No direct custody access from employee devices
   - Centralized patch management and security configuration
-  
+
 - Cloud Workspace Isolation: Use browser-isolated or virtual workspace environments (e.g., Citrix, AWS WorkSpaces, Azure
   Virtual Desktop)
   - Custody access occurs only within a controlled virtual environment
@@ -148,11 +156,16 @@ For Critical and High impact accounts, implement centralized security monitoring
 For Medium and Low impact accounts, leverage custodian's native audit logs with weekly manual review and automated
 alerting for critical events (new device enrollment, policy changes, transactions above threshold).
 
+## Further reading
+
+- [Classification Framework](/treasury-operations/classification)
+- [Registration Documents](/treasury-operations/registration-documents)
+- [Transaction Verification](/treasury-operations/transaction-verification)
+- [Treasury Operations overview](/treasury-operations/overview)
+- [Multisig for Protocols](/multisig-for-protocols/overview)
+- [Infrastructure — Zero-Trust Principles](/infrastructure/zero-trust-principles)
+- [Monitoring](/monitoring/overview)
+
 ---
-
-### See also
-
-- Classification: [Custodial Treasury Security: Classification Framework](./classification)
-- Templates: [Registration Documents](./registration-documents)
 
 <ContributeFooter />

--- a/docs/pages/treasury-operations/overview.mdx
+++ b/docs/pages/treasury-operations/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Treasury Operations Security | SEAL"
-description: "Treasury Operations Framework: Institutional-grade security for custodial accounts and large crypto transfers. Risk classification and transfer protocols."
+description: "Treasury operations security: classify custodial accounts by impact, register controls, apply enhanced high-risk measures, and verify large cryptocurrency transfers."
 tags:
   - Treasury Ops
   - Operations
@@ -8,51 +8,68 @@ tags:
 contributors:
   - role: wrote
     users: [dickson]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
-import { TagList, AttributionList, ContributeFooter } from "../../../components"
+import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 # Treasury Operations Security
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> 💡 Institutional-grade security frameworks for managing custodial treasury accounts and large cryptocurrency transfers
+> 🔑 **Key Takeaway**: Treat custodial treasury accounts like cash vaults: classify by impact and access urgency,
+> document who can move funds, and verify every large transfer before it is irreversible.
 
-## What is Treasury Operations Security?
+Treasury operations security provides protocols for organizations that hold significant cryptocurrency through custodial
+accounts. The material covers risk classification, registration and review templates, extra controls for high-impact
+accounts, and step-by-step verification for large receive and send flows.
 
-Treasury operations security provides protocols and frameworks for organizations managing significant cryptocurrency
-holdings through custodial accounts. These guides help you classify accounts by risk, implement appropriate security
-controls, maintain proper documentation, and execute large transfers safely.
+These guides assume third-party or co-managed custody rather than day-to-day protocol governance multisigs. For protocol
+signer operations, see [Multisig for Protocols](/multisig-for-protocols/overview).
 
-## Core Components
+## What is treasury operations security?
 
-### [Classification Framework](./classification)
+Treasury operations security is the set of controls, documents, and procedures that keep custodial holdings available
+when needed and hard to drain when compromised. Classification sets the control bar; registration keeps access and
+configuration auditable; enhanced controls raise the bar for critical balances; transaction verification reduces
+social-engineering and address errors on large moves.
 
-Assess and classify custodial accounts based on financial impact and operational requirements. Determine appropriate
-security controls, approval thresholds, and monitoring levels for each account.
+## What this framework covers
 
-### [Registration Documents](./registration-documents)
+1. [Classification Framework](/treasury-operations/classification): dual impact and operational classification plus a
+   security control matrix for approvers, MFA, and whitelist delays.
+2. [Registration Documents](/treasury-operations/registration-documents): templates for account registration, access
+   changes, security configuration, and quarterly review.
+3. [Enhanced Controls for High-Risk Accounts](/treasury-operations/enhanced-controls): additional measures for High and
+   Critical impact accounts, including MPC considerations, policy engines, and monitoring.
+4. [Guide: Large Cryptocurrency Transfers](/treasury-operations/transaction-verification): receive and send protocols with
+   address verification, test transactions, and multi-party confirmation.
 
-Standardized templates for registering custodial accounts, tracking access changes, documenting security configurations,
-and performing quarterly reviews.
+## Getting started
 
-### [Enhanced Controls](./enhanced-controls)
+1. Classify accounts with the [Classification Framework](/treasury-operations/classification).
+2. Register each account using [Registration Documents](/treasury-operations/registration-documents).
+3. Apply baseline controls from the matrix; add
+   [Enhanced Controls](/treasury-operations/enhanced-controls) for High and Critical impact.
+4. Follow [Transaction Verification](/treasury-operations/transaction-verification) for large transfers.
 
-Additional security measures for high-risk and critical accounts, including MPC recommendations, zero-trust
-architecture, and advanced monitoring.
+## Related frameworks
 
-### [Transaction Verification](./transaction-verification)
+- [Multisig for Protocols](/multisig-for-protocols/overview): protocol and ops multisig design and runbooks
+- [Wallet Security](/wallet-security/overview): key storage, hardware, and transaction simulation
+- [IAM](/iam/overview): identity lifecycle adjacent to custody platform access
+- [Incident Management](/incident-management/overview): response when custody or treasury access is abused
+- [OpSec](/opsec/overview): personnel and physical practices around high-value ceremonies
+- [SEAL 911 Cert — Treasury Ops](/certs/sfc-treasury-ops): certification surface for treasury operations
 
-Step-by-step protocols for receiving and sending large cryptocurrency transfers, including address verification, test
-transactions, and multi-party confirmation requirements.
+## Further reading
 
-## Getting Started
-
-1. **Classify your accounts** using the [Classification Framework](./classification) to determine risk levels
-2. **Register each account** using the [Registration Documents](./registration-documents) templates
-3. **Implement controls** based on classification, with [Enhanced Controls](./enhanced-controls) for high-risk accounts
-4. **Follow verification protocols** from [Transaction Verification](./transaction-verification) for all large transfers
+- Child pages linked above and the transaction verification guide for procedure detail
+- Custodian SOC reports and platform policy-engine docs for your chosen provider
 
 ---
 

--- a/docs/pages/treasury-operations/registration-documents.mdx
+++ b/docs/pages/treasury-operations/registration-documents.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Custodial Account Registration | SEAL"
-description: "Standardized templates for custodial account registration: track access changes, document security configurations, quarterly reviews, and maintain compliance with institutional treasury standards."
+description: "Standardized custodial account registration templates: access change logs, security configuration, quarterly reviews, and institutional treasury documentation."
 tags:
   - Treasury Ops
   - Operations
@@ -10,19 +10,25 @@ contributors:
     users: [dickson]
   - role: reviewed
     users: [relotnek, bsamuels453]
+  - role: fact-checked
+    users: []
 ---
 
-import { TagList, AttributionList, ContributeFooter } from "../../../components"
+import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 # Registration Documents
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Use these standardized templates to register custodial accounts, track access changes, document security configurations,
-and perform quarterly reviews.
+> 🔑 **Key Takeaway**: Register every custodial account once, log every access change, snapshot security settings, and
+> run quarterly reviews so classification and controls stay aligned with reality.
 
-> See also: [Classification Framework](./classification) and [Enhanced Controls for High-Risk Accounts](./enhanced-controls)
+Use these standardized templates to register custodial accounts, track access changes, document security configurations,
+and perform quarterly reviews. Complete classification first so impact and operational type match the control matrix.
+
+See also: [Classification Framework](/treasury-operations/classification) and
+[Enhanced Controls for High-Risk Accounts](/treasury-operations/enhanced-controls).
 
 ---
 
@@ -399,6 +405,14 @@ Treasury Lead: _________________ Date: _______
 
 Next Review Due: YYYY-MM-DD
 ```
+
+---
+
+## Further reading
+
+- [Classification Framework](/treasury-operations/classification)
+- [Enhanced Controls for High-Risk Accounts](/treasury-operations/enhanced-controls)
+- [Treasury Operations overview](/treasury-operations/overview)
 
 ---
 

--- a/docs/pages/treasury-operations/transaction-verification.mdx
+++ b/docs/pages/treasury-operations/transaction-verification.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Treasury Transaction Verification | SEAL"
-description: "Step-by-step protocols for large cryptocurrency transfers: address verification, bidirectional test transactions, video verification, anti-social-engineering measures, and multi-party confirmation."
+description: "Protocols for large cryptocurrency transfers: address verification, bidirectional tests, video checks, anti-social-engineering controls, and multi-party confirmation before irreversible settlement."
 tags:
   - Treasury Ops
   - Protocol
@@ -12,19 +12,29 @@ contributors:
     users: [dickson]
   - role: reviewed
     users: [relotnek, ElliotFriedman]
+  - role: fact-checked
+    users: []
 ---
 
-import { TagList, AttributionList, ContributeFooter } from "../../../components"
+import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 # Guide: Large Cryptocurrency Transfers
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
+> 🔑 **Key Takeaway**: Large transfers are irreversible. Verify destination and amount through multiple people and
+> channels, run small tests first, and treat urgency as a social-engineering signal.
+
 ## Core Principles
 
 Large cryptocurrency transfers require rigorous verification because transactions are irreversible. This guide covers
 both receiving and sending significant amounts, with security measures scaling to transfer size.
+
+For account classification and custody policy baselines, start with the
+[Classification Framework](/treasury-operations/classification) and
+[Enhanced Controls](/treasury-operations/enhanced-controls). For protocol multisig operations, see
+[Multisig for Protocols](/multisig-for-protocols/overview).
 
 ## Part 1: Receiving Large Transfers
 
@@ -70,7 +80,7 @@ Have 2-3 team members independently verify the address:
 
 This should occur **24-48 hours before the main transfer**.
 
-**Phase 1: Sender → You (Incoming Test): **
+**Phase 1: Sender → You (Incoming Test):**
 
 ```
 1. Sender sends small amount (0.001 ETH or 0.0001 BTC) to your new address
@@ -81,7 +91,7 @@ This should occur **24-48 hours before the main transfer**.
 3. Document transaction hash and confirmation time
 ```
 
-**Phase 2: You → Sender (Outgoing Test): **
+**Phase 2: You → Sender (Outgoing Test):**
 
 ```
 4. Send test amount BACK to another address you control
@@ -114,6 +124,7 @@ Request from sender:
 - **\>$10M**: Consider 2-3 separate transactions (reduces single-transaction risk, allows staged confirmation, provides
   pause points to verify each step)
 - **\>$50M**: Multiple transactions strongly recommended with 30-minute intervals between each
+
 **Anti-Duress Protocols:**
 
 Since kidnapping and other forms of duress have been employed by criminals to steal cryptocurrency, organizations should
@@ -121,6 +132,7 @@ prepare for this. Establish a duress word that indicates a transfer is not being
 duress word is mentioned during an exchange involving the transfer, law enforcement will be contacted and the
 transaction will not be processed. Procedures should be put in place with concrete runbooks for these situations. Safe words
 should not appear in runbooks or any digital format.
+
 **Anti-Social-Engineering Protocols:**
 
 Establish a code phrase during the initial verified meeting. Use this phrase to authenticate any address changes or unusual
@@ -359,9 +371,8 @@ After transaction reaches finality:
 
 ## Multi-Signature Best Practices
 
-See the Multisigs for Protocols guide.
-
-# TODO: Add link to Multisigs for Protocols guide. AFTER IT IS MERGED
+For protocol and operational multisig design, thresholds, and runbooks, see
+[Multisig for Protocols](/multisig-for-protocols/overview).
 
 ## Critical Risk Mitigations
 
@@ -425,6 +436,15 @@ See the Multisigs for Protocols guide.
 extensive, but preventing a single mistake justifies significant operational overhead.
 
 The cost of verification is measured in minutes. The cost of a mistake is measured in millions.
+
+## Further reading
+
+- [Treasury Operations overview](/treasury-operations/overview)
+- [Classification Framework](/treasury-operations/classification)
+- [Enhanced Controls for High-Risk Accounts](/treasury-operations/enhanced-controls)
+- [Multisig for Protocols](/multisig-for-protocols/overview)
+- [Wallet Security](/wallet-security/overview)
+- [OpSec](/opsec/overview)
 
 ---
 

--- a/docs/pages/treasury-operations/transaction-verification.mdx
+++ b/docs/pages/treasury-operations/transaction-verification.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Treasury Transaction Verification | SEAL"
-description: "Protocols for large cryptocurrency transfers: address verification, bidirectional tests, video checks, anti-social-engineering controls, and multi-party confirmation before irreversible settlement."
+description: "Protocols for large cryptocurrency transfers: address verification, bidirectional tests, video checks, anti-social-engineering controls"
 tags:
   - Treasury Ops
   - Protocol


### PR DESCRIPTION
## Scope

Normalize **Treasury Operations** (`docs/pages/treasury-operations/`).

## Why

Overview used a non-canonical callout instead of Key Takeaway and a relative TOC without Related frameworks. Child pages lacked KTs / Further reading / `fact-checked` roles. Transaction guide had an unresolved `# TODO` for Multisig for Protocols.

## Content model applied

- Framework overview map synced to sidebar children
- Canonical `> 🔑 **Key Takeaway**:` on all content pages
- Absolute internal links; Related frameworks + Further reading
- Contributor roles preserved; empty `fact-checked: []` added

## Changes

- Rewrote overview chrome + Getting started as absolute routes
- Linked Multisig for Protocols (removed TODO comment)
- Chrome/cross-links only on classification, registration templates, enhanced controls, transaction verification

## Substantive security changes

**None.** Control matrices, template bodies, and transfer procedures unchanged in meaning.

## Intentionally unchanged

- Classification thresholds and control matrix body
- Registration template text (code-fence templates)
- Enhanced control recommendations and policy tables
- Transfer ceremony procedures

## Validation

- [x] cspell
- [x] markdownlint-cli2 clean on touch paths
- [x] signed commit

## Dependencies

**#561** by reference (content-model / style / validator). Do not copy standards files into this PR.

## Reviewer focus

- Absolute links vs relative deep-links
- Multisig cross-link accuracy
- Template pages still usable as copy-paste scaffolds