### PR TITLE
docs(multisig-for-protocols): normalize structure and wording

### DIFF
--- a/docs/pages/multisig-for-protocols/backup-signing-and-infrastructure.mdx
+++ b/docs/pages/multisig-for-protocols/backup-signing-and-infrastructure.mdx
@@ -238,6 +238,11 @@ Verification](/wallet-security/signing-and-verification/secure-multisig-safe-ver
 - [Emergency Procedures](/multisig-for-protocols/emergency-procedures) - General emergency response
 - [Communication Setup](/multisig-for-protocols/communication-setup) - Backup communication during outages
 
+
+## Further Reading
+
+- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/backup-signing-and-infrastructure.mdx
+++ b/docs/pages/multisig-for-protocols/backup-signing-and-infrastructure.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Backup Signing & Infrastructure | SEAL"
-description: "Use backup interfaces when Safe or Squads are compromised. Eternal Safe for EVM, Squads Public Client for Solana, alternative RPCs, and block explorers like Blockscout for emergency signing."
+description: "Use backup interfaces when Safe or Squads are compromised. Eternal Safe for EVM, Squads Public Client for Solana, alternative RPCs"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/multisig-for-protocols/backup-signing-and-infrastructure.mdx
+++ b/docs/pages/multisig-for-protocols/backup-signing-and-infrastructure.mdx
@@ -10,6 +10,8 @@ contributors:
     users: [isaac, geoffrey, louis, pablo, dickson]
   - role: reviewed
     users: [pinalikefruit, engn33r]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from "../../../components"
@@ -18,6 +20,9 @@ import { TagList, AttributionList, ContributeFooter } from "../../../components"
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Practice alternate Safe/Squads clients before the primary UI fails; backup
+> infrastructure is useless if first used during an incident.
 
 If the default interfaces for either Safe or Squads are down or suspected of being compromised, these alternatives
 enable continued critical signing operations. As a signer, you should familiarize yourself with these tools and practice
@@ -232,5 +237,7 @@ When using backup systems:
 Verification](/wallet-security/signing-and-verification/secure-multisig-safe-verification) - Verification procedures
 - [Emergency Procedures](/multisig-for-protocols/emergency-procedures) - General emergency response
 - [Communication Setup](/multisig-for-protocols/communication-setup) - Backup communication during outages
+
+---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/backup-signing-and-infrastructure.mdx
+++ b/docs/pages/multisig-for-protocols/backup-signing-and-infrastructure.mdx
@@ -231,17 +231,13 @@ When using backup systems:
 - **Team assistance**: Coordinate with other signers for problem-solving
 - **Alternative tools**: Have multiple backup options available
 
-### Related Documents
-
-- [Safe Multisig: Step-by-Step
-Verification](/wallet-security/signing-and-verification/secure-multisig-safe-verification) - Verification procedures
-- [Emergency Procedures](/multisig-for-protocols/emergency-procedures) - General emergency response
-- [Communication Setup](/multisig-for-protocols/communication-setup) - Backup communication during outages
-
-
 ## Further Reading
 
-- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+- [Multisig for Protocols overview](/multisig-for-protocols/overview): how the pages of this framework fit together
+- [Emergency Procedures](/multisig-for-protocols/emergency-procedures): general emergency response
+- [Communication Setup](/multisig-for-protocols/communication-setup): backup communication during outages
+- [Safe Multisig Verification](/wallet-security/signing-and-verification/secure-multisig-safe-verification):
+  verification procedures on the backup path
 
 ---
 

--- a/docs/pages/multisig-for-protocols/backup-signing-and-infrastructure.mdx
+++ b/docs/pages/multisig-for-protocols/backup-signing-and-infrastructure.mdx
@@ -203,7 +203,7 @@ When using backup systems:
 - **Emergency operations only**: For critical emergency responses, proceed with enhanced verification
 - **Communication**: Keep team informed about system status and verification procedures
 
-## Testing and Preparation
+### Testing and Preparation
 
 ### Regular Practice
 
@@ -217,7 +217,7 @@ When using backup systems:
 - **Communication testing**: Verify backup communication channels work with backup UIs
 - **Time measurement**: Track how long backup system activation takes
 
-## Troubleshooting
+### Troubleshooting
 
 ### Common Issues
 
@@ -231,7 +231,7 @@ When using backup systems:
 - **Team assistance**: Coordinate with other signers for problem-solving
 - **Alternative tools**: Have multiple backup options available
 
-## Related Documents
+### Related Documents
 
 - [Safe Multisig: Step-by-Step
 Verification](/wallet-security/signing-and-verification/secure-multisig-safe-verification) - Verification procedures

--- a/docs/pages/multisig-for-protocols/communication-setup.mdx
+++ b/docs/pages/multisig-for-protocols/communication-setup.mdx
@@ -53,10 +53,12 @@ For multisigs requiring rapid response:
 - Link to emergency runbooks in notification message
 - Test quarterly to ensure reliability
 
-
 ## Further Reading
 
-- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+- [Multisig for Protocols overview](/multisig-for-protocols/overview): how the pages of this framework fit together
+- [Emergency Procedures](/multisig-for-protocols/emergency-procedures): when these backup channels get used
+- [Incident Reporting](/multisig-for-protocols/incident-reporting): where reports are sent once contact is made
+- [Encrypted Communication Tools](/privacy/encrypted-communication-tools): choosing platforms for signer coordination
 
 ---
 

--- a/docs/pages/multisig-for-protocols/communication-setup.mdx
+++ b/docs/pages/multisig-for-protocols/communication-setup.mdx
@@ -53,6 +53,11 @@ For multisigs requiring rapid response:
 - Link to emergency runbooks in notification message
 - Test quarterly to ensure reliability
 
+
+## Further Reading
+
+- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/communication-setup.mdx
+++ b/docs/pages/multisig-for-protocols/communication-setup.mdx
@@ -8,9 +8,10 @@ tags:
 contributors:
   - role: wrote
     users: [isaac, geoffrey, louis, pablo, dickson]
-
   - role: reviewed
     users: [pinalikefruit, engn33r]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -19,6 +20,12 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Give every multisig a dedicated E2EE primary channel, a backup on a different platform,
+> and paging for critical response windows.
+
+Establish secure primary and backup channels before the first real signing ceremony so
+emergencies are not the first time the team coordinates.
 
 ## Primary channel
 
@@ -45,5 +52,7 @@ For multisigs requiring rapid response:
 - Include essential info in page: multisig name, urgency level, primary action needed
 - Link to emergency runbooks in notification message
 - Test quarterly to ensure reliability
+
+---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/communication-setup.mdx
+++ b/docs/pages/multisig-for-protocols/communication-setup.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Multisig Communication Setup | SEAL"
-description: "Configure secure multisig communication channels: Signal with end-to-end encryption as primary, backup channels on Telegram or Discord, and paging systems for 24/7 emergency response."
+description: "Configure secure multisig communication channels: Signal with end-to-end encryption as primary, backup channels on Telegram or Discord"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/multisig-for-protocols/emergency-procedures.mdx
+++ b/docs/pages/multisig-for-protocols/emergency-procedures.mdx
@@ -10,6 +10,8 @@ contributors:
     users: [isaac, geoffrey, louis, pablo, dickson]
   - role: reviewed
     users: [pinalikefruit, engn33r]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -18,6 +20,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Pre-agree compromise, lost-key, and channel-breach steps so the team can rotate or
+> freeze without improvising under pressure.
 
 When security incidents occur, quick and decisive action is critical. This page covers procedures for key compromise,
 lost access, and communication breaches.
@@ -234,5 +239,7 @@ and use the runbook page for the transaction-specific signing and execution step
 - [Seed Phrase Management](/wallet-security/seed-phrase-management) - Key recovery procedures
 - [Personal Security (OpSec)](/multisig-for-protocols/personal-security-opsec) - Account security measures
 - [Operational Runbooks](/multisig-for-protocols/runbooks/overview) - Example runbooks for common operations
+
+---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/emergency-procedures.mdx
+++ b/docs/pages/multisig-for-protocols/emergency-procedures.mdx
@@ -240,6 +240,11 @@ and use the runbook page for the transaction-specific signing and execution step
 - [Personal Security (OpSec)](/multisig-for-protocols/personal-security-opsec) - Account security measures
 - [Operational Runbooks](/multisig-for-protocols/runbooks/overview) - Example runbooks for common operations
 
+
+## Further Reading
+
+- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/emergency-procedures.mdx
+++ b/docs/pages/multisig-for-protocols/emergency-procedures.mdx
@@ -196,7 +196,7 @@ and use the runbook page for the transaction-specific signing and execution step
 3. **Process verification** - Ensure procedures work under pressure
 4. **Documentation review** - Update procedures based on drill results
 
-## Recovery and Post-Incident
+### Recovery and Post-Incident
 
 ### Immediate Recovery
 
@@ -217,7 +217,7 @@ and use the runbook page for the transaction-specific signing and execution step
 2. **Stakeholder updates** - Notify relevant parties as appropriate
 3. **Documentation** - Complete incident report for future reference
 
-## Emergency Contact Information
+### Emergency Contact Information
 
 ### Security Team Contact
 
@@ -231,7 +231,7 @@ and use the runbook page for the transaction-specific signing and execution step
 - **Technical team**: [Emergency technical contact]
 - **Legal/compliance**: [If regulatory notification required]
 
-## Related Documents
+### Related Documents
 
 - [Incident Reporting](/multisig-for-protocols/incident-reporting) - Formal incident reporting procedures
 - [Communication Setup](/multisig-for-protocols/communication-setup) - Backup communication channels

--- a/docs/pages/multisig-for-protocols/emergency-procedures.mdx
+++ b/docs/pages/multisig-for-protocols/emergency-procedures.mdx
@@ -181,22 +181,22 @@ Use the full [Emergency Pause Runbook](/multisig-for-protocols/runbooks/emergenc
 playbook for emergency pause transactions. Keep this page focused on incident coordination, communication, and recovery,
 and use the runbook page for the transaction-specific signing and execution steps.
 
-### Emergency Drill Procedures
+## Emergency Drill Procedures
 
-#### Regular Testing Schedule
+### Regular Testing Schedule
 
 - **Quarterly**: Communication system tests
 - **Bi-annually**: Emergency paging system tests
 - **Annually**: Full emergency simulation with all signers
 
-#### Drill Components
+### Drill Components
 
 1. **Notification test** - Verify all signers receive alerts
 2. **Response time measurement** - Track time to threshold signatures
 3. **Process verification** - Ensure procedures work under pressure
 4. **Documentation review** - Update procedures based on drill results
 
-### Recovery and Post-Incident
+## Recovery and Post-Incident
 
 ### Immediate Recovery
 
@@ -217,7 +217,7 @@ and use the runbook page for the transaction-specific signing and execution step
 2. **Stakeholder updates** - Notify relevant parties as appropriate
 3. **Documentation** - Complete incident report for future reference
 
-### Emergency Contact Information
+## Emergency Contact Information
 
 ### Security Team Contact
 
@@ -231,19 +231,12 @@ and use the runbook page for the transaction-specific signing and execution step
 - **Technical team**: [Emergency technical contact]
 - **Legal/compliance**: [If regulatory notification required]
 
-### Related Documents
-
-- [Incident Reporting](/multisig-for-protocols/incident-reporting) - Formal incident reporting procedures
-- [Communication Setup](/multisig-for-protocols/communication-setup) - Backup communication channels
-- [Hardware Wallet Setup](/wallet-security/intermediates-and-medium-funds) - Device replacement procedures
-- [Seed Phrase Management](/wallet-security/seed-phrase-management) - Key recovery procedures
-- [Personal Security (OpSec)](/multisig-for-protocols/personal-security-opsec) - Account security measures
-- [Operational Runbooks](/multisig-for-protocols/runbooks/overview) - Example runbooks for common operations
-
-
 ## Further Reading
 
-- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+- [Incident Reporting](/multisig-for-protocols/incident-reporting): formal incident reporting procedures
+- [Communication Setup](/multisig-for-protocols/communication-setup): backup communication channels
+- [Seed Phrase Management](/wallet-security/seed-phrase-management): key recovery procedures
+- [Operational Runbooks](/multisig-for-protocols/runbooks/overview): step-by-step procedures for pause and rotation
 
 ---
 

--- a/docs/pages/multisig-for-protocols/emergency-procedures.mdx
+++ b/docs/pages/multisig-for-protocols/emergency-procedures.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Multisig Emergency Procedures | SEAL"
-description: "Handle multisig key compromise, lost access, and communication breaches. 30-minute immediate action checklist, identity verification processes, key recovery, and emergency notification templates."
+description: "Handle multisig key compromise, lost access, and communication breaches. 30-minute immediate action checklist, identity verification processes, key recovery"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/multisig-for-protocols/implementation-checklist.mdx
+++ b/docs/pages/multisig-for-protocols/implementation-checklist.mdx
@@ -272,7 +272,7 @@ Additional training required after:
 - New tool adoption
 - Role changes or additional responsibilities
 
-## Related Documents
+### Related Documents
 
 All documents in this framework serve as training materials. Refer to individual documents for detailed procedures and
 requirements specific to your role.

--- a/docs/pages/multisig-for-protocols/implementation-checklist.mdx
+++ b/docs/pages/multisig-for-protocols/implementation-checklist.mdx
@@ -277,6 +277,11 @@ Additional training required after:
 All documents in this framework serve as training materials. Refer to individual documents for detailed procedures and
 requirements specific to your role.
 
+
+## Further Reading
+
+- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/implementation-checklist.mdx
+++ b/docs/pages/multisig-for-protocols/implementation-checklist.mdx
@@ -272,15 +272,15 @@ Additional training required after:
 - New tool adoption
 - Role changes or additional responsibilities
 
-### Related Documents
-
-All documents in this framework serve as training materials. Refer to individual documents for detailed procedures and
-requirements specific to your role.
-
-
 ## Further Reading
 
-- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+All pages in this framework double as training material. Refer to individual pages for procedures specific to your role.
+
+- [Multisig for Protocols overview](/multisig-for-protocols/overview): how the pages of this framework fit together
+- [Key Takeaways](/multisig-for-protocols/key-takeaways): the condensed version to train against
+- [Operational Runbooks](/multisig-for-protocols/runbooks/overview): the procedures signers should rehearse
+- [Secure Multisig Best Practices](/wallet-security/secure-multisig-best-practices): the design rules behind this
+  checklist
 
 ---
 

--- a/docs/pages/multisig-for-protocols/implementation-checklist.mdx
+++ b/docs/pages/multisig-for-protocols/implementation-checklist.mdx
@@ -10,6 +10,8 @@ contributors:
     users: [isaac, geoffrey, louis, pablo, dickson]
   - role: reviewed
     users: [pinalikefruit, engn33r]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../components'
@@ -18,6 +20,9 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Do not go live until admins and every signer can complete the role checklist: plan,
+> hardware, verification skills, emergency drills, and OpSec baseline.
 
 This checklist ensures all multisig participants have the knowledge and skills necessary for secure operations. Complete
 all applicable sections before beginning multisig operations.
@@ -271,5 +276,7 @@ Additional training required after:
 
 All documents in this framework serve as training materials. Refer to individual documents for detailed procedures and
 requirements specific to your role.
+
+---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/implementation-checklist.mdx
+++ b/docs/pages/multisig-for-protocols/implementation-checklist.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Multisig Implementation Checklist | SEAL"
-description: "Verify multisig readiness: administrator planning, signer hardware setup, transaction verification skills, emergency preparedness, personal security (OpSec), and role-specific training requirements."
+description: "Verify multisig readiness: administrator planning, signer hardware setup, transaction verification skills, emergency preparedness, personal security (OpSec)"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/multisig-for-protocols/incident-reporting.mdx
+++ b/docs/pages/multisig-for-protocols/incident-reporting.mdx
@@ -139,10 +139,13 @@ Additional notes:
 [Any other relevant information]
 ```
 
-
 ## Further Reading
 
-- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+- [Multisig for Protocols overview](/multisig-for-protocols/overview): how the pages of this framework fit together
+- [Emergency Procedures](/multisig-for-protocols/emergency-procedures): containment steps that precede a report
+- [Incident Management overview](/incident-management/overview): the wider response process
+- [SEAL 911 War Room Guidelines](/incident-management/playbooks/seal-911-war-room-guidelines): reaching outside help
+  quickly
 
 ---
 

--- a/docs/pages/multisig-for-protocols/incident-reporting.mdx
+++ b/docs/pages/multisig-for-protocols/incident-reporting.mdx
@@ -139,6 +139,11 @@ Additional notes:
 [Any other relevant information]
 ```
 
+
+## Further Reading
+
+- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/incident-reporting.mdx
+++ b/docs/pages/multisig-for-protocols/incident-reporting.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Multisig Incident Reporting | SEAL"
-description: "Report multisig security incidents: key compromise, account takeovers, device theft, and phishing attempts. Templates for urgent security incidents and standard operational issue reports."
+description: "Report multisig security incidents: key compromise, account takeovers, device theft, and phishing attempts. Templates for urgent security incidents and standard"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/multisig-for-protocols/incident-reporting.mdx
+++ b/docs/pages/multisig-for-protocols/incident-reporting.mdx
@@ -10,6 +10,8 @@ contributors:
     users: [isaac, geoffrey, louis, pablo, dickson]
   - role: reviewed
     users: [pinalikefruit, engn33r]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -18,6 +20,12 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Report suspected key compromise and account takeovers immediately; operational tooling
+> failures within 24 hours and with enough detail to act.
+
+Fast, accurate reporting is how a compromised key becomes a rotation instead of a drain.
+Use the definitions and templates below.
 
 ## What to Report
 
@@ -130,5 +138,7 @@ Impact:
 Additional notes:
 [Any other relevant information]
 ```
+
+---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/joining-a-multisig.mdx
+++ b/docs/pages/multisig-for-protocols/joining-a-multisig.mdx
@@ -88,10 +88,14 @@ Note: Enter plain text message (not the hex version MyEtherWallet will give!) an
 Note that "msg" is hex text starting with 0x (add 0x before the hex encoded string if necessary). 4. See whether the
 signature provided is valid.
 
-
 ## Further Reading
 
-- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+- [Multisig for Protocols overview](/multisig-for-protocols/overview): how the pages of this framework fit together
+- [Registration & Documentation](/multisig-for-protocols/registration-and-documentation): the record your signer entry
+  creates
+- [Personal Security (OpSec)](/multisig-for-protocols/personal-security-opsec): the posture expected of every signer
+- [Signing & Verification](/wallet-security/signing-and-verification/signing-verification): what you commit to checking
+  before each signature
 
 ---
 

--- a/docs/pages/multisig-for-protocols/joining-a-multisig.mdx
+++ b/docs/pages/multisig-for-protocols/joining-a-multisig.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Joining a Multisig | Security Alliance"
-description: "Join a multisig securely: create fresh hardware wallet addresses, sign proof of ownership messages via MyCrypto, and verify Ethereum signatures using Etherscan or MyCrypto verification tools."
+description: "Join a multisig securely: create fresh hardware wallet addresses, sign proof of ownership messages via MyCrypto. Join with a dedicated hardware-wallet"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/multisig-for-protocols/joining-a-multisig.mdx
+++ b/docs/pages/multisig-for-protocols/joining-a-multisig.mdx
@@ -10,6 +10,8 @@ contributors:
     users: [isaac, geoffrey, louis, pablo, dickson]
   - role: reviewed
     users: [pinalikefruit, engn33r, ElliotFriedman]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -18,6 +20,12 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Join with a dedicated hardware-wallet address per multisig and prove ownership before
+> you are relied on to sign.
+
+Complete dedicated-key setup and address ownership proof before accepting signer
+responsibility on a protocol multisig.
 
 ## Use a Dedicated Key for Each Multisig
 
@@ -79,5 +87,7 @@ Note: Enter plain text message (not the hex version MyEtherWallet will give!) an
 
 Note that "msg" is hex text starting with 0x (add 0x before the hex encoded string if necessary). 4. See whether the
 signature provided is valid.
+
+---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/joining-a-multisig.mdx
+++ b/docs/pages/multisig-for-protocols/joining-a-multisig.mdx
@@ -88,6 +88,11 @@ Note: Enter plain text message (not the hex version MyEtherWallet will give!) an
 Note that "msg" is hex text starting with 0x (add 0x before the hex encoded string if necessary). 4. See whether the
 signature provided is valid.
 
+
+## Further Reading
+
+- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/key-takeaways.mdx
+++ b/docs/pages/multisig-for-protocols/key-takeaways.mdx
@@ -89,21 +89,21 @@ Always use a verified
 explorer transaction history, Etherscan, or chat messages. For first-time recipients, perform a bidirectional test
 transaction. For high-value transfers, verify addresses character-by-character on a video call.
 
-### 8. Watch for Permissionless Safe Additions
+## 8. Watch for Permissionless Safe Additions
 
 Anyone can create a Safe and add you as an owner without your consent, making it appear in your Safe app. Attackers
 create Safes with addresses matching the first 4 and last 4 characters of your real Safes. Always verify the full
 address and navigate from bookmarks, not the dashboard. See
 [Address Poisoning](/wallet-security/secure-multisig-best-practices#address-poisoning-and-permissionless-safe-additions).
 
-### 9. Verify Calldata, Not Just Hashes
+## 9. Verify Calldata, Not Just Hashes
 
 Hash verification confirms you are signing the intended transaction, but it does not tell you what the transaction does.
 Always [decode the calldata](/wallet-security/signing-and-verification/secure-multisig-safe-verification#5-calldata-review)
 and verify the function, target, and parameters match what was described. Watch for red flags like unexpected
 `DELEGATECALL`, `approve` calls, or hidden batch operations.
 
-### 10. Use Delegated Proposers and Non-Signer Execution
+## 10. Use Delegated Proposers and Non-Signer Execution
 
 Set up a [delegated proposer](/multisig-for-protocols/setup-and-configuration#delegated-proposer) for Safe multisigs.
 Hash verification tools rely on the Safe API, which only has data after a transaction is proposed. Without a delegated
@@ -112,7 +112,7 @@ proposer, the first signer faces additional challenges to verify what they are s
 action. Instead, have all signers sign only, then have a non-signer execute the
 fully-signed transaction.
 
-### 11. Hardware Wallets, Backup Infrastructure, and Drills
+## 11. Hardware Wallets, Backup Infrastructure, and Drills
 
 All signers must use hardware wallets. Maintain
 [backup signing infrastructure](/multisig-for-protocols/backup-signing-and-infrastructure) (Eternal Safe, Squads Public
@@ -126,10 +126,13 @@ For the full framework, see the [Multisig Security Framework Overview](/multisig
 
 </TagProvider>
 
-
 ## Further Reading
 
-- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+- [Multisig for Protocols overview](/multisig-for-protocols/overview): how the pages of this framework fit together
+- [Implementation Checklist](/multisig-for-protocols/implementation-checklist): turning these takeaways into tracked
+  work
+- [Operational Runbooks](/multisig-for-protocols/runbooks/overview): the procedures behind the takeaways
+- [Secure Multisig Best Practices](/wallet-security/secure-multisig-best-practices): the detailed design rules
 
 ---
 

--- a/docs/pages/multisig-for-protocols/key-takeaways.mdx
+++ b/docs/pages/multisig-for-protocols/key-takeaways.mdx
@@ -89,21 +89,21 @@ Always use a verified
 explorer transaction history, Etherscan, or chat messages. For first-time recipients, perform a bidirectional test
 transaction. For high-value transfers, verify addresses character-by-character on a video call.
 
-## 8. Watch for Permissionless Safe Additions
+### 8. Watch for Permissionless Safe Additions
 
 Anyone can create a Safe and add you as an owner without your consent, making it appear in your Safe app. Attackers
 create Safes with addresses matching the first 4 and last 4 characters of your real Safes. Always verify the full
 address and navigate from bookmarks, not the dashboard. See
 [Address Poisoning](/wallet-security/secure-multisig-best-practices#address-poisoning-and-permissionless-safe-additions).
 
-## 9. Verify Calldata, Not Just Hashes
+### 9. Verify Calldata, Not Just Hashes
 
 Hash verification confirms you are signing the intended transaction, but it does not tell you what the transaction does.
 Always [decode the calldata](/wallet-security/signing-and-verification/secure-multisig-safe-verification#5-calldata-review)
 and verify the function, target, and parameters match what was described. Watch for red flags like unexpected
 `DELEGATECALL`, `approve` calls, or hidden batch operations.
 
-## 10. Use Delegated Proposers and Non-Signer Execution
+### 10. Use Delegated Proposers and Non-Signer Execution
 
 Set up a [delegated proposer](/multisig-for-protocols/setup-and-configuration#delegated-proposer) for Safe multisigs.
 Hash verification tools rely on the Safe API, which only has data after a transaction is proposed. Without a delegated
@@ -112,7 +112,7 @@ proposer, the first signer faces additional challenges to verify what they are s
 action. Instead, have all signers sign only, then have a non-signer execute the
 fully-signed transaction.
 
-## 11. Hardware Wallets, Backup Infrastructure, and Drills
+### 11. Hardware Wallets, Backup Infrastructure, and Drills
 
 All signers must use hardware wallets. Maintain
 [backup signing infrastructure](/multisig-for-protocols/backup-signing-and-infrastructure) (Eternal Safe, Squads Public

--- a/docs/pages/multisig-for-protocols/key-takeaways.mdx
+++ b/docs/pages/multisig-for-protocols/key-takeaways.mdx
@@ -11,6 +11,8 @@ contributors:
     users: [isaac]
   - role: reviewed
     users: [ElliotFriedman]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, TagProvider, TagFilter, ContributeFooter } from '../../../components'
@@ -22,6 +24,9 @@ import { TagList, AttributionList, TagProvider, TagFilter, ContributeFooter } fr
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: If you only read one multisig page, read this one: timelocks, function separation,
+> dedicated keys, calldata verification, and monitored queues beat unenforced policy.
 
 If you read one page from the Multisig Security Framework, make it this one. These are the principles that matter most.
 
@@ -120,4 +125,7 @@ that communication channels work. See the
 For the full framework, see the [Multisig Security Framework Overview](/multisig-for-protocols/overview).
 
 </TagProvider>
+
+---
+
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/key-takeaways.mdx
+++ b/docs/pages/multisig-for-protocols/key-takeaways.mdx
@@ -15,10 +15,7 @@ contributors:
     users: []
 ---
 
-import { TagList, AttributionList, TagProvider, TagFilter, ContributeFooter } from '../../../components'
-
-<TagProvider>
-<TagFilter />
+import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 # Key Takeaways
 
@@ -119,12 +116,6 @@ All signers must use hardware wallets. Maintain
 Client) in case primary UIs go down. Run regular emergency drills to verify that signers can respond under pressure and
 that communication channels work. See the
 [Implementation Checklist](/multisig-for-protocols/implementation-checklist).
-
----
-
-For the full framework, see the [Multisig Security Framework Overview](/multisig-for-protocols/overview).
-
-</TagProvider>
 
 ## Further Reading
 

--- a/docs/pages/multisig-for-protocols/key-takeaways.mdx
+++ b/docs/pages/multisig-for-protocols/key-takeaways.mdx
@@ -126,6 +126,11 @@ For the full framework, see the [Multisig Security Framework Overview](/multisig
 
 </TagProvider>
 
+
+## Further Reading
+
+- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/offboarding.mdx
+++ b/docs/pages/multisig-for-protocols/offboarding.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Multisig Offboarding | Security Alliance"
-description: "Safely leave a multisig role: coordinate signer removal with the team, execute removal transaction, leave communication channels, delete locally stored sensitive information, and complete handover."
+description: "Safely leave a multisig role: coordinate signer removal with the team, execute removal transaction, leave communication channels"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/multisig-for-protocols/offboarding.mdx
+++ b/docs/pages/multisig-for-protocols/offboarding.mdx
@@ -10,6 +10,8 @@ contributors:
     users: [isaac, geoffrey, louis, pablo, dickson]
   - role: reviewed
     users: [pinalikefruit, engn33r, mattaereal]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -19,7 +21,13 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
+> 🔑 **Key Takeaway**: Leaving a multisig is not logout: coordinate rotation, confirm on-chain removal, and
+> wipe local signing state so residual access cannot linger.
+
 When leaving a multisig, follow these steps:
+
+Coordinate removal so residual access cannot survive a role change. Follow the sequence
+below end to end.
 
 ## Signer removal
 
@@ -50,5 +58,7 @@ policy and make sure it is understood by all signers. For example:
 
 - Share any relevant context or pending items with remaining signers
 - Provide contact information if needed for transition questions
+
+---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/offboarding.mdx
+++ b/docs/pages/multisig-for-protocols/offboarding.mdx
@@ -59,10 +59,12 @@ policy and make sure it is understood by all signers. For example:
 - Share any relevant context or pending items with remaining signers
 - Provide contact information if needed for transition questions
 
-
 ## Further Reading
 
-- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+- [Multisig for Protocols overview](/multisig-for-protocols/overview): how the pages of this framework fit together
+- [Signer Rotation Runbook](/multisig-for-protocols/runbooks/signer-rotation): the on-chain procedure for removal
+- [Joining a Multisig](/multisig-for-protocols/joining-a-multisig): the onboarding steps being reversed here
+- [Access Management](/iam/access-management): revoking the wider access that came with the role
 
 ---
 

--- a/docs/pages/multisig-for-protocols/offboarding.mdx
+++ b/docs/pages/multisig-for-protocols/offboarding.mdx
@@ -59,6 +59,11 @@ policy and make sure it is understood by all signers. For example:
 - Share any relevant context or pending items with remaining signers
 - Provide contact information if needed for transition questions
 
+
+## Further Reading
+
+- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/overview.mdx
+++ b/docs/pages/multisig-for-protocols/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Multisig Security Framework | SEAL"
-description: "Multisig Security Framework: Complete guide for setup, signer onboarding, hardware wallet requirements, transaction verification, and emergency procedures."
+description: "Multisig security for protocols: plan and classify risk, configure Safe/Squads, onboard signers, run operational runbooks, and prepare emergency and backup signing paths."
 tags:
   - Engineer/Developer
   - Security Specialist
@@ -10,6 +10,8 @@ contributors:
     users: [isaac, geoffrey, louis, pablo, dickson]
   - role: reviewed
     users: [pinalikefruit, engn33r]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -19,62 +21,104 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-## How to use this guide
+> 🔑 **Key Takeaway**: Protocol multisigs fail operationally more often than cryptographically. Separate functions, match
+> thresholds to blast radius, verify calldata—not just hashes—and drill emergency and backup paths.
 
-**Short on time?** Start with [Key Takeaways](/multisig-for-protocols/key-takeaways) for the most important points
-on one page.
+This framework covers how protocols and product teams design, deploy, operate, and exit multi-signature control of
+privileged actions: upgrades, parameters, treasury, and emergency pause. Wallet construction and seed hygiene live
+primarily in [Wallet Security](/wallet-security/overview); this family focuses on protocol multisig administration and
+signer operations.
 
-**Quick start**: New to multisigs? Start with the Foundation for the essentials, then jump to your role:
-
-- Setting up a new multisig? → Multisig Administration: [Setup &
-  Configuration](/multisig-for-protocols/setup-and-configuration) and [Registration &
-  Documentation](/multisig-for-protocols/registration-and-documentation)
-- Joining as a signer? → [Joining a Multisig](/multisig-for-protocols/joining-a-multisig) and [Hardware Wallet Setup](/wallet-security/intermediates-and-medium-funds)
-- Need to sign a transaction? → Signing & Verification:
-[Safe Multisig](/wallet-security/signing-and-verification/secure-multisig-safe-verification) and
-[Squads](/wallet-security/signing-and-verification/secure-multisig-squads-verification), plus
-[Operational Runbooks](/multisig-for-protocols/runbooks/overview)
-- Emergency situation? → [Emergency Procedures](/multisig-for-protocols/emergency-procedures)
+**Short on time?** Read [Key Takeaways](/multisig-for-protocols/key-takeaways) first.
 
 ## Core principles
 
-- **Security first**: Every multisig must meet [minimum security standards](/wallet-security/secure-multisig-best-practices)
-- **Built-in slowness**: Timelocks and review windows are intentional security mechanisms, not obstacles to work around
-- **Constrained emergency powers**: Emergency bypass mechanisms should do the minimum necessary and nothing more
+- **Security first**: Meet [minimum multisig standards](/wallet-security/secure-multisig-best-practices)
+- **Built-in slowness**: Timelocks and review windows are intentional controls, not friction to bypass
+- **Constrained emergency powers**: Bypass paths should do the minimum necessary and nothing more
 - **Operational readiness**: Procedures that work under pressure
-- **Clear accountability**: Everyone knows their role and responsibilities
-- **Emergency preparedness**: Plans for when things go wrong
+- **Clear accountability**: Defined roles for proposers, signers, and executors
+- **Emergency preparedness**: Documented loss-of-key and channel-compromise paths
 
-## Framework Structure
+## How to use this guide
 
-### 1. Foundation
+- **New multisig setup**: [Planning & Classification](/multisig-for-protocols/planning-and-classification) →
+  [Setup & Configuration](/multisig-for-protocols/setup-and-configuration) →
+  [Registration](/multisig-for-protocols/registration-and-documentation)
+- **Joining as a signer**: [Joining a Multisig](/multisig-for-protocols/joining-a-multisig) and
+  [Hardware Wallet Setup](/wallet-security/intermediates-and-medium-funds)
+- **Signing a transaction**:
+  [Safe verification](/wallet-security/signing-and-verification/secure-multisig-safe-verification),
+  [Squads verification](/wallet-security/signing-and-verification/secure-multisig-squads-verification),
+  [Runbooks](/multisig-for-protocols/runbooks/overview)
+- **Emergency**: [Emergency Procedures](/multisig-for-protocols/emergency-procedures)
+- **Readiness check**: [Implementation Checklist](/multisig-for-protocols/implementation-checklist)
 
-- [Secure Multisig Best Practices](/wallet-security/secure-multisig-best-practices) - Core requirements for all multisigs
+## What this framework covers
 
-### 2. Multisig Administration
+### Foundation
 
-- [Planning & Classification](/multisig-for-protocols/planning-and-classification) - Assess requirements and classify risk
-- [Setup & Configuration](/multisig-for-protocols/setup-and-configuration) - Deploy and configure multisigs
-- [Registration & Documentation](/multisig-for-protocols/registration-and-documentation) - Document and verify setup
-- [Communication Setup](/multisig-for-protocols/communication-setup) - Establish secure communication channels
-- [Use Case Specific Requirements](/multisig-for-protocols/use-case-specific-requirements) - Special requirements by type
-- [Operational Runbooks](/multisig-for-protocols/runbooks/overview) - Example procedures for common operations
+1. [Key Takeaways](/multisig-for-protocols/key-takeaways): highest-leverage principles on one page
+2. [Secure Multisig Best Practices](/wallet-security/secure-multisig-best-practices): core requirements (Wallet
+   Security)
 
-### 3. For Signers
+### Multisig administration
 
-- [Hardware Wallet Setup](/wallet-security/intermediates-and-medium-funds) - Secure device configuration
-- [Seed Phrase Management](/wallet-security/seed-phrase-management) - Protect your recovery keys
-- [Joining a Multisig](/multisig-for-protocols/joining-a-multisig) - Verification and onboarding process
+1. [Planning & Classification](/multisig-for-protocols/planning-and-classification): impact assessment and thresholds
+2. [Setup & Configuration](/multisig-for-protocols/setup-and-configuration): deploy and configure on supported networks
+3. [Registration & Documentation](/multisig-for-protocols/registration-and-documentation): inventory and audit trail
+4. [Communication Setup](/multisig-for-protocols/communication-setup): primary, backup, and paging channels
+5. [Use Case Specific Requirements](/multisig-for-protocols/use-case-specific-requirements): separation, timelocks,
+   treasury patterns
+6. [Operational Runbooks](/multisig-for-protocols/runbooks/overview): token transfer, signer rotation, threshold
+   change, emergency pause
+
+### For signers
+
+1. [Joining a Multisig](/multisig-for-protocols/joining-a-multisig): dedicated keys and proof of ownership
+2. [Emergency Procedures](/multisig-for-protocols/emergency-procedures): compromise and lost-access response
+3. [Backup Signing & Infrastructure](/multisig-for-protocols/backup-signing-and-infrastructure): alternate UIs when
+   primary fails
+4. [Personal Security (OpSec)](/multisig-for-protocols/personal-security-opsec): accounts, devices, travel
+5. [Incident Reporting](/multisig-for-protocols/incident-reporting): what and how to report
+6. [Offboarding](/multisig-for-protocols/offboarding): leave a signer role cleanly
+
+Related signer hardware and verification (Wallet Security):
+
+- [Hardware Wallet Setup](/wallet-security/intermediates-and-medium-funds)
+- [Seed Phrase Management](/wallet-security/seed-phrase-management)
 - [Safe Multisig: Step-by-Step
-Verification](/wallet-security/signing-and-verification/secure-multisig-safe-verification) - Safely verify and sign transactions
-- [Emergency Procedures](/multisig-for-protocols/emergency-procedures) - Handle key compromise and emergencies
-- [Backup Signing & Infrastructure](/multisig-for-protocols/backup-signing-and-infrastructure) - Use backup interfaces
-- [Personal Security (OpSec)](/multisig-for-protocols/personal-security-opsec) - Protect your accounts and devices
-- [Incident Reporting](/multisig-for-protocols/incident-reporting) - Report security issues and incidents
-- [Offboarding](/multisig-for-protocols/offboarding) - Safely leave a multisig role
+  Verification](/wallet-security/signing-and-verification/secure-multisig-safe-verification)
+- [Squads Multisig: Step-by-Step
+  Verification](/wallet-security/signing-and-verification/secure-multisig-squads-verification)
 
-### 4. Reference
+### Reference
 
-- [Implementation Checklist](/multisig-for-protocols/implementation-checklist) - Verify readiness for multisig operations
+1. [Implementation Checklist](/multisig-for-protocols/implementation-checklist): administrator and signer readiness
+
+### Runbooks subsection
+
+1. [Runbooks overview](/multisig-for-protocols/runbooks/overview)
+2. [Token Transfer](/multisig-for-protocols/runbooks/token-transfer)
+3. [Signer Rotation](/multisig-for-protocols/runbooks/signer-rotation)
+4. [Threshold Change](/multisig-for-protocols/runbooks/threshold-change)
+5. [Emergency Pause](/multisig-for-protocols/runbooks/emergency-pause)
+
+## Related frameworks
+
+- [Wallet Security](/wallet-security/overview): device setup, best practices, signing verification
+- [Treasury Operations](/treasury-operations/overview): custodial large-transfer ceremonies
+- [Incident Management](/incident-management/overview): broader IR beyond multisig-specific paths
+- [OpSec](/opsec/overview): personnel and physical security depth
+- [Governance](/governance/overview): governance process context for admin powers
+- [SEAL 911 Cert — Multisig Operations](/certs/sfc-multisig-ops): certification surface
+
+## Further reading
+
+- Condensed principles on [Key Takeaways](/multisig-for-protocols/key-takeaways)
+- [Secure Multisig Best Practices](/wallet-security/secure-multisig-best-practices)
+- Platform docs for Safe and Squads used by your stack
+
+---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/personal-security-opsec.mdx
+++ b/docs/pages/multisig-for-protocols/personal-security-opsec.mdx
@@ -10,6 +10,8 @@ contributors:
     users: [isaac, geoffrey, louis, pablo, dickson, auditware]
   - role: reviewed
     users: [pinalikefruit, engn33r]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -18,6 +20,12 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Signer OpSec is part of the quorum: phishing, SIM-swap, and device theft bypass
+> cryptography faster than rogue co-signers.
+
+Personal account and device security is part of the multisig trust model. The guidance
+below covers baseline and elevated OpSec for signers.
 
 ## Account Security
 
@@ -197,5 +205,7 @@ Remember: Perfect security doesn't exist - focus on practical improvements that 
 remaining operationally feasible.
 
 For the full OpSec article, see [Operational Security](/opsec/overview).
+
+---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/personal-security-opsec.mdx
+++ b/docs/pages/multisig-for-protocols/personal-security-opsec.mdx
@@ -206,6 +206,11 @@ remaining operationally feasible.
 
 For the full OpSec article, see [Operational Security](/opsec/overview).
 
+
+## Further Reading
+
+- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/personal-security-opsec.mdx
+++ b/docs/pages/multisig-for-protocols/personal-security-opsec.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Multisig Personal Security (OpSec) | SEAL"
-description: "Protect multisig signers with personal OpSec: YubiKey 2FA, password managers, cold backup accounts, full disk encryption, Signal safety number verification, and travel security procedures."
+description: "Protect multisig signers with personal OpSec: YubiKey 2FA, password managers, cold backup accounts, full disk encryption, Signal safety number verification"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/multisig-for-protocols/personal-security-opsec.mdx
+++ b/docs/pages/multisig-for-protocols/personal-security-opsec.mdx
@@ -206,10 +206,12 @@ remaining operationally feasible.
 
 For the full OpSec article, see [Operational Security](/opsec/overview).
 
-
 ## Further Reading
 
-- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+- [Multisig for Protocols overview](/multisig-for-protocols/overview): how the pages of this framework fit together
+- [Joining a Multisig](/multisig-for-protocols/joining-a-multisig): the posture expected before you become a signer
+- [Seed Phrase Management](/wallet-security/seed-phrase-management): protecting the key material behind your signature
+- [OpSec overview](/opsec/overview): the wider operator hygiene this page draws on
 
 ---
 

--- a/docs/pages/multisig-for-protocols/planning-and-classification.mdx
+++ b/docs/pages/multisig-for-protocols/planning-and-classification.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Multisig Planning & Classification | SEAL"
-description: "Plan multisig setup: assess financial exposure, protocol impact, and reputational risk. Classify by impact level (Low to Critical) and operational type (Routine, Time-Sensitive, Emergency)."
+description: "Plan multisig setup: assess financial exposure, protocol impact, and reputational risk. Classify by impact level (Low to Critical) and operational type"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/multisig-for-protocols/planning-and-classification.mdx
+++ b/docs/pages/multisig-for-protocols/planning-and-classification.mdx
@@ -178,6 +178,11 @@ After completing classification, proceed to:
 1. [Setup & Configuration](/multisig-for-protocols/setup-and-configuration) - Deploy your multisig
 2. [Registration & Documentation](/multisig-for-protocols/registration-and-documentation) - Document your setup
 
+
+## Further Reading
+
+- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/planning-and-classification.mdx
+++ b/docs/pages/multisig-for-protocols/planning-and-classification.mdx
@@ -178,10 +178,13 @@ After completing classification, proceed to:
 1. [Setup & Configuration](/multisig-for-protocols/setup-and-configuration) - Deploy your multisig
 2. [Registration & Documentation](/multisig-for-protocols/registration-and-documentation) - Document your setup
 
-
 ## Further Reading
 
-- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+- [Multisig for Protocols overview](/multisig-for-protocols/overview): how the pages of this framework fit together
+- [Setup and Configuration](/multisig-for-protocols/setup-and-configuration): applying the classification to real settings
+- [Use-Case Specific Requirements](/multisig-for-protocols/use-case-specific-requirements): per-function rules once
+  classified
+- [Registration and Documentation](/multisig-for-protocols/registration-and-documentation): recording the result
 
 ---
 

--- a/docs/pages/multisig-for-protocols/planning-and-classification.mdx
+++ b/docs/pages/multisig-for-protocols/planning-and-classification.mdx
@@ -10,6 +10,8 @@ contributors:
     users: [isaac, geoffrey, louis, pablo, dickson]
   - role: reviewed
     users: [pinalikefruit, engn33r]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from "../../../components"
@@ -18,6 +20,9 @@ import { TagList, AttributionList, ContributeFooter } from "../../../components"
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Classify impact and access urgency before choosing thresholds, signers, and modules.
+> Wrong sizing is a design defect, not a tooling problem.
 
 Before setting up a new multisig, take time to properly assess its role and requirements. This planning phase will guide
 all subsequent configuration decisions and help ensure appropriate security measures.
@@ -172,5 +177,7 @@ After completing classification, proceed to:
 
 1. [Setup & Configuration](/multisig-for-protocols/setup-and-configuration) - Deploy your multisig
 2. [Registration & Documentation](/multisig-for-protocols/registration-and-documentation) - Document your setup
+
+---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/registration-and-documentation.mdx
+++ b/docs/pages/multisig-for-protocols/registration-and-documentation.mdx
@@ -10,6 +10,8 @@ contributors:
     users: [isaac, geoffrey, louis, pablo, dickson]
   - role: reviewed
     users: [pinalikefruit, engn33r]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -18,6 +20,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Write down who can do what, which address holds which role, and keep the inventory
+> matched to on-chain state after every change.
 
 Proper documentation is essential for multisig security and accountability. This page covers the registration process
 and required documentation.
@@ -384,5 +389,7 @@ Use the template in [Registration & Documentation → Update Template](/multisig
 - [Planning & Classification](/multisig-for-protocols/planning-and-classification) - How to classify your multisig
 - [Joining a Multisig](/multisig-for-protocols/joining-a-multisig) - Signer verification process
 - [Operational Runbooks](/multisig-for-protocols/runbooks/overview) - Example procedures for common operations
+
+---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/registration-and-documentation.mdx
+++ b/docs/pages/multisig-for-protocols/registration-and-documentation.mdx
@@ -384,16 +384,12 @@ After any signer change:
 
 Use the template in [Registration & Documentation → Update Template](/multisig-for-protocols/registration-and-documentation#update-template).
 
-### Related Documents
-
-- [Planning & Classification](/multisig-for-protocols/planning-and-classification) - How to classify your multisig
-- [Joining a Multisig](/multisig-for-protocols/joining-a-multisig) - Signer verification process
-- [Operational Runbooks](/multisig-for-protocols/runbooks/overview) - Example procedures for common operations
-
-
 ## Further Reading
 
-- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+- [Multisig for Protocols overview](/multisig-for-protocols/overview): how the pages of this framework fit together
+- [Planning and Classification](/multisig-for-protocols/planning-and-classification): how to classify your multisig
+- [Joining a Multisig](/multisig-for-protocols/joining-a-multisig): the signer verification process
+- [Operational Runbooks](/multisig-for-protocols/runbooks/overview): procedures whose changes must be recorded here
 
 ---
 

--- a/docs/pages/multisig-for-protocols/registration-and-documentation.mdx
+++ b/docs/pages/multisig-for-protocols/registration-and-documentation.mdx
@@ -390,6 +390,11 @@ Use the template in [Registration & Documentation → Update Template](/multisig
 - [Joining a Multisig](/multisig-for-protocols/joining-a-multisig) - Signer verification process
 - [Operational Runbooks](/multisig-for-protocols/runbooks/overview) - Example procedures for common operations
 
+
+## Further Reading
+
+- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/registration-and-documentation.mdx
+++ b/docs/pages/multisig-for-protocols/registration-and-documentation.mdx
@@ -384,7 +384,7 @@ After any signer change:
 
 Use the template in [Registration & Documentation → Update Template](/multisig-for-protocols/registration-and-documentation#update-template).
 
-## Related Documents
+### Related Documents
 
 - [Planning & Classification](/multisig-for-protocols/planning-and-classification) - How to classify your multisig
 - [Joining a Multisig](/multisig-for-protocols/joining-a-multisig) - Signer verification process

--- a/docs/pages/multisig-for-protocols/runbooks/emergency-pause.mdx
+++ b/docs/pages/multisig-for-protocols/runbooks/emergency-pause.mdx
@@ -165,7 +165,7 @@ Use backup infrastructure:
 
 See [Backup Signing & Infrastructure](/multisig-for-protocols/backup-signing-and-infrastructure) for detailed instructions.
 
-## Escalation
+### Escalation
 
 If threshold cannot be reached within SLA:
 
@@ -176,7 +176,7 @@ If threshold cannot be reached within SLA:
 
 **Emergency contacts**: See your configured emergency contact list.
 
-## Related Documents
+### Related Documents
 
 - [Emergency Procedures](/multisig-for-protocols/emergency-procedures)
 - [Backup Signing & Infrastructure](/multisig-for-protocols/backup-signing-and-infrastructure)

--- a/docs/pages/multisig-for-protocols/runbooks/emergency-pause.mdx
+++ b/docs/pages/multisig-for-protocols/runbooks/emergency-pause.mdx
@@ -8,6 +8,8 @@ tags:
 contributors:
   - role: wrote
     users: [isaac, geoffrey, louis, pablo, dickson]
+  - role: reviewed
+    users: []
   - role: fact-checked
     users: []
 ---
@@ -176,17 +178,13 @@ If threshold cannot be reached within SLA:
 
 **Emergency contacts**: See your configured emergency contact list.
 
-### Related Documents
-
-- [Emergency Procedures](/multisig-for-protocols/emergency-procedures)
-- [Backup Signing & Infrastructure](/multisig-for-protocols/backup-signing-and-infrastructure)
-- [Incident Reporting](/multisig-for-protocols/incident-reporting)
-- [Operational Runbooks](/multisig-for-protocols/runbooks/overview)
-
-
 ## Further Reading
 
-- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+- [Operational Runbooks](/multisig-for-protocols/runbooks/overview): how the runbooks in this section fit together
+- [Emergency Procedures](/multisig-for-protocols/emergency-procedures): the wider response this pause is part of
+- [Backup Signing & Infrastructure](/multisig-for-protocols/backup-signing-and-infrastructure): signing paths when the
+  primary interface is down
+- [Incident Reporting](/multisig-for-protocols/incident-reporting): formal reporting once the pause is in place
 
 ---
 

--- a/docs/pages/multisig-for-protocols/runbooks/emergency-pause.mdx
+++ b/docs/pages/multisig-for-protocols/runbooks/emergency-pause.mdx
@@ -8,6 +8,8 @@ tags:
 contributors:
   - role: wrote
     users: [isaac, geoffrey, louis, pablo, dickson]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../components'
@@ -16,6 +18,9 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Pause runbooks trade review time for speed: constrain what emergency paths can do and
+> use pre-tested backup UIs when minutes matter.
 
 This is an example runbook. Review and customize it for your protocol before use. Add your specific contract
 addresses, pause functions, emergency contacts, and communication channels.
@@ -177,5 +182,7 @@ If threshold cannot be reached within SLA:
 - [Backup Signing & Infrastructure](/multisig-for-protocols/backup-signing-and-infrastructure)
 - [Incident Reporting](/multisig-for-protocols/incident-reporting)
 - [Operational Runbooks](/multisig-for-protocols/runbooks/overview)
+
+---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/runbooks/emergency-pause.mdx
+++ b/docs/pages/multisig-for-protocols/runbooks/emergency-pause.mdx
@@ -183,6 +183,11 @@ If threshold cannot be reached within SLA:
 - [Incident Reporting](/multisig-for-protocols/incident-reporting)
 - [Operational Runbooks](/multisig-for-protocols/runbooks/overview)
 
+
+## Further Reading
+
+- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/runbooks/emergency-pause.mdx
+++ b/docs/pages/multisig-for-protocols/runbooks/emergency-pause.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Emergency Pause Runbook | SEAL"
-description: "Runbook for emergency multisig pause transactions, including alerting, streamlined verification, backup interfaces, and post-pause actions."
+description: "Runbook for emergency multisig pause transactions, including alerting, streamlined verification, backup interfaces, and post-pause actions. This is an example"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/multisig-for-protocols/runbooks/overview.mdx
+++ b/docs/pages/multisig-for-protocols/runbooks/overview.mdx
@@ -43,6 +43,11 @@ These are example runbooks for common multisig operations. Review and customize 
 - [Backup Signing & Infrastructure](/multisig-for-protocols/backup-signing-and-infrastructure) - Use backup interfaces
   when primary systems are unavailable
 
+
+## Further Reading
+
+- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/runbooks/overview.mdx
+++ b/docs/pages/multisig-for-protocols/runbooks/overview.mdx
@@ -8,6 +8,8 @@ tags:
 contributors:
   - role: wrote
     users: [isaac, geoffrey, louis, pablo, dickson]
+  - role: reviewed
+    users: []
   - role: fact-checked
     users: []
 ---
@@ -35,18 +37,14 @@ These are example runbooks for common multisig operations. Review and customize 
 - [Emergency Pause Runbook](/multisig-for-protocols/runbooks/emergency-pause) - Execute urgent pause transactions with
   streamlined verification and backup infrastructure.
 
-## Related Documents
-
-- [Registration & Documentation](/multisig-for-protocols/registration-and-documentation) - Record changes and maintain
-  audit trails
-- [Emergency Procedures](/multisig-for-protocols/emergency-procedures) - Coordinate incidents and recovery actions
-- [Backup Signing & Infrastructure](/multisig-for-protocols/backup-signing-and-infrastructure) - Use backup interfaces
-  when primary systems are unavailable
-
-
 ## Further Reading
 
-- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+- [Multisig for Protocols overview](/multisig-for-protocols/overview): how the pages of this framework fit together
+- [Registration & Documentation](/multisig-for-protocols/registration-and-documentation): record changes and maintain
+  audit trails
+- [Emergency Procedures](/multisig-for-protocols/emergency-procedures): coordinate incidents and recovery actions
+- [Backup Signing & Infrastructure](/multisig-for-protocols/backup-signing-and-infrastructure): use backup interfaces
+  when primary systems are unavailable
 
 ---
 

--- a/docs/pages/multisig-for-protocols/runbooks/overview.mdx
+++ b/docs/pages/multisig-for-protocols/runbooks/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Multisig Operational Runbooks | SEAL"
-description: "Operational runbooks for common multisig actions, including token transfers, threshold changes, and emergency pause transactions."
+description: "Operational runbooks for common multisig actions, including token transfers, threshold changes, and emergency pause transactions. Treat these runbooks as"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/multisig-for-protocols/runbooks/overview.mdx
+++ b/docs/pages/multisig-for-protocols/runbooks/overview.mdx
@@ -8,6 +8,8 @@ tags:
 contributors:
   - role: wrote
     users: [isaac, geoffrey, louis, pablo, dickson]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
@@ -16,6 +18,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Treat these runbooks as templates. Customize addresses, channels, and policy before the
+> first production operation.
 
 These are example runbooks for common multisig operations. Review and customize them for your protocol before use.
 
@@ -37,5 +42,7 @@ These are example runbooks for common multisig operations. Review and customize 
 - [Emergency Procedures](/multisig-for-protocols/emergency-procedures) - Coordinate incidents and recovery actions
 - [Backup Signing & Infrastructure](/multisig-for-protocols/backup-signing-and-infrastructure) - Use backup interfaces
   when primary systems are unavailable
+
+---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/runbooks/overview.mdx
+++ b/docs/pages/multisig-for-protocols/runbooks/overview.mdx
@@ -24,7 +24,7 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 
 These are example runbooks for common multisig operations. Review and customize them for your protocol before use.
 
-## Available Runbooks
+## What this framework covers
 
 - [Token Transfer Runbook](/multisig-for-protocols/runbooks/token-transfer) - Send tokens from a multisig to another
   address using standard verification and execution steps.

--- a/docs/pages/multisig-for-protocols/runbooks/signer-rotation.mdx
+++ b/docs/pages/multisig-for-protocols/runbooks/signer-rotation.mdx
@@ -8,6 +8,8 @@ tags:
 contributors:
   - role: wrote
     users: [isaac, geoffrey, louis, pablo, dickson]
+  - role: reviewed
+    users: []
   - role: fact-checked
     users: []
 ---
@@ -150,7 +152,7 @@ Can combine add and remove in a single transaction:
 
 **Benefits**: Atomic operation, no intermediate state with wrong threshold.
 
-### Post-Transaction
+## Post-Transaction
 
 After execution:
 
@@ -161,7 +163,7 @@ After execution:
 - [ ] Test that the new signer can successfully sign a test transaction
 </Checklist>
 
-### Offboarding Checklist
+## Offboarding Checklist
 
 When removing a signer:
 
@@ -179,17 +181,13 @@ When removing a signer:
 - Critical-class: 7 days
 - Others: 14 days
 
-### Related Documents
-
-- [Joining a Multisig](/multisig-for-protocols/joining-a-multisig)
-- [Threshold Change Runbook](/multisig-for-protocols/runbooks/threshold-change)
-- [Offboarding](/multisig-for-protocols/offboarding)
-- [Operational Runbooks](/multisig-for-protocols/runbooks/overview)
-
-
 ## Further Reading
 
-- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+- [Operational Runbooks](/multisig-for-protocols/runbooks/overview): how the runbooks in this section fit together
+- [Joining a Multisig](/multisig-for-protocols/joining-a-multisig): verification steps for the incoming signer
+- [Offboarding](/multisig-for-protocols/offboarding): revoking the outgoing signer's wider access
+- [Threshold Change Runbook](/multisig-for-protocols/runbooks/threshold-change): the companion procedure when the
+  threshold moves too
 
 ---
 

--- a/docs/pages/multisig-for-protocols/runbooks/signer-rotation.mdx
+++ b/docs/pages/multisig-for-protocols/runbooks/signer-rotation.mdx
@@ -186,6 +186,11 @@ When removing a signer:
 - [Offboarding](/multisig-for-protocols/offboarding)
 - [Operational Runbooks](/multisig-for-protocols/runbooks/overview)
 
+
+## Further Reading
+
+- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/runbooks/signer-rotation.mdx
+++ b/docs/pages/multisig-for-protocols/runbooks/signer-rotation.mdx
@@ -150,7 +150,7 @@ Can combine add and remove in a single transaction:
 
 **Benefits**: Atomic operation, no intermediate state with wrong threshold.
 
-## Post-Transaction
+### Post-Transaction
 
 After execution:
 
@@ -161,7 +161,7 @@ After execution:
 - [ ] Test that the new signer can successfully sign a test transaction
 </Checklist>
 
-## Offboarding Checklist
+### Offboarding Checklist
 
 When removing a signer:
 
@@ -179,7 +179,7 @@ When removing a signer:
 - Critical-class: 7 days
 - Others: 14 days
 
-## Related Documents
+### Related Documents
 
 - [Joining a Multisig](/multisig-for-protocols/joining-a-multisig)
 - [Threshold Change Runbook](/multisig-for-protocols/runbooks/threshold-change)

--- a/docs/pages/multisig-for-protocols/runbooks/signer-rotation.mdx
+++ b/docs/pages/multisig-for-protocols/runbooks/signer-rotation.mdx
@@ -8,6 +8,8 @@ tags:
 contributors:
   - role: wrote
     users: [isaac, geoffrey, louis, pablo, dickson]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../components'
@@ -16,6 +18,9 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Rotate signers without dropping below policy towards threshold; verify membership
+> on-chain after the change settles.
 
 This is an example runbook. Review and customize it for your protocol before use. Add your specific multisig
 addresses, signer requirements, and communication channels.
@@ -180,5 +185,7 @@ When removing a signer:
 - [Threshold Change Runbook](/multisig-for-protocols/runbooks/threshold-change)
 - [Offboarding](/multisig-for-protocols/offboarding)
 - [Operational Runbooks](/multisig-for-protocols/runbooks/overview)
+
+---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/runbooks/threshold-change.mdx
+++ b/docs/pages/multisig-for-protocols/runbooks/threshold-change.mdx
@@ -179,6 +179,11 @@ When removing a signer, plan final signer count and threshold together:
 - [Registration & Documentation](/multisig-for-protocols/registration-and-documentation)
 - [Operational Runbooks](/multisig-for-protocols/runbooks/overview)
 
+
+## Further Reading
+
+- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/runbooks/threshold-change.mdx
+++ b/docs/pages/multisig-for-protocols/runbooks/threshold-change.mdx
@@ -8,6 +8,8 @@ tags:
 contributors:
   - role: wrote
     users: [isaac, geoffrey, louis, pablo, dickson]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../components'
@@ -16,6 +18,9 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Threshold changes alter liveness and security together—confirm new m-of-n is authorized,
+> executable with remaining keys, and recorded.
 
 This is an example runbook. Review and customize it for your protocol before use. Adjust threshold requirements to match
 your organization's policies.
@@ -173,5 +178,7 @@ When removing a signer, plan final signer count and threshold together:
 - [Planning & Classification](/multisig-for-protocols/planning-and-classification)
 - [Registration & Documentation](/multisig-for-protocols/registration-and-documentation)
 - [Operational Runbooks](/multisig-for-protocols/runbooks/overview)
+
+---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/runbooks/threshold-change.mdx
+++ b/docs/pages/multisig-for-protocols/runbooks/threshold-change.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Threshold Change Runbook | SEAL"
-description: "Runbook for changing multisig thresholds on Safe and Squads, including policy checks, signer coordination, and post-change verification."
+description: "Runbook for changing multisig thresholds on Safe and Squads, including policy checks, signer coordination, and post-change verification. This is an example"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/multisig-for-protocols/runbooks/threshold-change.mdx
+++ b/docs/pages/multisig-for-protocols/runbooks/threshold-change.mdx
@@ -8,6 +8,8 @@ tags:
 contributors:
   - role: wrote
     users: [isaac, geoffrey, louis, pablo, dickson]
+  - role: reviewed
+    users: []
   - role: fact-checked
     users: []
 ---
@@ -150,7 +152,7 @@ your organization's policies.
 - [ ] Update any documentation referencing old threshold
 </Checklist>
 
-### Common Scenarios
+## Common Scenarios
 
 ### Adding Signer + Adjusting Threshold
 
@@ -173,16 +175,15 @@ When removing a signer, plan final signer count and threshold together:
 1. If needed, reduce threshold first or in the same change window
 2. Ensure the final configuration still meets policy requirements and avoids `N of N`
 
-### Related Documents
-
-- [Planning & Classification](/multisig-for-protocols/planning-and-classification)
-- [Registration & Documentation](/multisig-for-protocols/registration-and-documentation)
-- [Operational Runbooks](/multisig-for-protocols/runbooks/overview)
-
-
 ## Further Reading
 
-- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+- [Operational Runbooks](/multisig-for-protocols/runbooks/overview): how the runbooks in this section fit together
+- [Planning & Classification](/multisig-for-protocols/planning-and-classification): the classification matrix that sets
+  the target threshold
+- [Registration & Documentation](/multisig-for-protocols/registration-and-documentation): recording the change
+  afterwards
+- [Signer Rotation Runbook](/multisig-for-protocols/runbooks/signer-rotation): the companion procedure when membership
+  changes too
 
 ---
 

--- a/docs/pages/multisig-for-protocols/runbooks/threshold-change.mdx
+++ b/docs/pages/multisig-for-protocols/runbooks/threshold-change.mdx
@@ -150,7 +150,7 @@ your organization's policies.
 - [ ] Update any documentation referencing old threshold
 </Checklist>
 
-## Common Scenarios
+### Common Scenarios
 
 ### Adding Signer + Adjusting Threshold
 
@@ -173,7 +173,7 @@ When removing a signer, plan final signer count and threshold together:
 1. If needed, reduce threshold first or in the same change window
 2. Ensure the final configuration still meets policy requirements and avoids `N of N`
 
-## Related Documents
+### Related Documents
 
 - [Planning & Classification](/multisig-for-protocols/planning-and-classification)
 - [Registration & Documentation](/multisig-for-protocols/registration-and-documentation)

--- a/docs/pages/multisig-for-protocols/runbooks/token-transfer.mdx
+++ b/docs/pages/multisig-for-protocols/runbooks/token-transfer.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Token Transfer Runbook | SEAL"
-description: "Runbook for multisig token transfers on Safe and Squads, including verification, simulation, signing, and execution checks."
+description: "Runbook for multisig token transfers on Safe and Squads, including verification, simulation, signing, and execution checks. Add your specific multisig"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/multisig-for-protocols/runbooks/token-transfer.mdx
+++ b/docs/pages/multisig-for-protocols/runbooks/token-transfer.mdx
@@ -8,6 +8,8 @@ tags:
 contributors:
   - role: wrote
     users: [isaac, geoffrey, louis, pablo, dickson]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../components'
@@ -16,6 +18,9 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Token sends fail on address and network mistakes: verify destination from authoritative
+> sources, test small, then execute with full dual-check.
 
 This is an example runbook. Review and customize it for your protocol before use. Add your specific multisig addresses,
 token details, and verification procedures.
@@ -180,5 +185,7 @@ For ERC20 or SPL tokens, verify decimals:
 - [Safe Multisig: Step-by-Step Verification](/wallet-security/signing-and-verification/secure-multisig-safe-verification)
 - [Squads Multisig: Step-by-Step Verification](/wallet-security/signing-and-verification/secure-multisig-squads-verification)
 - [Operational Runbooks](/multisig-for-protocols/runbooks/overview)
+
+---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/runbooks/token-transfer.mdx
+++ b/docs/pages/multisig-for-protocols/runbooks/token-transfer.mdx
@@ -186,6 +186,11 @@ For ERC20 or SPL tokens, verify decimals:
 - [Squads Multisig: Step-by-Step Verification](/wallet-security/signing-and-verification/secure-multisig-squads-verification)
 - [Operational Runbooks](/multisig-for-protocols/runbooks/overview)
 
+
+## Further Reading
+
+- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/runbooks/token-transfer.mdx
+++ b/docs/pages/multisig-for-protocols/runbooks/token-transfer.mdx
@@ -8,6 +8,8 @@ tags:
 contributors:
   - role: wrote
     users: [isaac, geoffrey, louis, pablo, dickson]
+  - role: reviewed
+    users: []
   - role: fact-checked
     users: []
 ---
@@ -180,16 +182,14 @@ For ERC20 or SPL tokens, verify decimals:
 | Nonce mismatch | Clear pending transactions first |
 | Recipient can't receive | Verify address is correct type (EOA vs contract) |
 
-### Related Documents
-
-- [Safe Multisig: Step-by-Step Verification](/wallet-security/signing-and-verification/secure-multisig-safe-verification)
-- [Squads Multisig: Step-by-Step Verification](/wallet-security/signing-and-verification/secure-multisig-squads-verification)
-- [Operational Runbooks](/multisig-for-protocols/runbooks/overview)
-
-
 ## Further Reading
 
-- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+- [Operational Runbooks](/multisig-for-protocols/runbooks/overview): how the runbooks in this section fit together
+- [Safe Multisig Verification](/wallet-security/signing-and-verification/secure-multisig-safe-verification): the EVM
+  verification walkthrough
+- [Squads Multisig Verification](/wallet-security/signing-and-verification/secure-multisig-squads-verification): the
+  Solana equivalent
+- [Transaction Verification](/treasury-operations/transaction-verification): treasury-side checks before a transfer
 
 ---
 

--- a/docs/pages/multisig-for-protocols/runbooks/token-transfer.mdx
+++ b/docs/pages/multisig-for-protocols/runbooks/token-transfer.mdx
@@ -180,7 +180,7 @@ For ERC20 or SPL tokens, verify decimals:
 | Nonce mismatch | Clear pending transactions first |
 | Recipient can't receive | Verify address is correct type (EOA vs contract) |
 
-## Related Documents
+### Related Documents
 
 - [Safe Multisig: Step-by-Step Verification](/wallet-security/signing-and-verification/secure-multisig-safe-verification)
 - [Squads Multisig: Step-by-Step Verification](/wallet-security/signing-and-verification/secure-multisig-squads-verification)

--- a/docs/pages/multisig-for-protocols/setup-and-configuration.mdx
+++ b/docs/pages/multisig-for-protocols/setup-and-configuration.mdx
@@ -137,7 +137,7 @@ invariant is violated.
 - [ ] Safe addresses documented for all networks
 </Checklist>
 
-### Practice on Testnet
+## Practice on Testnet
 
 Before deploying on mainnet, thoroughly practice wallet creation, transaction signing, and owner management on
 a test network.
@@ -145,7 +145,7 @@ a test network.
 Once setup is complete, proceed to [Registration &
 Documentation](/multisig-for-protocols/registration-and-documentation) for registration and documentation requirements.
 
-### Nested Safes
+## Nested Safes
 
 A nested Safe is one in which a Safe is set as a signer on another Safe rather than an EOA. This can be useful on a
 case-by-case basis. For example, if a signer is an entity that might want to have multiple individual signers, the
@@ -155,7 +155,7 @@ allows the signers on the nested Safe to update the signer addresses without nee
 It is generally recommended **not** to use nested safe on protocol multisigs unless there is a specific use case that
 it enables.
 
-### Next Steps
+## Next Steps
 
 After completing setup:
 
@@ -163,7 +163,7 @@ After completing setup:
 2. [Communication Setup](/multisig-for-protocols/communication-setup) - Establish secure communication
 3. [Hardware Wallet Setup](/wallet-security/intermediates-and-medium-funds) - Ensure all signers are properly configured
 
-### Active Monitoring
+## Active Monitoring
 
 Implement monitoring and alerting systems to be immediately notified of any on-chain activity related to the multisig,
 including proposed transactions, new signatures, and owner changes (e.g., using tools like [Safe
@@ -185,10 +185,15 @@ Monitoring channels (e.g. email, Slack or Telegram chats) must be immutable (or 
 changes or logs are deleted/tampered with) and redundant such that an admin could not disable or tamper with one
 monitoring channel without generating an alert on the other channel.
 
-
 ## Further Reading
 
-- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+- [Multisig for Protocols overview](/multisig-for-protocols/overview): how the pages of this framework fit together
+- [Planning & Classification](/multisig-for-protocols/planning-and-classification): the classification that drives these
+  settings
+- [Use-Case Specific Requirements](/multisig-for-protocols/use-case-specific-requirements): per-function configuration
+  rules
+- [Secure Multisig Best Practices](/wallet-security/secure-multisig-best-practices): signer, threshold, and device
+  design principles
 
 ---
 

--- a/docs/pages/multisig-for-protocols/setup-and-configuration.mdx
+++ b/docs/pages/multisig-for-protocols/setup-and-configuration.mdx
@@ -10,6 +10,8 @@ contributors:
     users: [isaac, geoffrey, louis, pablo, dickson, auditware]
   - role: reviewed
     users: [pinalikefruit, engn33r]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../components'
@@ -18,6 +20,9 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Deploy configuration must match the plan: owners, threshold, modules, delegated
+> proposers, and network verified on-chain before first real use.
 
 This page covers the technical deployment and configuration of multisigs on supported networks.
 
@@ -179,5 +184,7 @@ execution window. See
 Monitoring channels (e.g. email, Slack or Telegram chats) must be immutable (or trigger alerts when their configuration
 changes or logs are deleted/tampered with) and redundant such that an admin could not disable or tamper with one
 monitoring channel without generating an alert on the other channel.
+
+---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/setup-and-configuration.mdx
+++ b/docs/pages/multisig-for-protocols/setup-and-configuration.mdx
@@ -145,7 +145,7 @@ a test network.
 Once setup is complete, proceed to [Registration &
 Documentation](/multisig-for-protocols/registration-and-documentation) for registration and documentation requirements.
 
-## Nested Safes
+### Nested Safes
 
 A nested Safe is one in which a Safe is set as a signer on another Safe rather than an EOA. This can be useful on a
 case-by-case basis. For example, if a signer is an entity that might want to have multiple individual signers, the
@@ -155,7 +155,7 @@ allows the signers on the nested Safe to update the signer addresses without nee
 It is generally recommended **not** to use nested safe on protocol multisigs unless there is a specific use case that
 it enables.
 
-## Next Steps
+### Next Steps
 
 After completing setup:
 
@@ -163,7 +163,7 @@ After completing setup:
 2. [Communication Setup](/multisig-for-protocols/communication-setup) - Establish secure communication
 3. [Hardware Wallet Setup](/wallet-security/intermediates-and-medium-funds) - Ensure all signers are properly configured
 
-## Active Monitoring
+### Active Monitoring
 
 Implement monitoring and alerting systems to be immediately notified of any on-chain activity related to the multisig,
 including proposed transactions, new signatures, and owner changes (e.g., using tools like [Safe

--- a/docs/pages/multisig-for-protocols/setup-and-configuration.mdx
+++ b/docs/pages/multisig-for-protocols/setup-and-configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Multisig Setup & Configuration | SEAL"
-description: "Deploy multisigs on EVM networks with Safe and Solana with Squads. Configure delegated proposers, allowance modules for treasury rescue, nested Safes, and active monitoring with Safe Watcher."
+description: "Deploy multisigs on EVM networks with Safe and Solana with Squads. Configure delegated proposers, allowance modules for treasury rescue, nested Safes"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/multisig-for-protocols/setup-and-configuration.mdx
+++ b/docs/pages/multisig-for-protocols/setup-and-configuration.mdx
@@ -185,6 +185,11 @@ Monitoring channels (e.g. email, Slack or Telegram chats) must be immutable (or 
 changes or logs are deleted/tampered with) and redundant such that an admin could not disable or tamper with one
 monitoring channel without generating an alert on the other channel.
 
+
+## Further Reading
+
+- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/use-case-specific-requirements.mdx
+++ b/docs/pages/multisig-for-protocols/use-case-specific-requirements.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Multisig Use Case Requirements | SEAL"
-description: "Multisig requirements by use case: treasury with allowance modules, emergency response with 24/7 availability, capital allocation with on-chain constraints, and smart contract control with timelocks."
+description: "Multisig requirements by use case: treasury with allowance modules, emergency response with 24/7 availability, capital allocation with on-chain constraints"
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/multisig-for-protocols/use-case-specific-requirements.mdx
+++ b/docs/pages/multisig-for-protocols/use-case-specific-requirements.mdx
@@ -10,6 +10,8 @@ contributors:
     users: [isaac, geoffrey, louis, pablo, dickson, auditware]
   - role: reviewed
     users: [pinalikefruit, engn33r, ElliotFriedman]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -18,6 +20,12 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Split admin powers by function so one compromised set cannot upgrade, pause, and move
+> treasury in one shot; match timelock and threshold to blast radius.
+
+Different admin powers deserve different multisigs, thresholds, and delays. Apply
+the patterns below instead of one global God-mode set.
 
 ## Separating Multisigs by Function
 
@@ -231,5 +239,7 @@ proposal will simply execute after the delay period. The monitoring window IS th
 
 Make timelock queues publicly visible through a dashboard or notification feed. This allows the broader
 community to observe pending changes, which adds an additional layer of scrutiny beyond the core team.
+
+---
 
 <ContributeFooter />

--- a/docs/pages/multisig-for-protocols/use-case-specific-requirements.mdx
+++ b/docs/pages/multisig-for-protocols/use-case-specific-requirements.mdx
@@ -240,10 +240,13 @@ proposal will simply execute after the delay period. The monitoring window IS th
 Make timelock queues publicly visible through a dashboard or notification feed. This allows the broader
 community to observe pending changes, which adds an additional layer of scrutiny beyond the core team.
 
-
 ## Further Reading
 
-- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+- [Multisig for Protocols overview](/multisig-for-protocols/overview): how the pages of this framework fit together
+- [Planning and Classification](/multisig-for-protocols/planning-and-classification): choosing the right category first
+- [Setup & Configuration](/multisig-for-protocols/setup-and-configuration): the baseline settings these requirements
+  extend
+- [Operational Runbooks](/multisig-for-protocols/runbooks/overview): procedures for the functions described here
 
 ---
 

--- a/docs/pages/multisig-for-protocols/use-case-specific-requirements.mdx
+++ b/docs/pages/multisig-for-protocols/use-case-specific-requirements.mdx
@@ -240,6 +240,11 @@ proposal will simply execute after the delay period. The monitoring window IS th
 Make timelock queues publicly visible through a dashboard or notification feed. This allows the broader
 community to observe pending changes, which adds an additional layer of scrutiny beyond the core team.
 
+
+## Further Reading
+
+- [Multisig For Protocols overview](/multisig-for-protocols/overview)
+
 ---
 
 <ContributeFooter />


### PR DESCRIPTION
## Scope

Normalize **Multisig for Protocols** (`docs/pages/multisig-for-protocols/` including `runbooks/`).

## Why

Overview lacked Key Takeaway and Related frameworks; child pages and runbooks had no canonical KT or `fact-checked` roles; structure was good but chrome incomplete vs content model (#561).

## Content model applied

- Framework overview page map + runbooks subsection + cross-links to Wallet Security
- Canonical Key Takeaway on all content pages
- Brief unheaded intros where pages jumped straight to H2
- Related frameworks / Further reading on overview; HR before ContributeFooter

## Changes

- Overview rewrite (chrome + routing table as list)
- KT + fact-checked on administration, signer, checklist, and runbook pages
- Key Takeaways page kept; added page-level KT + fact-checked

## Substantive security changes

**None.** Procedures, checklists, thresholds, and best-practice bodies preserved.

## Intentionally unchanged

- Implementation checklist content and `<Checklist>` blocks
- Runbook procedure steps
- Use-case separation tables and timelock guidance
- key-takeaways numbered principles body

## Validation

- [x] cspell
- [x] markdownlint-cli2 clean on touch paths
- [x] signed commit

## Dependencies

**#561** by reference only.

## Reviewer focus

- Overview map matches sidebar (including runbooks)
- Wallet Security cross-links remain accurate
- No accidental procedure edits in runbooks