### PR TITLE
docs(incident-management): normalize structure and wording

### DIFF
--- a/docs/pages/incident-management/communication-strategies.mdx
+++ b/docs/pages/incident-management/communication-strategies.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Incident Communication Strategies | SEAL"
-description: "Establish secure communication channels for incident response. Appoint spokespersons, develop pre-approved notification templates"
+description: "Establish secure incident channels, appoint primary and backup spokespersons, and use pre-approved templates to update stakeholders on a fixed cadence."
 tags:
   - Security Specialist
   - Operations & Strategy
@@ -48,7 +48,7 @@ Avoid speculation and provide factual information.
 For message templates and example public updates, see
 [Incident Response Template: Communications](/incident-management/incident-response-template/communications).
 
-## Further Reading
+## Further reading
 
 - [Incident Management overview](/incident-management/overview): how the pages of this framework fit together
 - [Communications template](/incident-management/incident-response-template/communications): ready-to-adapt holding statements and updates

--- a/docs/pages/incident-management/communication-strategies.mdx
+++ b/docs/pages/incident-management/communication-strategies.mdx
@@ -31,7 +31,7 @@ information before confirming that it's accurate, can often be very negative and
 have a person designated for communication during an incident, and that updates are sent out on a fixed schedule, and
 it can often be that the update is that there is currently no new information available.
 
-## Best Practices
+## Best practices
 
 1. Define and establish secure communication channels for incident response teams.
 Use [encrypted messaging apps](/encryption/communication-encryption)

--- a/docs/pages/incident-management/communication-strategies.mdx
+++ b/docs/pages/incident-management/communication-strategies.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Incident Communication Strategies | SEAL"
-description: "Establish secure communication channels for incident response. Appoint spokespersons, develop pre-approved notification templates, and provide regular stakeholder updates during security incidents."
+description: "Establish secure communication channels for incident response. Appoint spokespersons, develop pre-approved notification templates"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/incident-management/communication-strategies.mdx
+++ b/docs/pages/incident-management/communication-strategies.mdx
@@ -48,10 +48,12 @@ Avoid speculation and provide factual information.
 For message templates and example public updates, see
 [Incident Response Template: Communications](/incident-management/incident-response-template/communications).
 
-
 ## Further Reading
 
-- [Incident Management overview](/incident-management/overview)
+- [Incident Management overview](/incident-management/overview): how the pages of this framework fit together
+- [Communications template](/incident-management/incident-response-template/communications): ready-to-adapt holding statements and updates
+- [Community Management](/community-management/overview): the channels these messages go out on
+- [Incident Detection and Response](/incident-management/incident-detection-and-response): what triggers a communication
 
 ---
 

--- a/docs/pages/incident-management/communication-strategies.mdx
+++ b/docs/pages/incident-management/communication-strategies.mdx
@@ -4,6 +4,13 @@ description: "Establish secure communication channels for incident response. App
 tags:
   - Security Specialist
   - Operations & Strategy
+contributors:
+  - role: wrote
+    users: []
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -12,6 +19,10 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Designate a single spokesperson and fixed update cadence before
+> chaos starts. Ship only confirmed facts; "no new information" is a valid status update
+> that reduces speculation damage.
 
 Communication during an incident can be very hard, as people are often scrambling to fix the issue at hand. Nonetheless,
 from a team member’s, outsider’s, or observer’s point of view, communication is very important to be able to understand

--- a/docs/pages/incident-management/communication-strategies.mdx
+++ b/docs/pages/incident-management/communication-strategies.mdx
@@ -48,6 +48,11 @@ Avoid speculation and provide factual information.
 For message templates and example public updates, see
 [Incident Response Template: Communications](/incident-management/incident-response-template/communications).
 
+
+## Further Reading
+
+- [Incident Management overview](/incident-management/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/forensic-readiness.mdx
+++ b/docs/pages/incident-management/forensic-readiness.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Forensic Readiness | Security Alliance"
-description: "Forensic readiness: prepare your organization to preserve, collect, and present trustworthy evidence before an incident occurs. Design evidence collection into architecture, maintain chain of custody, and meet regulatory disclosure requirements."
+description: "Forensic readiness: prepare your organization to preserve, collect, and present trustworthy evidence before an incident occurs. Design evidence collection into..."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/incident-management/incident-detection-and-response.mdx
+++ b/docs/pages/incident-management/incident-detection-and-response.mdx
@@ -52,7 +52,7 @@ For a complete incident response policy template covering roles, severity, docum
 and
 [Incident Response Template: Roles and Staffing](/incident-management/incident-response-template/roles-and-staffing).
 
-## Further Reading
+## Further reading
 
 - [Incident Management overview](/incident-management/overview): how the pages of this framework fit together
 - [Monitoring overview](/monitoring/overview): the signals detection depends on

--- a/docs/pages/incident-management/incident-detection-and-response.mdx
+++ b/docs/pages/incident-management/incident-detection-and-response.mdx
@@ -52,10 +52,12 @@ For a complete incident response policy template covering roles, severity, docum
 and
 [Incident Response Template: Roles and Staffing](/incident-management/incident-response-template/roles-and-staffing).
 
-
 ## Further Reading
 
-- [Incident Management overview](/incident-management/overview)
+- [Incident Management overview](/incident-management/overview): how the pages of this framework fit together
+- [Monitoring overview](/monitoring/overview): the signals detection depends on
+- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy): severity levels, roles, and escalation
+- [Lessons Learned](/incident-management/lessons-learned): turning each incident into a change
 
 ---
 

--- a/docs/pages/incident-management/incident-detection-and-response.mdx
+++ b/docs/pages/incident-management/incident-detection-and-response.mdx
@@ -4,6 +4,13 @@ description: "Detect security incidents early with continuous on-chain monitorin
 tags:
   - Security Specialist
   - Operations & Strategy
+contributors:
+  - role: wrote
+    users: []
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -12,6 +19,10 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Detect on-chain and off-chain anomalies early, then execute a
+> prepared response cycle: IRT roles, containment, recovery, and post-incident review.
+> Delay multiplies irreversible Web3 losses.
 
 You don't want to be the project that has funds stolen and then doesn't notice it for multiple days. Early detection
 and effective response to security incidents will help minimize damage.

--- a/docs/pages/incident-management/incident-detection-and-response.mdx
+++ b/docs/pages/incident-management/incident-detection-and-response.mdx
@@ -52,6 +52,11 @@ For a complete incident response policy template covering roles, severity, docum
 and
 [Incident Response Template: Roles and Staffing](/incident-management/incident-response-template/roles-and-staffing).
 
+
+## Further Reading
+
+- [Incident Management overview](/incident-management/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-detection-and-response.mdx
+++ b/docs/pages/incident-management/incident-detection-and-response.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Incident Detection And Response | SEAL"
-description: "Detect security incidents early with continuous on-chain monitoring and logging. Build an Incident Response Team (IRT) with clear roles for containment, recovery, and post-incident review."
+description: "Detect security incidents early with continuous on-chain monitoring and logging. Build an Incident Response Team (IRT) with clear roles for containment"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/incident-management/incident-response-template/communications.mdx
+++ b/docs/pages/incident-management/incident-response-template/communications.mdx
@@ -7,7 +7,10 @@ tags:
 contributors:
   - role: wrote
     users: [hexnickk4997, n0guest]
-
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../components'
@@ -16,6 +19,10 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Adapt pre-built internal and public message blocks so spokespeople
+> ship factual updates under pressure. Avoid root-cause speculation, blame, and
+> excessive apologies until facts are confirmed.
 
 Templates and building blocks for incident communications. Adapt these to your situation and tone.
 
@@ -201,6 +208,8 @@ Use these as modular pieces. Combine as needed for your situation.
 - Acknowledge impact on users
 - Avoid excessive apologies (one is enough)
 
-*See [Incident Response Policy](./incident-response-policy) for the overall response process.*
+*See [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy) for the overall response process.*
+
+---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/communications.mdx
+++ b/docs/pages/incident-management/incident-response-template/communications.mdx
@@ -210,7 +210,7 @@ Use these as modular pieces. Combine as needed for your situation.
 
 *See [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy) for the overall response process.*
 
-## Further Reading
+## Further reading
 
 - [Incident Response Template overview](/incident-management/incident-response-template/overview): how the template pieces fit together
 - [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy): severity levels, roles, and escalation

--- a/docs/pages/incident-management/incident-response-template/communications.mdx
+++ b/docs/pages/incident-management/incident-response-template/communications.mdx
@@ -210,10 +210,12 @@ Use these as modular pieces. Combine as needed for your situation.
 
 *See [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy) for the overall response process.*
 
-
 ## Further Reading
 
-- [Incident Management overview](/incident-management/overview)
+- [Incident Response Template overview](/incident-management/incident-response-template/overview): how the template pieces fit together
+- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy): severity levels, roles, and escalation
+- [Communication Strategies](/incident-management/communication-strategies): the principles behind these templates
+- [Community Management](/community-management/overview): the channels these messages go out on
 
 ---
 

--- a/docs/pages/incident-management/incident-response-template/communications.mdx
+++ b/docs/pages/incident-management/incident-response-template/communications.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Communication Templates | Security Alliance"
-description: "Templates and building blocks for incident communications. Adapt these to your situation and tone."
+description: "Templates and building blocks for incident communications. Adapt these to your situation and tone. Adapt pre-built internal and public message blocks"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/incident-management/incident-response-template/communications.mdx
+++ b/docs/pages/incident-management/incident-response-template/communications.mdx
@@ -210,6 +210,11 @@ Use these as modular pieces. Combine as needed for your situation.
 
 *See [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy) for the overall response process.*
 
+
+## Further Reading
+
+- [Incident Management overview](/incident-management/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/contacts.mdx
+++ b/docs/pages/incident-management/incident-response-template/contacts.mdx
@@ -150,6 +150,11 @@ For P1 (critical) incidents, contact in this order:
 *See [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy) and [Roles and Staffing](/incident-management/incident-response-template/roles-and-staffing) for how
 these contacts fit into the response process.*
 
+
+## Further Reading
+
+- [Incident Management overview](/incident-management/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/contacts.mdx
+++ b/docs/pages/incident-management/incident-response-template/contacts.mdx
@@ -150,7 +150,7 @@ For P1 (critical) incidents, contact in this order:
 *See [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy) and [Roles and Staffing](/incident-management/incident-response-template/roles-and-staffing) for how
 these contacts fit into the response process.*
 
-## Further Reading
+## Further reading
 
 - [Incident Response Template overview](/incident-management/incident-response-template/overview): how the template pieces fit together
 - [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy): severity levels, roles, and escalation

--- a/docs/pages/incident-management/incident-response-template/contacts.mdx
+++ b/docs/pages/incident-management/incident-response-template/contacts.mdx
@@ -150,10 +150,12 @@ For P1 (critical) incidents, contact in this order:
 *See [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy) and [Roles and Staffing](/incident-management/incident-response-template/roles-and-staffing) for how
 these contacts fit into the response process.*
 
-
 ## Further Reading
 
-- [Incident Management overview](/incident-management/overview)
+- [Incident Response Template overview](/incident-management/incident-response-template/overview): how the template pieces fit together
+- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy): severity levels, roles, and escalation
+- [Roles and Staffing](/incident-management/incident-response-template/roles-and-staffing): the roles these contacts fill
+- [SEAL 911 War Room Guidelines](/incident-management/playbooks/seal-911-war-room-guidelines): reaching outside help fast
 
 ---
 

--- a/docs/pages/incident-management/incident-response-template/contacts.mdx
+++ b/docs/pages/incident-management/incident-response-template/contacts.mdx
@@ -7,7 +7,10 @@ tags:
 contributors:
   - role: wrote
     users: [hexnickk4997, n0guest]
-
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../components'
@@ -16,6 +19,10 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Keep emergency internal, partner, vendor, legal, and PR contacts
+> verified and owned. Stale phone trees waste the minutes that matter most during
+> containment.
 
 Keep this updated. Stale contacts during an incident waste critical time.
 
@@ -140,7 +147,9 @@ For P1 (critical) incidents, contact in this order:
 
 **Owner:** [Assign someone to maintain this document]
 
-*See [Incident Response Policy](./incident-response-policy) and [Roles and Staffing](./roles-and-staffing) for how
+*See [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy) and [Roles and Staffing](/incident-management/incident-response-template/roles-and-staffing) for how
 these contacts fit into the response process.*
+
+---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/contacts.mdx
+++ b/docs/pages/incident-management/incident-response-template/contacts.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Critical Contacts | Security Alliance"
-description: "Keep this updated. Stale contacts during an incident waste critical time."
+description: "Keep this updated. Stale contacts during an incident waste critical time. Keep emergency internal, partner, vendor, legal, and PR contacts verified"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/incident-management/incident-response-template/contacts.mdx
+++ b/docs/pages/incident-management/incident-response-template/contacts.mdx
@@ -126,7 +126,7 @@ Protocols, exchanges, or other partners to notify during major incidents.
 | Public updates | | |
 | Team alerts | | |
 
-## Quick Reference - P1 Escalation
+### Quick Reference - P1 Escalation
 
 For P1 (critical) incidents, contact in this order:
 
@@ -137,7 +137,7 @@ For P1 (critical) incidents, contact in this order:
 4. [ ] Legal (if fund loss or regulatory implications)
 </Checklist>
 
-## Maintenance
+### Maintenance
 
 <Checklist id="maintenance">
 - [ ] Review and update quarterly

--- a/docs/pages/incident-management/incident-response-template/incident-response-policy.mdx
+++ b/docs/pages/incident-management/incident-response-template/incident-response-policy.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Incident Response Policy | Security Alliance"
-description: "This policy defines how we respond to security and operational incidents. It covers roles, severity classification, and the steps from detection through post-incident review."
+description: "This policy defines how we respond to security and operational incidents. It covers roles, severity classification. Define severity, decision makers"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/incident-management/incident-response-template/incident-response-policy.mdx
+++ b/docs/pages/incident-management/incident-response-template/incident-response-policy.mdx
@@ -212,7 +212,7 @@ See [Runbooks](/incident-management/incident-response-template/runbooks/overview
 
 *Customize this policy for your protocol's tools, team structure, and communication channels.*
 
-## Further Reading
+## Further reading
 
 - [Incident Response Template overview](/incident-management/incident-response-template/overview): how the template pieces fit together
 - [Roles and Staffing](/incident-management/incident-response-template/roles-and-staffing): team structure options

--- a/docs/pages/incident-management/incident-response-template/incident-response-policy.mdx
+++ b/docs/pages/incident-management/incident-response-template/incident-response-policy.mdx
@@ -204,19 +204,6 @@ See [Runbooks](/incident-management/incident-response-template/runbooks/overview
   examples.
 - **Transparency:** Default to sharing post-mortems publicly (redacting sensitive details).
 
-## Related Documents
-
-- [Roles and Staffing](/incident-management/incident-response-template/roles-and-staffing) - Team structure options
-- [Communications](/incident-management/incident-response-template/communications) - Public announcement guidance
-- [Incident Log
-  Template](/incident-management/incident-response-template/templates/incident-log-template) - Fill
-  out during incidents
-- [Post-Mortem
-  Template](/incident-management/incident-response-template/templates/post-mortem-template) -
-  Complete after incidents
-- [Contacts](/incident-management/incident-response-template/contacts) - Critical contacts
-- [Runbooks](/incident-management/incident-response-template/runbooks/overview) - Step-by-step incident guides
-
 ## Document Control
 
 | Version | Date | Author | Changes |
@@ -225,10 +212,12 @@ See [Runbooks](/incident-management/incident-response-template/runbooks/overview
 
 *Customize this policy for your protocol's tools, team structure, and communication channels.*
 
-
 ## Further Reading
 
-- [Incident Management overview](/incident-management/overview)
+- [Incident Response Template overview](/incident-management/incident-response-template/overview): how the template pieces fit together
+- [Roles and Staffing](/incident-management/incident-response-template/roles-and-staffing): team structure options
+- [Runbooks overview](/incident-management/incident-response-template/runbooks/overview): how the runbooks in this section fit together
+- [Templates overview](/incident-management/incident-response-template/templates/overview): how the templates in this section fit together
 
 ---
 

--- a/docs/pages/incident-management/incident-response-template/incident-response-policy.mdx
+++ b/docs/pages/incident-management/incident-response-template/incident-response-policy.mdx
@@ -8,7 +8,10 @@ tags:
 contributors:
   - role: wrote
     users: [hexnickk4997, n0guest]
-
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../components'
@@ -18,12 +21,16 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
+> 🔑 **Key Takeaway**: Define severity, decision makers, and the detect-to-review flow in
+> writing before an incident. Policy that exists only in heads fails when minutes matter
+> and funds can leave forever.
+
+This policy defines how we respond to security and operational incidents. It covers roles,
+severity classification, and the steps from detection through post-incident review. For role
+structures and on-call options, see
+[Roles and Staffing](/incident-management/incident-response-template/roles-and-staffing).
+
 ## Overview
-
-This policy defines how we respond to security and operational incidents. It covers roles, severity classification,
-and the steps from detection through post-incident review.
-
-For role structures and on-call options, see [Roles and Staffing](./roles-and-staffing).
 
 ## Roles
 
@@ -40,7 +47,9 @@ Makers when needed.
 
 ### Scribe
 
-Documents everything in the [Incident Log](./templates/incident-log-template). Maintains timestamps (UTC), captures
+Documents everything in the [Incident
+  Log](/incident-management/incident-response-template/templates/incident-log-template). Maintains
+  timestamps (UTC), captures
 decisions and rationale. This is a focused role. Don't also assign the Scribe to fix things.
 
 ### Communication Manager
@@ -134,7 +143,7 @@ The Detector's job: get the right people involved, fast.
 **Incident Leader responsibilities:**
 
 1. Pull in relevant SMEs
-2. Assign a Scribe → they create an [Incident Log](./templates/incident-log-template)
+2. Assign a Scribe → they create an [Incident Log](/incident-management/incident-response-template/templates/incident-log-template)
 3. Assign Communication Manager(s)
 
 ### Step 3: Investigation
@@ -163,7 +172,8 @@ If a temporary fix (rollback, pause, disable feature) is faster than a full fix 
 - [ ] Plan permanent fix with owner and timeline
 </Checklist>
 
-See [Runbooks](./runbooks/overview) for step-by-step guides for specific incident types.
+See [Runbooks](/incident-management/incident-response-template/runbooks/overview) for step-by-step
+  guides for specific incident types.
 
 ### Step 5: Monitoring
 
@@ -179,7 +189,7 @@ See [Runbooks](./runbooks/overview) for step-by-step guides for specific inciden
 **Goal:** Learn and prevent recurrence.
 
 1. Incident Leader schedules post-mortem (within a week of resolution)
-2. Scribe prepares [Post-Mortem](./templates/post-mortem-template) draft
+2. Scribe prepares [Post-Mortem](/incident-management/incident-response-template/templates/post-mortem-template) draft
 3. Team reviews timeline, identifies root causes, captures lessons
 4. Define action items with owners and deadlines
 5. Share with team (and community if appropriate)
@@ -189,18 +199,23 @@ See [Runbooks](./runbooks/overview) for step-by-step guides for specific inciden
 ## Communication Guidelines
 
 - **Internal:** Regular updates in the incident channel. Frequency depends on severity.
-- **External:** Communication Manager drafts, gets approval before posting. See [Communications](./communications) for
+- **External:** Communication Manager drafts, gets approval before posting. See
+  [Communications](/incident-management/incident-response-template/communications) for
   examples.
 - **Transparency:** Default to sharing post-mortems publicly (redacting sensitive details).
 
 ## Related Documents
 
-- [Roles and Staffing](./roles-and-staffing) - Team structure options
-- [Communications](./communications) - Public announcement guidance
-- [Incident Log Template](./templates/incident-log-template) - Fill out during incidents
-- [Post-Mortem Template](./templates/post-mortem-template) - Complete after incidents
-- [Contacts](./contacts) - Critical contacts
-- [Runbooks](./runbooks/overview) - Step-by-step incident guides
+- [Roles and Staffing](/incident-management/incident-response-template/roles-and-staffing) - Team structure options
+- [Communications](/incident-management/incident-response-template/communications) - Public announcement guidance
+- [Incident Log
+  Template](/incident-management/incident-response-template/templates/incident-log-template) - Fill
+  out during incidents
+- [Post-Mortem
+  Template](/incident-management/incident-response-template/templates/post-mortem-template) -
+  Complete after incidents
+- [Contacts](/incident-management/incident-response-template/contacts) - Critical contacts
+- [Runbooks](/incident-management/incident-response-template/runbooks/overview) - Step-by-step incident guides
 
 ## Document Control
 
@@ -209,5 +224,7 @@ See [Runbooks](./runbooks/overview) for step-by-step guides for specific inciden
 | 1.0 | [DATE] | [AUTHOR] | Initial release |
 
 *Customize this policy for your protocol's tools, team structure, and communication channels.*
+
+---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/incident-response-policy.mdx
+++ b/docs/pages/incident-management/incident-response-template/incident-response-policy.mdx
@@ -225,6 +225,11 @@ See [Runbooks](/incident-management/incident-response-template/runbooks/overview
 
 *Customize this policy for your protocol's tools, team structure, and communication channels.*
 
+
+## Further Reading
+
+- [Incident Management overview](/incident-management/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/overview.mdx
+++ b/docs/pages/incident-management/incident-response-template/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Incident Response Template for Web3 Protocols | Security Alliance"
-description: "A practical template for building incident response capabilities at cryptocurrency protocols and DAOs."
+description: "A practical template for building incident response capabilities at cryptocurrency protocols and DAOs. Customize severity, roles, contacts, and runbook"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/incident-management/incident-response-template/overview.mdx
+++ b/docs/pages/incident-management/incident-response-template/overview.mdx
@@ -85,7 +85,7 @@ That's it to start. Add complexity only as you need it.
 - Review past incidents (yours or others via [Rekt News](https://rekt.news/))
 - Update docs when you find gaps
 
-## Using This Template
+## What this framework covers
 
 Review and adapt these pages for your own internal incident response documentation.
 

--- a/docs/pages/incident-management/incident-response-template/overview.mdx
+++ b/docs/pages/incident-management/incident-response-template/overview.mdx
@@ -7,7 +7,10 @@ tags:
 contributors:
   - role: wrote
     users: [hexnickk4997, n0guest]
-
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../components'
@@ -16,6 +19,10 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: This template is a skeleton, not a finished plan. Customize
+> severity, roles, contacts, and runbook commands, then tabletop the result before a
+> real exploit forces improvisation.
 
 A practical template for building incident response capabilities at cryptocurrency protocols and DAOs.
 
@@ -84,16 +91,18 @@ Review and adapt these pages for your own internal incident response documentati
 
 ### What's Included
 
-| Document | Purpose |
-| --- | --- |
-| [Incident Response Policy](./incident-response-policy) | Core policy defining roles, severity levels, and response steps |
-| [Roles and Staffing](./roles-and-staffing) | Options for structuring your response team |
-| [Communications](./communications) | Guidance and examples for public announcements |
-| [Contacts](./contacts) | Critical partner and vendor contact sheet |
-| [Templates](./templates/overview) | Incident log and post-mortem templates |
-| [Example Incident Log](./templates/example-incident-log) | Sample filled-out incident log |
-| [Example Post-Mortem](./templates/example-post-mortem) | Sample filled-out post-mortem |
-| [Runbooks](./runbooks/overview) | Step-by-step guides for specific incident types |
+1. [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy):
+   roles, severity levels, and response steps.
+2. [Roles and Staffing](/incident-management/incident-response-template/roles-and-staffing): how to
+   structure the response team by size.
+3. [Communications](/incident-management/incident-response-template/communications): internal and public
+   announcement building blocks.
+4. [Contacts](/incident-management/incident-response-template/contacts): critical partner and vendor
+   contact sheet.
+5. [Templates hub](/incident-management/incident-response-template/templates/overview): incident log,
+   post-mortem, runbook templates, and examples.
+6. [Runbooks hub](/incident-management/incident-response-template/runbooks/overview): step-by-step
+   guides for specific incident types.
 
 ### Customization Checklist
 
@@ -162,5 +171,7 @@ You don't need all of these to start. Build them over time as your protocol matu
 - [SEAL 911](https://securityalliance.org/seal-911) - Emergency response coordination
 
 *This template is open source. Adapt it to your needs.*
+
+---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/overview.mdx
+++ b/docs/pages/incident-management/incident-response-template/overview.mdx
@@ -153,7 +153,7 @@ These documents support effective incident response but typically live elsewhere
 
 You don't need all of these to start. Build them over time as your protocol matures.
 
-## Key Principles
+## Key principles
 
 **When in doubt, escalate.** Treating a P2 as P1 creates some noise. Treating a P1 as P2 can cost millions.
 

--- a/docs/pages/incident-management/incident-response-template/roles-and-staffing.mdx
+++ b/docs/pages/incident-management/incident-response-template/roles-and-staffing.mdx
@@ -8,7 +8,10 @@ tags:
 contributors:
   - role: wrote
     users: [hexnickk4997, n0guest]
-
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../components'
@@ -18,10 +21,16 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
+> 🔑 **Key Takeaway**: Match IR staffing to team size: small teams split lead versus fix,
+> larger teams add on-call and specialists. A light process people follow beats a
+> heavyweight binder nobody opens.
+
 How you staff incident response depends on your team size and structure. This document covers options from small teams
 to larger organizations.
 
-See [Incident Response Policy](./incident-response-policy#roles) for role definitions.
+See [Incident Response
+  Policy](/incident-management/incident-response-template/incident-response-policy#roles) for role
+  definitions.
 
 ## Core Roles (All Team Sizes)
 
@@ -30,7 +39,7 @@ Every incident needs these roles filled, even if one person wears multiple hats:
 | Role | Responsibility |
 | ------- | ----------------- |
 | **Incident Leader** | Coordinates response, assigns tasks, makes decisions |
-| **Scribe** | Documents everything in [Incident Log](./templates/incident-log-template) |
+| **Scribe** | Documents everything in [Incident Log](/incident-management/incident-response-template/templates/incident-log-template) |
 | **Responders** | Execute fixes, investigate, implement mitigations |
 
 For larger incidents, add:
@@ -56,7 +65,7 @@ Everyone knows everything. Just make sure someone is always reachable.
 
 ### Expectations
 
-- Keep a shared contact list (see [Contacts](./contacts))
+- Keep a shared contact list (see [Contacts](/incident-management/incident-response-template/contacts))
 - Establish one communication channel for incidents
 - Someone should always be reachable (informal coverage)
 
@@ -146,8 +155,11 @@ ex. With 8 people per rotation, each person is on-call one week every two months
 Before going on-call, complete:
 
 <Checklist id="first-responder-training">
-- [ ] Review [Incident Response Policy](./incident-response-policy)
-- [ ] Review [Incident Log](./templates/incident-log-template) and [Post-Mortem](./templates/post-mortem-template) templates
+- [ ] Review [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
+- [ ] Review [Incident
+      Log](/incident-management/incident-response-template/templates/incident-log-template) and
+      [Post-Mortem](/incident-management/incident-response-template/templates/post-mortem-template)
+      templates
 - [ ] Read 2-3 past post-mortems
 - [ ] Understand basic architecture (infra and smart contracts)
 - [ ] Know how to reach SMEs and Decision Makers
@@ -196,7 +208,7 @@ Ensure your on-call personnel have access to:
 - [ ] Video conferencing
 - [ ] Monitoring dashboards
 - [ ] On-call schedule
-- [ ] [Contacts](./contacts) list
+- [ ] [Contacts](/incident-management/incident-response-template/contacts) list
 </Checklist>
 
 ## Choosing Your Model
@@ -211,6 +223,8 @@ Ensure your on-call personnel have access to:
 **Start simple and add structure as you grow.** A lightweight process that people follow beats a heavyweight process
 that gets ignored.
 
-*See [Incident Response Policy](./incident-response-policy) for how these roles work during an actual incident.*
+*See [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy) for how these roles work during an actual incident.*
+
+---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/roles-and-staffing.mdx
+++ b/docs/pages/incident-management/incident-response-template/roles-and-staffing.mdx
@@ -225,6 +225,11 @@ that gets ignored.
 
 *See [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy) for how these roles work during an actual incident.*
 
+
+## Further Reading
+
+- [Incident Management overview](/incident-management/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/roles-and-staffing.mdx
+++ b/docs/pages/incident-management/incident-response-template/roles-and-staffing.mdx
@@ -225,10 +225,12 @@ that gets ignored.
 
 *See [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy) for how these roles work during an actual incident.*
 
-
 ## Further Reading
 
-- [Incident Management overview](/incident-management/overview)
+- [Incident Response Template overview](/incident-management/incident-response-template/overview): how the template pieces fit together
+- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy): severity levels, roles, and escalation
+- [Contacts template](/incident-management/incident-response-template/contacts): who to reach for each role
+- [Communications template](/incident-management/incident-response-template/communications): who speaks publicly and when
 
 ---
 

--- a/docs/pages/incident-management/incident-response-template/roles-and-staffing.mdx
+++ b/docs/pages/incident-management/incident-response-template/roles-and-staffing.mdx
@@ -225,7 +225,7 @@ that gets ignored.
 
 *See [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy) for how these roles work during an actual incident.*
 
-## Further Reading
+## Further reading
 
 - [Incident Response Template overview](/incident-management/incident-response-template/overview): how the template pieces fit together
 - [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy): severity levels, roles, and escalation

--- a/docs/pages/incident-management/incident-response-template/runbooks/build-pipeline-compromise.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/build-pipeline-compromise.mdx
@@ -8,7 +8,10 @@ tags:
 contributors:
   - role: wrote
     users: [isaac]
-
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../../components'
@@ -18,7 +21,11 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> **Stub runbook.** Customize with your CI/CD platform and procedures.
+> 🔑 **Key Takeaway**: A compromised CI/CD path can ship trojans as trusted releases.
+> Freeze pipelines, rotate secrets and signing keys, audit recent jobs, and only
+> re-enable after integrity checks pass.
+
+**Stub runbook.** Customize with your CI/CD platform and procedures.
 
 ## Quick Reference
 
@@ -77,8 +84,10 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 ## Related
 
-- [Frontend Compromise](./frontend-compromise)
-- [Dependency Attack](./dependency-attack)
-- [Incident Response Policy](../incident-response-policy)
+- [Frontend Compromise](/incident-management/incident-response-template/runbooks/frontend-compromise)
+- [Dependency Attack](/incident-management/incident-response-template/runbooks/dependency-attack)
+- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
+
+---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/runbooks/build-pipeline-compromise.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/build-pipeline-compromise.mdx
@@ -88,6 +88,11 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 - [Dependency Attack](/incident-management/incident-response-template/runbooks/dependency-attack)
 - [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
 
+
+## Further Reading
+
+- [Incident Management overview](/incident-management/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/runbooks/build-pipeline-compromise.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/build-pipeline-compromise.mdx
@@ -82,7 +82,7 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 - [ ] Separate build and deploy permissions
 </Checklist>
 
-## Further Reading
+## Further reading
 
 - [Runbooks overview](/incident-management/incident-response-template/runbooks/overview): how the runbooks in this section fit together
 - [Dependency Attack](/incident-management/incident-response-template/runbooks/dependency-attack): the adjacent supply chain scenario

--- a/docs/pages/incident-management/incident-response-template/runbooks/build-pipeline-compromise.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/build-pipeline-compromise.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Runbook: Build Pipeline Compromise | Security Alliance"
-description: "Stub runbook. Customize with your CI/CD platform and procedures."
+description: "Stub runbook. Customize with your CI/CD platform and procedures. A compromised CI/CD path can ship trojans as trusted releases. Freeze pipelines, rotate"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/incident-management/incident-response-template/runbooks/build-pipeline-compromise.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/build-pipeline-compromise.mdx
@@ -82,16 +82,12 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 - [ ] Separate build and deploy permissions
 </Checklist>
 
-## Related
-
-- [Frontend Compromise](/incident-management/incident-response-template/runbooks/frontend-compromise)
-- [Dependency Attack](/incident-management/incident-response-template/runbooks/dependency-attack)
-- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
-
-
 ## Further Reading
 
-- [Incident Management overview](/incident-management/overview)
+- [Runbooks overview](/incident-management/incident-response-template/runbooks/overview): how the runbooks in this section fit together
+- [Dependency Attack](/incident-management/incident-response-template/runbooks/dependency-attack): the adjacent supply chain scenario
+- [CI/CD Security](/devsecops/continuous-integration-continuous-deployment): pipeline controls that prevent this
+- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy): severity levels, roles, and escalation
 
 ---
 

--- a/docs/pages/incident-management/incident-response-template/runbooks/cdn-hosting-compromise.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/cdn-hosting-compromise.mdx
@@ -79,7 +79,7 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 - [ ] Regular access audits
 </Checklist>
 
-## Further Reading
+## Further reading
 
 - [Runbooks overview](/incident-management/incident-response-template/runbooks/overview): how the runbooks in this section fit together
 - [Frontend Compromise](/incident-management/incident-response-template/runbooks/frontend-compromise): the broader scenario this feeds into

--- a/docs/pages/incident-management/incident-response-template/runbooks/cdn-hosting-compromise.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/cdn-hosting-compromise.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Runbook: CDN/Hosting Compromise | Security Alliance"
-description: "Stub runbook. Customize with your CDN and hosting provider details."
+description: "Stub runbook. Customize with your CDN and hosting provider details. Compromised CDN or hosting can serve malicious assets at your legitimate origin."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/incident-management/incident-response-template/runbooks/cdn-hosting-compromise.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/cdn-hosting-compromise.mdx
@@ -84,6 +84,11 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 - [Frontend Compromise](/incident-management/incident-response-template/runbooks/frontend-compromise)
 - [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
 
+
+## Further Reading
+
+- [Incident Management overview](/incident-management/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/runbooks/cdn-hosting-compromise.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/cdn-hosting-compromise.mdx
@@ -8,7 +8,10 @@ tags:
 contributors:
   - role: wrote
     users: [isaac]
-
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../../components'
@@ -18,7 +21,11 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> **Stub runbook.** Customize with your CDN and hosting provider details.
+> 🔑 **Key Takeaway**: Compromised CDN or hosting can serve malicious assets at your
+> legitimate origin. Invalidate caches, rotate credentials, restore known-good builds,
+> and verify integrity of what users fetch.
+
+**Stub runbook.** Customize with your CDN and hosting provider details.
 
 ## Quick Reference
 
@@ -74,7 +81,9 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 ## Related
 
-- [Frontend Compromise](./frontend-compromise)
-- [Incident Response Policy](../incident-response-policy)
+- [Frontend Compromise](/incident-management/incident-response-template/runbooks/frontend-compromise)
+- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
+
+---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/runbooks/cdn-hosting-compromise.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/cdn-hosting-compromise.mdx
@@ -79,15 +79,12 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 - [ ] Regular access audits
 </Checklist>
 
-## Related
-
-- [Frontend Compromise](/incident-management/incident-response-template/runbooks/frontend-compromise)
-- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
-
-
 ## Further Reading
 
-- [Incident Management overview](/incident-management/overview)
+- [Runbooks overview](/incident-management/incident-response-template/runbooks/overview): how the runbooks in this section fit together
+- [Frontend Compromise](/incident-management/incident-response-template/runbooks/frontend-compromise): the broader scenario this feeds into
+- [Web Application Security](/front-end-web-app/web-application-security): hardening the delivery path
+- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy): severity levels, roles, and escalation
 
 ---
 

--- a/docs/pages/incident-management/incident-response-template/runbooks/ddos-attack.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/ddos-attack.mdx
@@ -195,6 +195,11 @@ After resolving, consider:
 - [Frontend Compromise](/incident-management/incident-response-template/runbooks/frontend-compromise)
 - [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
 
+
+## Further Reading
+
+- [Incident Management overview](/incident-management/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/runbooks/ddos-attack.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/ddos-attack.mdx
@@ -189,7 +189,7 @@ After resolving, consider:
 - [ ] Backup/failover infrastructure
 </Checklist>
 
-## Further Reading
+## Further reading
 
 - [Runbooks overview](/incident-management/incident-response-template/runbooks/overview): how the runbooks in this section fit together
 - [Third-Party Outage](/incident-management/incident-response-template/runbooks/third-party-outage): the adjacent availability scenario

--- a/docs/pages/incident-management/incident-response-template/runbooks/ddos-attack.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/ddos-attack.mdx
@@ -164,7 +164,7 @@ For AWS:
 - [ ] Consider permanent mitigations
 </Checklist>
 
-## Communication
+### Communication
 
 ### Internal
 
@@ -177,7 +177,7 @@ For AWS:
 
 Usually not needed for brief DDoS attacks. Avoid drawing attention.
 
-## Prevention
+### Prevention
 
 After resolving, consider:
 
@@ -189,7 +189,7 @@ After resolving, consider:
 - [ ] Backup/failover infrastructure
 </Checklist>
 
-## Related
+### Related
 
 - [Third-Party Outage](/incident-management/incident-response-template/runbooks/third-party-outage)
 - [Frontend Compromise](/incident-management/incident-response-template/runbooks/frontend-compromise)

--- a/docs/pages/incident-management/incident-response-template/runbooks/ddos-attack.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/ddos-attack.mdx
@@ -164,7 +164,7 @@ For AWS:
 - [ ] Consider permanent mitigations
 </Checklist>
 
-### Communication
+## Communication
 
 ### Internal
 
@@ -177,7 +177,7 @@ For AWS:
 
 Usually not needed for brief DDoS attacks. Avoid drawing attention.
 
-### Prevention
+## Prevention
 
 After resolving, consider:
 
@@ -189,16 +189,12 @@ After resolving, consider:
 - [ ] Backup/failover infrastructure
 </Checklist>
 
-### Related
-
-- [Third-Party Outage](/incident-management/incident-response-template/runbooks/third-party-outage)
-- [Frontend Compromise](/incident-management/incident-response-template/runbooks/frontend-compromise)
-- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
-
-
 ## Further Reading
 
-- [Incident Management overview](/incident-management/overview)
+- [Runbooks overview](/incident-management/incident-response-template/runbooks/overview): how the runbooks in this section fit together
+- [Third-Party Outage](/incident-management/incident-response-template/runbooks/third-party-outage): the adjacent availability scenario
+- [DDoS Protection](/infrastructure/ddos-protection): controls to have in place beforehand
+- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy): severity levels, roles, and escalation
 
 ---
 

--- a/docs/pages/incident-management/incident-response-template/runbooks/ddos-attack.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/ddos-attack.mdx
@@ -8,7 +8,10 @@ tags:
 contributors:
   - role: wrote
     users: [isaac]
-
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../../components'
@@ -18,8 +21,11 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> **This is an example runbook.** Review and customize for your protocol before use. Add your specific CDN/WAF
-> provider commands and escalation contacts.
+> 🔑 **Key Takeaway**: Under DDoS, engage your CDN/WAF play, protect origin capacity, and
+> separate availability response from security compromise until evidence says otherwise.
+
+**This is an example runbook.** Review and customize for your protocol before use. Add your specific
+CDN/WAF provider commands and escalation contacts.
 
 ## Quick Reference
 
@@ -134,8 +140,10 @@ For AWS:
 ## Escalation
 
 <Checklist id="escalation">
-- [ ] [CDN/hosting provider](../contacts#infrastructure-vendors) - for attack mitigation support
-- [ ] [Decision Makers](../contacts#decision-makers) - if extended outage
+- [ ] [CDN/hosting
+      provider](/incident-management/incident-response-template/contacts#infrastructure-vendors) -
+      for attack mitigation support
+- [ ] [Decision Makers](/incident-management/incident-response-template/contacts#decision-makers) - if extended outage
 </Checklist>
 
 ## Recovery
@@ -183,8 +191,10 @@ After resolving, consider:
 
 ## Related
 
-- [Third-Party Outage](./third-party-outage)
-- [Frontend Compromise](./frontend-compromise)
-- [Incident Response Policy](../incident-response-policy)
+- [Third-Party Outage](/incident-management/incident-response-template/runbooks/third-party-outage)
+- [Frontend Compromise](/incident-management/incident-response-template/runbooks/frontend-compromise)
+- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
+
+---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/runbooks/dependency-attack.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/dependency-attack.mdx
@@ -8,7 +8,10 @@ tags:
 contributors:
   - role: wrote
     users: [isaac]
-
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../../components'
@@ -18,7 +21,11 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> **Stub runbook.** Customize with your package management and build procedures.
+> 🔑 **Key Takeaway**: Malicious package updates poison builds and frontends. Pin and
+> verify dependencies, revoke tainted artifacts, rotate exposed secrets, and rebuild
+> from known-good sources.
+
+**Stub runbook.** Customize with your package management and build procedures.
 
 ## Quick Reference
 
@@ -81,8 +88,10 @@ Check for recent lockfile changes in git history.
 
 ## Related
 
-- [Frontend Compromise](./frontend-compromise)
-- [Build Pipeline Compromise](./build-pipeline-compromise)
-- [Incident Response Policy](../incident-response-policy)
+- [Frontend Compromise](/incident-management/incident-response-template/runbooks/frontend-compromise)
+- [Build Pipeline Compromise](/incident-management/incident-response-template/runbooks/build-pipeline-compromise)
+- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
+
+---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/runbooks/dependency-attack.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/dependency-attack.mdx
@@ -86,7 +86,7 @@ Check for recent lockfile changes in git history.
 - [ ] Review dependency changes in PRs
 </Checklist>
 
-## Further Reading
+## Further reading
 
 - [Runbooks overview](/incident-management/incident-response-template/runbooks/overview): how the runbooks in this section fit together
 - [Build Pipeline Compromise](/incident-management/incident-response-template/runbooks/build-pipeline-compromise): the adjacent scenario upstream

--- a/docs/pages/incident-management/incident-response-template/runbooks/dependency-attack.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/dependency-attack.mdx
@@ -86,16 +86,12 @@ Check for recent lockfile changes in git history.
 - [ ] Review dependency changes in PRs
 </Checklist>
 
-## Related
-
-- [Frontend Compromise](/incident-management/incident-response-template/runbooks/frontend-compromise)
-- [Build Pipeline Compromise](/incident-management/incident-response-template/runbooks/build-pipeline-compromise)
-- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
-
-
 ## Further Reading
 
-- [Incident Management overview](/incident-management/overview)
+- [Runbooks overview](/incident-management/incident-response-template/runbooks/overview): how the runbooks in this section fit together
+- [Build Pipeline Compromise](/incident-management/incident-response-template/runbooks/build-pipeline-compromise): the adjacent scenario upstream
+- [Frontend Compromise](/incident-management/incident-response-template/runbooks/frontend-compromise): where a poisoned dependency usually surfaces
+- [Supply Chain](/supply-chain/overview): prevention side of the same risk
 
 ---
 

--- a/docs/pages/incident-management/incident-response-template/runbooks/dependency-attack.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/dependency-attack.mdx
@@ -51,7 +51,7 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 ```
 npm audit
-# or
+ # or
 yarn audit
 ```
 

--- a/docs/pages/incident-management/incident-response-template/runbooks/dependency-attack.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/dependency-attack.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Runbook: Dependency Attack | Security Alliance"
-description: "Stub runbook. Customize with your package management and build procedures."
+description: "Stub runbook. Customize with your package management and build procedures. Pin and verify dependencies, revoke tainted artifacts, rotate exposed secrets"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/incident-management/incident-response-template/runbooks/dependency-attack.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/dependency-attack.mdx
@@ -92,6 +92,11 @@ Check for recent lockfile changes in git history.
 - [Build Pipeline Compromise](/incident-management/incident-response-template/runbooks/build-pipeline-compromise)
 - [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
 
+
+## Further Reading
+
+- [Incident Management overview](/incident-management/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/runbooks/dns-hijack.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/dns-hijack.mdx
@@ -8,7 +8,10 @@ tags:
 contributors:
   - role: wrote
     users: [isaac]
-
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../../components'
@@ -18,7 +21,11 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> **Stub runbook.** Customize with your DNS provider details and procedures.
+> 🔑 **Key Takeaway**: DNS hijacks redirect users to attacker infrastructure. Lock
+> registrar controls, restore authoritative records, force cache abandonment, and verify
+> resolution from multiple resolvers.
+
+**Stub runbook.** Customize with your DNS provider details and procedures.
 
 ## Quick Reference
 
@@ -71,7 +78,9 @@ dig yourdomain.com
 
 ## Related
 
-- [Frontend Compromise](./frontend-compromise)
-- [Incident Response Policy](../incident-response-policy)
+- [Frontend Compromise](/incident-management/incident-response-template/runbooks/frontend-compromise)
+- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
+
+---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/runbooks/dns-hijack.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/dns-hijack.mdx
@@ -50,7 +50,7 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 ```
 dig yourdomain.com
- # Compare output to expected IP
+# Compare output to expected IP
 ```
 
 ## Immediate Actions

--- a/docs/pages/incident-management/incident-response-template/runbooks/dns-hijack.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/dns-hijack.mdx
@@ -50,7 +50,7 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 ```
 dig yourdomain.com
-# Compare output to expected IP
+ # Compare output to expected IP
 ```
 
 ## Immediate Actions

--- a/docs/pages/incident-management/incident-response-template/runbooks/dns-hijack.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/dns-hijack.mdx
@@ -76,7 +76,7 @@ dig yourdomain.com
 - [ ] Monitor DNS records for changes
 </Checklist>
 
-## Further Reading
+## Further reading
 
 - [Runbooks overview](/incident-management/incident-response-template/runbooks/overview): how the runbooks in this section fit together
 - [Frontend Compromise](/incident-management/incident-response-template/runbooks/frontend-compromise): what users see when DNS is redirected

--- a/docs/pages/incident-management/incident-response-template/runbooks/dns-hijack.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/dns-hijack.mdx
@@ -76,15 +76,12 @@ dig yourdomain.com
 - [ ] Monitor DNS records for changes
 </Checklist>
 
-## Related
-
-- [Frontend Compromise](/incident-management/incident-response-template/runbooks/frontend-compromise)
-- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
-
-
 ## Further Reading
 
-- [Incident Management overview](/incident-management/overview)
+- [Runbooks overview](/incident-management/incident-response-template/runbooks/overview): how the runbooks in this section fit together
+- [Frontend Compromise](/incident-management/incident-response-template/runbooks/frontend-compromise): what users see when DNS is redirected
+- [Domain & DNS Security](/infrastructure/domain-and-dns-security/overview): registrar and record controls that prevent this
+- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy): severity levels, roles, and escalation
 
 ---
 

--- a/docs/pages/incident-management/incident-response-template/runbooks/dns-hijack.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/dns-hijack.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Runbook: DNS Hijack | Security Alliance"
-description: "Stub runbook. Customize with your DNS provider details and procedures."
+description: "Stub runbook. Customize with your DNS provider details and procedures. Lock registrar controls, restore authoritative records, force cache abandonment"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/incident-management/incident-response-template/runbooks/dns-hijack.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/dns-hijack.mdx
@@ -81,6 +81,11 @@ dig yourdomain.com
 - [Frontend Compromise](/incident-management/incident-response-template/runbooks/frontend-compromise)
 - [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
 
+
+## Further Reading
+
+- [Incident Management overview](/incident-management/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/runbooks/frontend-compromise.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/frontend-compromise.mdx
@@ -210,6 +210,11 @@ After resolving, review:
 - [Third-Party Outage](/incident-management/incident-response-template/runbooks/third-party-outage)
 - [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
 
+
+## Further Reading
+
+- [Incident Management overview](/incident-management/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/runbooks/frontend-compromise.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/frontend-compromise.mdx
@@ -200,7 +200,7 @@ After resolving, review:
 - [ ] Content Security Policy
 </Checklist>
 
-## Further Reading
+## Further reading
 
 - [Runbooks overview](/incident-management/incident-response-template/runbooks/overview): how the runbooks in this section fit together
 - [DNS Hijack](/incident-management/incident-response-template/runbooks/dns-hijack): one of the common root causes

--- a/docs/pages/incident-management/incident-response-template/runbooks/frontend-compromise.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/frontend-compromise.mdx
@@ -175,7 +175,7 @@ If users signed malicious transactions:
 - [ ] Document for post-mortem
 </Checklist>
 
-## Escalation
+### Escalation
 
 <Checklist id="escalation">
 - [ ] [Decision Makers](/incident-management/incident-response-template/contacts#decision-makers) - immediately
@@ -187,7 +187,7 @@ If users signed malicious transactions:
       - for user communication
 </Checklist>
 
-## Prevention Checklist
+### Prevention Checklist
 
 After resolving, review:
 
@@ -200,7 +200,7 @@ After resolving, review:
 - [ ] Content Security Policy
 </Checklist>
 
-## Related
+### Related
 
 - [DNS Hijack](/incident-management/incident-response-template/runbooks/dns-hijack)
 - [CDN/Hosting Compromise](/incident-management/incident-response-template/runbooks/cdn-hosting-compromise)

--- a/docs/pages/incident-management/incident-response-template/runbooks/frontend-compromise.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/frontend-compromise.mdx
@@ -175,7 +175,7 @@ If users signed malicious transactions:
 - [ ] Document for post-mortem
 </Checklist>
 
-### Escalation
+## Escalation
 
 <Checklist id="escalation">
 - [ ] [Decision Makers](/incident-management/incident-response-template/contacts#decision-makers) - immediately
@@ -187,7 +187,7 @@ If users signed malicious transactions:
       - for user communication
 </Checklist>
 
-### Prevention Checklist
+## Prevention Checklist
 
 After resolving, review:
 
@@ -200,20 +200,12 @@ After resolving, review:
 - [ ] Content Security Policy
 </Checklist>
 
-### Related
-
-- [DNS Hijack](/incident-management/incident-response-template/runbooks/dns-hijack)
-- [CDN/Hosting Compromise](/incident-management/incident-response-template/runbooks/cdn-hosting-compromise)
-- [Dependency Attack](/incident-management/incident-response-template/runbooks/dependency-attack)
-- [Build Pipeline Compromise](/incident-management/incident-response-template/runbooks/build-pipeline-compromise)
-- [DDoS Attack](/incident-management/incident-response-template/runbooks/ddos-attack)
-- [Third-Party Outage](/incident-management/incident-response-template/runbooks/third-party-outage)
-- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
-
-
 ## Further Reading
 
-- [Incident Management overview](/incident-management/overview)
+- [Runbooks overview](/incident-management/incident-response-template/runbooks/overview): how the runbooks in this section fit together
+- [DNS Hijack](/incident-management/incident-response-template/runbooks/dns-hijack): one of the common root causes
+- [CDN/Hosting Compromise](/incident-management/incident-response-template/runbooks/cdn-hosting-compromise): another common root cause
+- [Web Application Security](/front-end-web-app/web-application-security): hardening the app itself
 
 ---
 

--- a/docs/pages/incident-management/incident-response-template/runbooks/frontend-compromise.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/frontend-compromise.mdx
@@ -8,7 +8,10 @@ tags:
 contributors:
   - role: wrote
     users: [isaac]
-
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../../components'
@@ -18,8 +21,12 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> **This is an example runbook.** Review and customize for your protocol before use. Add your specific DNS
-> provider, hosting platform, and deployment procedures.
+> 🔑 **Key Takeaway**: Treat a compromised UI as a user-fund risk path. Restrict traffic,
+> identify the vector (DNS, CDN, dependency, or pipeline), and route into the matching
+> specialized runbook.
+
+**This is an example runbook.** Review and customize for your protocol before use. Add your specific
+DNS provider, hosting platform, and deployment procedures.
 
 ## Quick Reference
 
@@ -103,10 +110,10 @@ The first priority is understanding how the attacker gained access so you can cl
 
 Once identified, go to the specific runbook:
 
-- DNS hijack → [DNS Hijack](./dns-hijack)
-- CDN/hosting compromise → [CDN/Hosting Compromise](./cdn-hosting-compromise)
-- Dependency attack → [Dependency Attack](./dependency-attack)
-- Build pipeline compromise → [Build Pipeline Compromise](./build-pipeline-compromise)
+- DNS hijack → [DNS Hijack](/incident-management/incident-response-template/runbooks/dns-hijack)
+- CDN/hosting compromise → [CDN/Hosting Compromise](/incident-management/incident-response-template/runbooks/cdn-hosting-compromise)
+- Dependency attack → [Dependency Attack](/incident-management/incident-response-template/runbooks/dependency-attack)
+- Build pipeline compromise → [Build Pipeline Compromise](/incident-management/incident-response-template/runbooks/build-pipeline-compromise)
 
 ### Post-Mitigation Investigation
 
@@ -132,10 +139,10 @@ After the threat is contained, investigate impact:
 
 See the specific runbook for detailed mitigation steps:
 
-- [DNS Hijack](./dns-hijack)
-- [CDN/Hosting Compromise](./cdn-hosting-compromise)
-- [Dependency Attack](./dependency-attack)
-- [Build Pipeline Compromise](./build-pipeline-compromise)
+- [DNS Hijack](/incident-management/incident-response-template/runbooks/dns-hijack)
+- [CDN/Hosting Compromise](/incident-management/incident-response-template/runbooks/cdn-hosting-compromise)
+- [Dependency Attack](/incident-management/incident-response-template/runbooks/dependency-attack)
+- [Build Pipeline Compromise](/incident-management/incident-response-template/runbooks/build-pipeline-compromise)
 
 ## Recovery
 
@@ -171,9 +178,13 @@ If users signed malicious transactions:
 ## Escalation
 
 <Checklist id="escalation">
-- [ ] [Decision Makers](../contacts#decision-makers) - immediately
-- [ ] [Infrastructure Vendors](../contacts#infrastructure-vendors) - if hosting/CDN involved
-- [ ] [Legal & Communications](../contacts#legal--communications) - for user communication
+- [ ] [Decision Makers](/incident-management/incident-response-template/contacts#decision-makers) - immediately
+- [ ] [Infrastructure
+      Vendors](/incident-management/incident-response-template/contacts#infrastructure-vendors) - if
+      hosting/CDN involved
+- [ ] [Legal &
+      Communications](/incident-management/incident-response-template/contacts#legal--communications)
+      - for user communication
 </Checklist>
 
 ## Prevention Checklist
@@ -191,12 +202,14 @@ After resolving, review:
 
 ## Related
 
-- [DNS Hijack](./dns-hijack)
-- [CDN/Hosting Compromise](./cdn-hosting-compromise)
-- [Dependency Attack](./dependency-attack)
-- [Build Pipeline Compromise](./build-pipeline-compromise)
-- [DDoS Attack](./ddos-attack)
-- [Third-Party Outage](./third-party-outage)
-- [Incident Response Policy](../incident-response-policy)
+- [DNS Hijack](/incident-management/incident-response-template/runbooks/dns-hijack)
+- [CDN/Hosting Compromise](/incident-management/incident-response-template/runbooks/cdn-hosting-compromise)
+- [Dependency Attack](/incident-management/incident-response-template/runbooks/dependency-attack)
+- [Build Pipeline Compromise](/incident-management/incident-response-template/runbooks/build-pipeline-compromise)
+- [DDoS Attack](/incident-management/incident-response-template/runbooks/ddos-attack)
+- [Third-Party Outage](/incident-management/incident-response-template/runbooks/third-party-outage)
+- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
+
+---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/runbooks/key-compromise.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/key-compromise.mdx
@@ -182,7 +182,7 @@ After resolving, review:
 - [ ] Key rotation schedule
 </Checklist>
 
-## Further Reading
+## Further reading
 
 - [Runbooks overview](/incident-management/incident-response-template/runbooks/overview): how the runbooks in this section fit together
 - [Smart Contract Exploit](/incident-management/incident-response-template/runbooks/smart-contract-exploit): the follow-on scenario when keys hold admin roles

--- a/docs/pages/incident-management/incident-response-template/runbooks/key-compromise.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/key-compromise.mdx
@@ -187,6 +187,11 @@ After resolving, review:
 - [Smart Contract Exploit](/incident-management/incident-response-template/runbooks/smart-contract-exploit)
 - [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
 
+
+## Further Reading
+
+- [Incident Management overview](/incident-management/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/runbooks/key-compromise.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/key-compromise.mdx
@@ -182,15 +182,12 @@ After resolving, review:
 - [ ] Key rotation schedule
 </Checklist>
 
-### Related
-
-- [Smart Contract Exploit](/incident-management/incident-response-template/runbooks/smart-contract-exploit)
-- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
-
-
 ## Further Reading
 
-- [Incident Management overview](/incident-management/overview)
+- [Runbooks overview](/incident-management/incident-response-template/runbooks/overview): how the runbooks in this section fit together
+- [Smart Contract Exploit](/incident-management/incident-response-template/runbooks/smart-contract-exploit): the follow-on scenario when keys hold admin roles
+- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy): severity levels, roles, and escalation
+- [Seed Phrase Management](/wallet-security/seed-phrase-management): key custody practice that limits exposure
 
 ---
 

--- a/docs/pages/incident-management/incident-response-template/runbooks/key-compromise.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/key-compromise.mdx
@@ -8,7 +8,10 @@ tags:
 contributors:
   - role: wrote
     users: [isaac]
-
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../../components'
@@ -18,8 +21,12 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> **This is an example runbook.** Review and customize for your protocol before use. Fill in your key types, what
-> each controls, and your specific rotation procedures.
+> 🔑 **Key Takeaway**: On suspected key or signer compromise, inventory what the key
+> controls, revoke and rotate fast, and assess blast radius before declaring the
+> environment clean.
+
+**This is an example runbook.** Review and customize for your protocol before use. Fill in your key
+types, what each controls, and your specific rotation procedures.
 
 ## Quick Reference
 
@@ -154,9 +161,12 @@ For hot wallets:
 ## Escalation
 
 <Checklist id="escalation">
-- [ ] [Decision Makers](../contacts#decision-makers) - immediately for any confirmed compromise
-- [ ] [Security Partners](../contacts#security-partners) - for investigation support
-- [ ] [Legal](../contacts#legal--communications) - if funds were stolen
+- [ ] [Decision Makers](/incident-management/incident-response-template/contacts#decision-makers) -
+      immediately for any confirmed compromise
+- [ ] [Security
+      Partners](/incident-management/incident-response-template/contacts#security-partners) - for
+      investigation support
+- [ ] [Legal](/incident-management/incident-response-template/contacts#legal--communications) - if funds were stolen
 </Checklist>
 
 ## Prevention Checklist
@@ -174,7 +184,9 @@ After resolving, review:
 
 ## Related
 
-- [Smart Contract Exploit](./smart-contract-exploit)
-- [Incident Response Policy](../incident-response-policy)
+- [Smart Contract Exploit](/incident-management/incident-response-template/runbooks/smart-contract-exploit)
+- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
+
+---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/runbooks/key-compromise.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/key-compromise.mdx
@@ -182,7 +182,7 @@ After resolving, review:
 - [ ] Key rotation schedule
 </Checklist>
 
-## Related
+### Related
 
 - [Smart Contract Exploit](/incident-management/incident-response-template/runbooks/smart-contract-exploit)
 - [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)

--- a/docs/pages/incident-management/incident-response-template/runbooks/overview.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/overview.mdx
@@ -87,7 +87,7 @@ See
 [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
 for the overall response process.
 
-## Further Reading
+## Further reading
 
 - [Incident Response Template overview](/incident-management/incident-response-template/overview): how the template pieces fit together
 - [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy): severity levels, roles, and escalation

--- a/docs/pages/incident-management/incident-response-template/runbooks/overview.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/overview.mdx
@@ -87,10 +87,12 @@ See
 [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
 for the overall response process.
 
-
 ## Further Reading
 
-- [Incident Management overview](/incident-management/overview)
+- [Incident Response Template overview](/incident-management/incident-response-template/overview): how the template pieces fit together
+- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy): severity levels, roles, and escalation
+- [Runbook Template](/incident-management/incident-response-template/templates/runbook-template): the blank structure for writing your own
+- [Incident Management overview](/incident-management/overview): how the pages of this framework fit together
 
 ---
 

--- a/docs/pages/incident-management/incident-response-template/runbooks/overview.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/overview.mdx
@@ -8,7 +8,10 @@ tags:
 contributors:
   - role: wrote
     users: [isaac]
-
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../../components'
@@ -17,6 +20,9 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Runbooks cut cognitive load during active incidents. Customize every
+> command and contact for your stack; untested generic runbooks can be worse than none.
 
 Step-by-step guides for specific incident types. Use these during active incidents to reduce cognitive load and
 ensure consistent response.
@@ -30,22 +36,33 @@ ensure consistent response.
 
 ### Critical (P1)
 
-- [Smart Contract Exploit](./smart-contract-exploit) - Active exploit or critical vulnerability
-- [Key Compromise](./key-compromise) - Private key or signer compromise
-- [Frontend Compromise](./frontend-compromise) - Website/UI compromise (routes to specific runbooks below)
-  - [DNS Hijack](./dns-hijack) - Domain/DNS compromise
-  - [CDN/Hosting Compromise](./cdn-hosting-compromise) - CDN or hosting provider compromise
-  - [Dependency Attack](./dependency-attack) - npm/package supply chain attack
-  - [Build Pipeline Compromise](./build-pipeline-compromise) - CI/CD compromise
+1. [Smart Contract Exploit](/incident-management/incident-response-template/runbooks/smart-contract-exploit):
+   active exploit or critical vulnerability.
+2. [Key Compromise](/incident-management/incident-response-template/runbooks/key-compromise): private
+   key or signer compromise.
+3. [Frontend Compromise](/incident-management/incident-response-template/runbooks/frontend-compromise):
+   website/UI compromise (routes to specialized runbooks below).
+4. [DNS Hijack](/incident-management/incident-response-template/runbooks/dns-hijack): domain/DNS
+   compromise.
+5. [CDN/Hosting Compromise](/incident-management/incident-response-template/runbooks/cdn-hosting-compromise):
+   CDN or hosting provider compromise.
+6. [Dependency Attack](/incident-management/incident-response-template/runbooks/dependency-attack):
+   npm/package supply chain attack.
+7. [Build Pipeline Compromise](/incident-management/incident-response-template/runbooks/build-pipeline-compromise):
+   CI/CD compromise.
 
 ### High/Moderate (P2-P3)
 
-- [DDoS Attack](./ddos-attack) - Denial of service attacks
-- [Third-Party Outage](./third-party-outage) - External provider issues
+1. [DDoS Attack](/incident-management/incident-response-template/runbooks/ddos-attack): denial of
+   service attacks.
+2. [Third-Party Outage](/incident-management/incident-response-template/runbooks/third-party-outage):
+   external provider issues.
 
 ## Creating New Runbooks
 
-Use [Runbook Template](../templates/runbook-template) as your starting point.
+Use
+[Runbook Template](/incident-management/incident-response-template/templates/runbook-template) as
+your starting point.
 
 Good runbooks:
 
@@ -66,6 +83,10 @@ Consider creating runbooks for:
 - [ ] Data inconsistency
 </Checklist>
 
-*See [Incident Response Policy](../incident-response-policy) for the overall response process.*
+See
+[Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
+for the overall response process.
+
+---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/runbooks/overview.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/overview.mdx
@@ -32,7 +32,7 @@ ensure consistent response.
 > and procedures before relying on them during an actual incident. Untested runbooks can be worse than no runbook
 > at all.
 
-## Available Runbooks
+## What this framework covers
 
 ### Critical (P1)
 

--- a/docs/pages/incident-management/incident-response-template/runbooks/overview.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/overview.mdx
@@ -87,6 +87,11 @@ See
 [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
 for the overall response process.
 
+
+## Further Reading
+
+- [Incident Management overview](/incident-management/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/runbooks/smart-contract-exploit.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/smart-contract-exploit.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Runbook: Smart Contract Exploit | Security Alliance"
-description: "This is an example runbook. Review and customize for your protocol before use. Fill in the placeholder commands, add your specific contracts and addresses, and test during a tabletop exercise."
+description: "This is an example runbook. Review and customize for your protocol before use. Fill in the placeholder commands, add your specific contracts and addresses"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/incident-management/incident-response-template/runbooks/smart-contract-exploit.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/smart-contract-exploit.mdx
@@ -185,6 +185,11 @@ Contact immediately:
 - [Key Compromise](/incident-management/incident-response-template/runbooks/key-compromise)
 - [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
 
+
+## Further Reading
+
+- [Incident Management overview](/incident-management/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/runbooks/smart-contract-exploit.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/smart-contract-exploit.mdx
@@ -172,7 +172,7 @@ Contact immediately:
 - [ ] Engage with law enforcement if appropriate
 </Checklist>
 
-## Common Root Causes
+### Common Root Causes
 
 | Cause | Signs | Prevention |
 | ------- | ------- | ------------ |
@@ -180,7 +180,7 @@ Contact immediately:
 | Access control | Unauthorized caller | Proper modifiers |
 | Oracle manipulation | Price deviation before exploit | TWAP, multiple sources |
 
-## Related
+### Related
 
 - [Key Compromise](/incident-management/incident-response-template/runbooks/key-compromise)
 - [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)

--- a/docs/pages/incident-management/incident-response-template/runbooks/smart-contract-exploit.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/smart-contract-exploit.mdx
@@ -8,7 +8,10 @@ tags:
 contributors:
   - role: wrote
     users: [isaac]
-
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../../components'
@@ -18,8 +21,13 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> **This is an example runbook.** Review and customize for your protocol before use. Fill in the placeholder
-> commands, add your specific contracts and addresses, and test during a tabletop exercise.
+> 🔑 **Key Takeaway**: For active smart-contract exploits, confirm scope, pause or contain
+> if possible, preserve evidence, and coordinate recovery using your protocol-specific
+> commands—not the placeholders in this example.
+
+**This is an example runbook.** Review and customize for your protocol before use. Fill in the
+placeholder commands, add your specific contracts and addresses, and test during a tabletop
+exercise.
 
 ## Quick Reference
 
@@ -69,7 +77,7 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 **Why:** Get immediate expert support for active exploits
 
-See [SEAL 911](../contacts#seal-911)
+See [SEAL 911](/incident-management/incident-response-template/contacts#seal-911)
 
 ### Step 3: Pause if Possible
 
@@ -149,9 +157,9 @@ If your contracts have pause functionality:
 Contact immediately:
 
 <Checklist id="escalation">
-- [ ] [Decision Makers](../contacts#decision-makers)
-- [ ] [Security Partners](../contacts#security-partners)
-- [ ] [Legal](../contacts#legal--communications) if significant fund loss
+- [ ] [Decision Makers](/incident-management/incident-response-template/contacts#decision-makers)
+- [ ] [Security Partners](/incident-management/incident-response-template/contacts#security-partners)
+- [ ] [Legal](/incident-management/incident-response-template/contacts#legal--communications) if significant fund loss
 </Checklist>
 
 ## Post-Exploit
@@ -174,7 +182,9 @@ Contact immediately:
 
 ## Related
 
-- [Key Compromise](./key-compromise)
-- [Incident Response Policy](../incident-response-policy)
+- [Key Compromise](/incident-management/incident-response-template/runbooks/key-compromise)
+- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
+
+---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/runbooks/smart-contract-exploit.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/smart-contract-exploit.mdx
@@ -180,7 +180,7 @@ Contact immediately:
 | Access control | Unauthorized caller | Proper modifiers |
 | Oracle manipulation | Price deviation before exploit | TWAP, multiple sources |
 
-## Further Reading
+## Further reading
 
 - [Runbooks overview](/incident-management/incident-response-template/runbooks/overview): how the runbooks in this section fit together
 - [Key Compromise](/incident-management/incident-response-template/runbooks/key-compromise): the adjacent scenario when admin keys are involved

--- a/docs/pages/incident-management/incident-response-template/runbooks/smart-contract-exploit.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/smart-contract-exploit.mdx
@@ -180,15 +180,12 @@ Contact immediately:
 | Access control | Unauthorized caller | Proper modifiers |
 | Oracle manipulation | Price deviation before exploit | TWAP, multiple sources |
 
-### Related
-
-- [Key Compromise](/incident-management/incident-response-template/runbooks/key-compromise)
-- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
-
-
 ## Further Reading
 
-- [Incident Management overview](/incident-management/overview)
+- [Runbooks overview](/incident-management/incident-response-template/runbooks/overview): how the runbooks in this section fit together
+- [Key Compromise](/incident-management/incident-response-template/runbooks/key-compromise): the adjacent scenario when admin keys are involved
+- [Safe Harbor](/safe-harbor/overview): the whitehat rescue framework during an active exploit
+- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy): severity levels, roles, and escalation
 
 ---
 

--- a/docs/pages/incident-management/incident-response-template/runbooks/third-party-outage.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/third-party-outage.mdx
@@ -167,7 +167,7 @@ Include:
 - [ ] Consider SLA review with provider
 </Checklist>
 
-### Escalation
+## Escalation
 
 <Checklist id="escalation">
 - [ ] [Infrastructure
@@ -177,7 +177,7 @@ Include:
       if extended outage or no ETA
 </Checklist>
 
-### Prevention
+## Prevention
 
 Reduce third-party dependency risk:
 
@@ -190,22 +190,19 @@ Reduce third-party dependency risk:
 - [ ] Regular dependency review
 </Checklist>
 
-### Provider Contacts
+## Provider Contacts
 
 | Provider | Status Page | Support Contact |
 | --- | --- | --- |
 | | | |
 | | | |
 
-### Related
-
-- [DDoS Attack](/incident-management/incident-response-template/runbooks/ddos-attack)
-- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
-
-
 ## Further Reading
 
-- [Incident Management overview](/incident-management/overview)
+- [Runbooks overview](/incident-management/incident-response-template/runbooks/overview): how the runbooks in this section fit together
+- [DDoS Attack](/incident-management/incident-response-template/runbooks/ddos-attack): the adjacent availability scenario
+- [Vendor Risk Management](/supply-chain/vendor-risk-management): assessing dependencies before they fail
+- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy): severity levels, roles, and escalation
 
 ---
 

--- a/docs/pages/incident-management/incident-response-template/runbooks/third-party-outage.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/third-party-outage.mdx
@@ -202,6 +202,11 @@ Reduce third-party dependency risk:
 - [DDoS Attack](/incident-management/incident-response-template/runbooks/ddos-attack)
 - [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
 
+
+## Further Reading
+
+- [Incident Management overview](/incident-management/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/runbooks/third-party-outage.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/third-party-outage.mdx
@@ -167,7 +167,7 @@ Include:
 - [ ] Consider SLA review with provider
 </Checklist>
 
-## Escalation
+### Escalation
 
 <Checklist id="escalation">
 - [ ] [Infrastructure
@@ -177,7 +177,7 @@ Include:
       if extended outage or no ETA
 </Checklist>
 
-## Prevention
+### Prevention
 
 Reduce third-party dependency risk:
 
@@ -190,14 +190,14 @@ Reduce third-party dependency risk:
 - [ ] Regular dependency review
 </Checklist>
 
-## Provider Contacts
+### Provider Contacts
 
 | Provider | Status Page | Support Contact |
 | --- | --- | --- |
 | | | |
 | | | |
 
-## Related
+### Related
 
 - [DDoS Attack](/incident-management/incident-response-template/runbooks/ddos-attack)
 - [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)

--- a/docs/pages/incident-management/incident-response-template/runbooks/third-party-outage.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/third-party-outage.mdx
@@ -8,7 +8,10 @@ tags:
 contributors:
   - role: wrote
     users: [isaac]
-
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../../components'
@@ -18,8 +21,12 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> **This is an example runbook.** Review and customize for your protocol before use. Fill in your specific vendors,
-> dependencies, and failover procedures.
+> 🔑 **Key Takeaway**: Vendor outages cascade into protocol impact. Identify the
+> dependency, fail over if ready, communicate status honestly, and track vendor
+> remediation without pretending you control their systems.
+
+**This is an example runbook.** Review and customize for your protocol before use. Fill in your
+specific vendors, dependencies, and failover procedures.
 
 ## Quick Reference
 
@@ -163,8 +170,11 @@ Include:
 ## Escalation
 
 <Checklist id="escalation">
-- [ ] [Infrastructure Vendors](../contacts#infrastructure-vendors) - contact provider support
-- [ ] [Decision Makers](../contacts#decision-makers) - if extended outage or no ETA
+- [ ] [Infrastructure
+      Vendors](/incident-management/incident-response-template/contacts#infrastructure-vendors) -
+      contact provider support
+- [ ] [Decision Makers](/incident-management/incident-response-template/contacts#decision-makers) -
+      if extended outage or no ETA
 </Checklist>
 
 ## Prevention
@@ -189,7 +199,9 @@ Reduce third-party dependency risk:
 
 ## Related
 
-- [DDoS Attack](./ddos-attack)
-- [Incident Response Policy](../incident-response-policy)
+- [DDoS Attack](/incident-management/incident-response-template/runbooks/ddos-attack)
+- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
+
+---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/runbooks/third-party-outage.mdx
+++ b/docs/pages/incident-management/incident-response-template/runbooks/third-party-outage.mdx
@@ -197,7 +197,7 @@ Reduce third-party dependency risk:
 | | | |
 | | | |
 
-## Further Reading
+## Further reading
 
 - [Runbooks overview](/incident-management/incident-response-template/runbooks/overview): how the runbooks in this section fit together
 - [DDoS Attack](/incident-management/incident-response-template/runbooks/ddos-attack): the adjacent availability scenario

--- a/docs/pages/incident-management/incident-response-template/templates/example-incident-log.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/example-incident-log.mdx
@@ -8,7 +8,10 @@ tags:
 contributors:
   - role: wrote
     users: [hexnickk4997, n0guest]
-
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../../components'
@@ -18,7 +21,12 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../../compo
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> **This is an example incident log.** Delete this file or use it as reference when creating real incident logs.
+> 🔑 **Key Takeaway**: Use this filled API-outage log as a format reference only. Replace
+> it with real incident records; never treat sample commands or timelines as operational
+> truth.
+
+**This is an example incident log.** Delete this file or use it as reference when creating real
+incident logs.
 
 ## Summary
 
@@ -124,7 +132,7 @@ Rolled back rate limiter configuration to previous known-good version.
 ## Post-Incident
 
 - [x] Post-mortem scheduled for: 2024-01-17 15:00 UTC
-- [x] [Post-mortem document](./example-post-mortem) created
+- [x] [Post-mortem document](/incident-management/incident-response-template/templates/example-post-mortem) created
 - [ ] Action items assigned (pending post-mortem)
 
 ## Links & Evidence
@@ -133,6 +141,8 @@ Rolled back rate limiter configuration to previous known-good version.
 - Config PR that caused issue: [link]
 - Rollback PR: [link]
 
-*See [Incident Response Policy](../incident-response-policy) for severity definitions and process.*
+*See [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy) for severity definitions and process.*
+
+---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/templates/example-incident-log.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/example-incident-log.mdx
@@ -150,7 +150,7 @@ Rolled back rate limiter configuration to previous known-good version.
 
 *See [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy) for severity definitions and process.*
 
-## Further Reading
+## Further reading
 
 - [Templates overview](/incident-management/incident-response-template/templates/overview): how the templates in this section fit together
 - [Incident Log Template](/incident-management/incident-response-template/templates/incident-log-template): the blank version to copy

--- a/docs/pages/incident-management/incident-response-template/templates/example-incident-log.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/example-incident-log.mdx
@@ -16,6 +16,14 @@ contributors:
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../../components'
 
+{/*
+  content-model-exception:
+  type: template
+  reason: Reusable template body intentionally uses many H2 placeholders and static task lists for copy-paste.
+  owner: maintainers
+*/}
+
+
 # Incident: API Outage - Rate Limiter Misconfiguration
 
 <TagList tags={frontmatter.tags} />
@@ -121,7 +129,7 @@ Rolled back rate limiter configuration to previous known-good version.
 - [x] Sample API calls succeeding
 - [x] No user reports of issues post-fix
 
-## Communications Sent
+### Communications Sent
 
 | Time | Channel | Summary |
 | ---- | ------- | ------- |
@@ -129,13 +137,13 @@ Rolled back rate limiter configuration to previous known-good version.
 | 15:45 UTC | Discord #announcements | "API issues resolved" |
 | 16:00 UTC | Twitter | Brief update (optional) |
 
-## Post-Incident
+### Post-Incident
 
 - [x] Post-mortem scheduled for: 2024-01-17 15:00 UTC
 - [x] [Post-mortem document](/incident-management/incident-response-template/templates/example-post-mortem) created
 - [ ] Action items assigned (pending post-mortem)
 
-## Links & Evidence
+### Links & Evidence
 
 - DataDog dashboard: [link]
 - Config PR that caused issue: [link]

--- a/docs/pages/incident-management/incident-response-template/templates/example-incident-log.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/example-incident-log.mdx
@@ -107,15 +107,15 @@ Typo in rate limiter configuration: `10` instead of `1000` for requests per minu
 
 ### Immediate
 
-- [x] Identify source of errors @Dave
-- [x] Find recent changes @Dave
-- [x] Prepare rollback @Dave
+- [~x] Identify source of errors @Dave
+- [~x] Find recent changes @Dave
+- [~x] Prepare rollback @Dave
 
 ### Resolution
 
-- [x] Rollback config change @Dave
-- [x] Verify API functioning @Bob
-- [x] Post community update @Carol
+- [~x] Rollback config change @Dave
+- [~x] Verify API functioning @Bob
+- [~x] Post community update @Carol
 
 ## Resolution Summary
 
@@ -125,9 +125,9 @@ Rolled back rate limiter configuration to previous known-good version.
 
 ### Verification
 
-- [x] API error rate back to baseline (&lt;0.1%)
-- [x] Sample API calls succeeding
-- [x] No user reports of issues post-fix
+- [~x] API error rate back to baseline (&lt;0.1%)
+- [~x] Sample API calls succeeding
+- [~x] No user reports of issues post-fix
 
 ### Communications Sent
 
@@ -139,9 +139,9 @@ Rolled back rate limiter configuration to previous known-good version.
 
 ### Post-Incident
 
-- [x] Post-mortem scheduled for: 2024-01-17 15:00 UTC
-- [x] [Post-mortem document](/incident-management/incident-response-template/templates/example-post-mortem) created
-- [ ] Action items assigned (pending post-mortem)
+- [~x] Post-mortem scheduled for: 2024-01-17 15:00 UTC
+- [~x] [Post-mortem document](/incident-management/incident-response-template/templates/example-post-mortem) created
+- [~] Action items assigned (pending post-mortem)
 
 ### Links & Evidence
 

--- a/docs/pages/incident-management/incident-response-template/templates/example-incident-log.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/example-incident-log.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Incident: API Outage - Rate Limiter Misconfiguration | Security Alliance"
-description: "This is an example incident log. Delete this file or use it as reference when creating real incident logs."
+description: "This is an example incident log. Delete this file or use it as reference when creating real incident logs. never treat sample commands or timelines as"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/incident-management/incident-response-template/templates/example-incident-log.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/example-incident-log.mdx
@@ -143,6 +143,11 @@ Rolled back rate limiter configuration to previous known-good version.
 
 *See [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy) for severity definitions and process.*
 
+
+## Further Reading
+
+- [Incident Management overview](/incident-management/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/templates/example-incident-log.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/example-incident-log.mdx
@@ -106,15 +106,15 @@ Typo in rate limiter configuration: `10` instead of `1000` for requests per minu
 
 ### Immediate
 
-- [~x] Identify source of errors @Dave
-- [~x] Find recent changes @Dave
-- [~x] Prepare rollback @Dave
+- [x] Identify source of errors @Dave
+- [x] Find recent changes @Dave
+- [x] Prepare rollback @Dave
 
 ### Resolution
 
-- [~x] Rollback config change @Dave
-- [~x] Verify API functioning @Bob
-- [~x] Post community update @Carol
+- [x] Rollback config change @Dave
+- [x] Verify API functioning @Bob
+- [x] Post community update @Carol
 
 ## Resolution Summary
 
@@ -124,9 +124,9 @@ Rolled back rate limiter configuration to previous known-good version.
 
 ### Verification
 
-- [~x] API error rate back to baseline (&lt;0.1%)
-- [~x] Sample API calls succeeding
-- [~x] No user reports of issues post-fix
+- [x] API error rate back to baseline (&lt;0.1%)
+- [x] Sample API calls succeeding
+- [x] No user reports of issues post-fix
 
 ### Communications Sent
 
@@ -138,9 +138,9 @@ Rolled back rate limiter configuration to previous known-good version.
 
 ### Post-Incident
 
-- [~x] Post-mortem scheduled for: 2024-01-17 15:00 UTC
-- [~x] [Post-mortem document](/incident-management/incident-response-template/templates/example-post-mortem) created
-- [~] Action items assigned (pending post-mortem)
+- [x] Post-mortem scheduled for: 2024-01-17 15:00 UTC
+- [x] [Post-mortem document](/incident-management/incident-response-template/templates/example-post-mortem) created
+- [ ] Action items assigned (pending post-mortem)
 
 ### Links & Evidence
 

--- a/docs/pages/incident-management/incident-response-template/templates/example-incident-log.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/example-incident-log.mdx
@@ -23,7 +23,6 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../../compo
   owner: maintainers
 */}
 
-
 # Incident: API Outage - Rate Limiter Misconfiguration
 
 <TagList tags={frontmatter.tags} />
@@ -151,10 +150,12 @@ Rolled back rate limiter configuration to previous known-good version.
 
 *See [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy) for severity definitions and process.*
 
-
 ## Further Reading
 
-- [Incident Management overview](/incident-management/overview)
+- [Templates overview](/incident-management/incident-response-template/templates/overview): how the templates in this section fit together
+- [Incident Log Template](/incident-management/incident-response-template/templates/incident-log-template): the blank version to copy
+- [Post-Mortem Template](/incident-management/incident-response-template/templates/post-mortem-template): what to complete once the incident closes
+- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy): severity levels, roles, and escalation
 
 ---
 

--- a/docs/pages/incident-management/incident-response-template/templates/example-post-mortem.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/example-post-mortem.mdx
@@ -147,10 +147,10 @@ Human error during configuration change. The rate limit threshold was typed as `
 
 ### Lessons for Runbooks
 
-- [~x] Existing runbook sufficient: [Third-Party
+- [x] Existing runbook sufficient: [Third-Party
       Outage](/incident-management/incident-response-template/runbooks/third-party-outage) (config
       rollback section applicable)
-- [~] No new runbook needed
+- [ ] No new runbook needed
 
 ### Detection
 

--- a/docs/pages/incident-management/incident-response-template/templates/example-post-mortem.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/example-post-mortem.mdx
@@ -16,6 +16,14 @@ contributors:
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../../components'
 
+{/*
+  content-model-exception:
+  type: template
+  reason: Reusable template body intentionally uses many H2 placeholders and static task lists for copy-paste.
+  owner: maintainers
+*/}
+
+
 # Post-Mortem: API Outage - Rate Limiter Misconfiguration
 
 <TagList tags={frontmatter.tags} />
@@ -122,13 +130,13 @@ Human error during configuration change. The rate limit threshold was typed as `
 3. Alert took 17 minutes to fire (threshold too high)
 4. No validation for obviously wrong values (10 vs 1000)
 
-## Where We Got Lucky
+### Where We Got Lucky
 
 1. This happened during business hours when the team was available
 2. The fix (rollback) was simple. If the old config was also broken, recovery would have been harder
 3. No financial impact because this was the API layer, not smart contracts
 
-## Action Items
+### Action Items
 
 | Action | Owner | Deadline | Status |
 | ------ | ----- | -------- | ------ |
@@ -138,14 +146,14 @@ Human error during configuration change. The rate limit threshold was typed as `
 | Add staging environment testing for config changes | Dave | 2024-02-15 | In Progress |
 | Document config change process | Alice | 2024-01-31 | Not Started |
 
-## Lessons for Runbooks
+### Lessons for Runbooks
 
 - [x] Existing runbook sufficient: [Third-Party
       Outage](/incident-management/incident-response-template/runbooks/third-party-outage) (config
       rollback section applicable)
 - [ ] No new runbook needed
 
-## Detection
+### Detection
 
 | Aspect | Details |
 | ------ | ------- |
@@ -153,14 +161,14 @@ Human error during configuration change. The rate limit threshold was typed as `
 | Time to detection | 17 minutes |
 | Could we detect faster? | Yes - lower alert threshold to 1% |
 
-## Links
+### Links
 
 - Incident Log: [2024-01-15 Example API Outage](/incident-management/incident-response-template/templates/example-incident-log)
 - Config PR (bad): [link]
 - Rollback PR: [link]
 - Monitoring dashboard: [link]
 
-## Meeting Notes
+### Meeting Notes
 
 **Attendees:** Alice, Bob, Carol, Dave
 

--- a/docs/pages/incident-management/incident-response-template/templates/example-post-mortem.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/example-post-mortem.mdx
@@ -179,7 +179,7 @@ Human error during configuration change. The rate limit threshold was typed as `
 
 *See [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy#step-6-post-incident-review) for post-mortem process.*
 
-## Further Reading
+## Further reading
 
 - [Templates overview](/incident-management/incident-response-template/templates/overview): how the templates in this section fit together
 - [Post-Mortem Template](/incident-management/incident-response-template/templates/post-mortem-template): the blank version to copy

--- a/docs/pages/incident-management/incident-response-template/templates/example-post-mortem.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/example-post-mortem.mdx
@@ -172,6 +172,11 @@ Human error during configuration change. The rate limit threshold was typed as `
 
 *See [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy#step-6-post-incident-review) for post-mortem process.*
 
+
+## Further Reading
+
+- [Incident Management overview](/incident-management/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/templates/example-post-mortem.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/example-post-mortem.mdx
@@ -8,7 +8,10 @@ tags:
 contributors:
   - role: wrote
     users: [hexnickk4997, n0guest]
-
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../../components'
@@ -18,7 +21,12 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../../compo
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> **This is an example post-mortem.** Delete this file or use it as reference when creating real post-mortems.
+> 🔑 **Key Takeaway**: This sample post-mortem shows tone and structure for a config-driven
+> outage. Copy the learning posture—systems over blame—and write your own facts for
+> every real incident.
+
+**This is an example post-mortem.** Delete this file or use it as reference when creating real post-
+mortems.
 
 ## Metadata
 
@@ -28,7 +36,7 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../../compo
 | **Severity** | P2 |
 | **Authors** | Alice, Bob |
 | **Status** | Final |
-| **Incident Log** | [2024-01-15 Example API Outage](./example-incident-log) |
+| **Incident Log** | [2024-01-15 Example API Outage](/incident-management/incident-response-template/templates/example-incident-log) |
 
 ## Summary
 
@@ -74,7 +82,7 @@ at risk, but approximately 3,000 users experienced failed transactions during th
 | 15:25 | Rollback complete |
 | 16:45 | Incident resolved |
 
-See [Incident Log](./example-incident-log) for detailed timeline.
+See [Incident Log](/incident-management/incident-response-template/templates/example-incident-log) for detailed timeline.
 
 ## Root Cause
 
@@ -132,7 +140,9 @@ Human error during configuration change. The rate limit threshold was typed as `
 
 ## Lessons for Runbooks
 
-- [x] Existing runbook sufficient: [Third-Party Outage](../runbooks/third-party-outage) (config rollback section applicable)
+- [x] Existing runbook sufficient: [Third-Party
+      Outage](/incident-management/incident-response-template/runbooks/third-party-outage) (config
+      rollback section applicable)
 - [ ] No new runbook needed
 
 ## Detection
@@ -145,7 +155,7 @@ Human error during configuration change. The rate limit threshold was typed as `
 
 ## Links
 
-- Incident Log: [2024-01-15 Example API Outage](./example-incident-log)
+- Incident Log: [2024-01-15 Example API Outage](/incident-management/incident-response-template/templates/example-incident-log)
 - Config PR (bad): [link]
 - Rollback PR: [link]
 - Monitoring dashboard: [link]
@@ -160,6 +170,8 @@ Human error during configuration change. The rate limit threshold was typed as `
 - Discussed whether to require staging for all changes (decided yes)
 - Dave to implement validation this week
 
-*See [Incident Response Policy](../incident-response-policy#step-6-post-incident-review) for post-mortem process.*
+*See [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy#step-6-post-incident-review) for post-mortem process.*
+
+---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/templates/example-post-mortem.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/example-post-mortem.mdx
@@ -148,10 +148,10 @@ Human error during configuration change. The rate limit threshold was typed as `
 
 ### Lessons for Runbooks
 
-- [x] Existing runbook sufficient: [Third-Party
+- [~x] Existing runbook sufficient: [Third-Party
       Outage](/incident-management/incident-response-template/runbooks/third-party-outage) (config
       rollback section applicable)
-- [ ] No new runbook needed
+- [~] No new runbook needed
 
 ### Detection
 

--- a/docs/pages/incident-management/incident-response-template/templates/example-post-mortem.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/example-post-mortem.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Post-Mortem: API Outage - Rate Limiter Misconfiguration | Security Alliance"
-description: "This is an example post-mortem. Delete this file or use it as reference when creating real post-mortems."
+description: "This is an example post-mortem. Delete this file or use it as reference when creating real post-mortems. Covers Post-Mortem: API Outage - Rate Limiter"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/incident-management/incident-response-template/templates/example-post-mortem.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/example-post-mortem.mdx
@@ -23,7 +23,6 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../../compo
   owner: maintainers
 */}
 
-
 # Post-Mortem: API Outage - Rate Limiter Misconfiguration
 
 <TagList tags={frontmatter.tags} />
@@ -180,10 +179,12 @@ Human error during configuration change. The rate limit threshold was typed as `
 
 *See [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy#step-6-post-incident-review) for post-mortem process.*
 
-
 ## Further Reading
 
-- [Incident Management overview](/incident-management/overview)
+- [Templates overview](/incident-management/incident-response-template/templates/overview): how the templates in this section fit together
+- [Post-Mortem Template](/incident-management/incident-response-template/templates/post-mortem-template): the blank version to copy
+- [Lessons Learned](/incident-management/lessons-learned): turning findings into durable change
+- [Incident Log Template](/incident-management/incident-response-template/templates/incident-log-template): the record this draws from
 
 ---
 

--- a/docs/pages/incident-management/incident-response-template/templates/incident-log-template.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/incident-log-template.mdx
@@ -8,7 +8,10 @@ tags:
 contributors:
   - role: wrote
     users: [hexnickk4997, n0guest]
-
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../../components'
@@ -18,7 +21,13 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Use this template during active incidents. The [Scribe](../incident-response-policy#scribe) owns this document.
+> 🔑 **Key Takeaway**: The Scribe owns the live incident log. Timestamp decisions, actions,
+> and links continuously so later investigation and post-mortems are reconstruction, not
+> guesswork.
+
+Use this template during active incidents. The
+  [Scribe](/incident-management/incident-response-template/incident-response-policy#scribe) owns this
+  document.
 
 ## How to Use
 
@@ -118,7 +127,9 @@ HH:MM UTC - ...
 
 <Checklist id="post-incident">
 - [ ] Post-mortem scheduled for: [date]
-- [ ] [Post-mortem document](./post-mortem-template) created (save to your post-mortems folder)
+- [ ] [Post-mortem
+      document](/incident-management/incident-response-template/templates/post-mortem-template)
+      created (save to your post-mortems folder)
 - [ ] Action items assigned
 </Checklist>
 
@@ -138,6 +149,10 @@ HH:MM UTC - ...
 | P4 | Low - minor issues |
 | P5 | Info - no action needed |
 
-See [Incident Response Policy](../incident-response-policy#severity-levels) for full definitions.
+See [Incident Response
+  Policy](/incident-management/incident-response-template/incident-response-policy#severity-levels)
+  for full definitions.
+
+---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/templates/incident-log-template.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/incident-log-template.mdx
@@ -160,7 +160,7 @@ See [Incident Response
   Policy](/incident-management/incident-response-template/incident-response-policy#severity-levels)
   for full definitions.
 
-## Further Reading
+## Further reading
 
 - [Templates overview](/incident-management/incident-response-template/templates/overview): how the templates in this section fit together
 - [Example Incident Log](/incident-management/incident-response-template/templates/example-incident-log): a completed log to model

--- a/docs/pages/incident-management/incident-response-template/templates/incident-log-template.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/incident-log-template.mdx
@@ -102,15 +102,15 @@ HH:MM UTC - ...
 ### Immediate
 
 <Checklist id="immediate">
-- [~] [Action] @[Owner]
-- [~] [Action] @[Owner]
+- [ ] [Action] @[Owner]
+- [ ] [Action] @[Owner]
 </Checklist>
 
 ### Resolution
 
 <Checklist id="resolution">
-- [~] [Action] @[Owner]
-- [~] [Action] @[Owner]
+- [ ] [Action] @[Owner]
+- [ ] [Action] @[Owner]
 </Checklist>
 
 ## Resolution Summary
@@ -120,8 +120,8 @@ HH:MM UTC - ...
 ### Verification
 
 <Checklist id="verification">
-- [~] [Check 1]
-- [~] [Check 2]
+- [ ] [Check 1]
+- [ ] [Check 2]
 </Checklist>
 
 ### Communications Sent
@@ -133,11 +133,11 @@ HH:MM UTC - ...
 ### Post-Incident
 
 <Checklist id="post-incident">
-- [~] Post-mortem scheduled for: [date]
-- [~] [Post-mortem
+- [ ] Post-mortem scheduled for: [date]
+- [ ] [Post-mortem
       document](/incident-management/incident-response-template/templates/post-mortem-template)
       created (save to your post-mortems folder)
-- [~] Action items assigned
+- [ ] Action items assigned
 </Checklist>
 
 ### Links & Evidence

--- a/docs/pages/incident-management/incident-response-template/templates/incident-log-template.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/incident-log-template.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Incident Log Template | Security Alliance"
-description: "Use this template during active incidents. The Scribe owns this document."
+description: "Use this template during active incidents. The Scribe owns this document. Timestamp decisions, actions, and links continuously so later investigation"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/incident-management/incident-response-template/templates/incident-log-template.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/incident-log-template.mdx
@@ -153,6 +153,11 @@ See [Incident Response
   Policy](/incident-management/incident-response-template/incident-response-policy#severity-levels)
   for full definitions.
 
+
+## Further Reading
+
+- [Incident Management overview](/incident-management/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/templates/incident-log-template.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/incident-log-template.mdx
@@ -16,6 +16,14 @@ contributors:
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../../components'
 
+{/*
+  content-model-exception:
+  type: template
+  reason: Reusable template body intentionally uses many H2 placeholders and static task lists for copy-paste.
+  owner: maintainers
+*/}
+
+
 # Incident Log Template
 
 <TagList tags={frontmatter.tags} />
@@ -106,7 +114,7 @@ HH:MM UTC - ...
 - [ ] [Action] @[Owner]
 </Checklist>
 
-## Resolution Summary
+### Resolution Summary
 
 ### Mitigation Applied
 
@@ -117,13 +125,13 @@ HH:MM UTC - ...
 - [ ] [Check 2]
 </Checklist>
 
-## Communications Sent
+### Communications Sent
 
 | Time | Channel | Summary |
 | ---- | ------- | ------- |
 | | | |
 
-## Post-Incident
+### Post-Incident
 
 <Checklist id="post-incident">
 - [ ] Post-mortem scheduled for: [date]
@@ -133,13 +141,13 @@ HH:MM UTC - ...
 - [ ] Action items assigned
 </Checklist>
 
-## Links & Evidence
+### Links & Evidence
 
 - [Relevant dashboard]
 - [Relevant PR/commit]
 - [Screenshots]
 
-## Severity Reference
+### Severity Reference
 
 | Level | Description |
 | ----- | ----------- |

--- a/docs/pages/incident-management/incident-response-template/templates/incident-log-template.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/incident-log-template.mdx
@@ -103,15 +103,15 @@ HH:MM UTC - ...
 ### Immediate
 
 <Checklist id="immediate">
-- [ ] [Action] @[Owner]
-- [ ] [Action] @[Owner]
+- [~] [Action] @[Owner]
+- [~] [Action] @[Owner]
 </Checklist>
 
 ### Resolution
 
 <Checklist id="resolution">
-- [ ] [Action] @[Owner]
-- [ ] [Action] @[Owner]
+- [~] [Action] @[Owner]
+- [~] [Action] @[Owner]
 </Checklist>
 
 ### Resolution Summary
@@ -121,8 +121,8 @@ HH:MM UTC - ...
 ### Verification
 
 <Checklist id="verification">
-- [ ] [Check 1]
-- [ ] [Check 2]
+- [~] [Check 1]
+- [~] [Check 2]
 </Checklist>
 
 ### Communications Sent
@@ -134,11 +134,11 @@ HH:MM UTC - ...
 ### Post-Incident
 
 <Checklist id="post-incident">
-- [ ] Post-mortem scheduled for: [date]
-- [ ] [Post-mortem
+- [~] Post-mortem scheduled for: [date]
+- [~] [Post-mortem
       document](/incident-management/incident-response-template/templates/post-mortem-template)
       created (save to your post-mortems folder)
-- [ ] Action items assigned
+- [~] Action items assigned
 </Checklist>
 
 ### Links & Evidence

--- a/docs/pages/incident-management/incident-response-template/templates/incident-log-template.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/incident-log-template.mdx
@@ -23,7 +23,6 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
   owner: maintainers
 */}
 
-
 # Incident Log Template
 
 <TagList tags={frontmatter.tags} />
@@ -114,7 +113,7 @@ HH:MM UTC - ...
 - [~] [Action] @[Owner]
 </Checklist>
 
-### Resolution Summary
+## Resolution Summary
 
 ### Mitigation Applied
 
@@ -161,10 +160,12 @@ See [Incident Response
   Policy](/incident-management/incident-response-template/incident-response-policy#severity-levels)
   for full definitions.
 
-
 ## Further Reading
 
-- [Incident Management overview](/incident-management/overview)
+- [Templates overview](/incident-management/incident-response-template/templates/overview): how the templates in this section fit together
+- [Example Incident Log](/incident-management/incident-response-template/templates/example-incident-log): a completed log to model
+- [Post-Mortem Template](/incident-management/incident-response-template/templates/post-mortem-template): what to complete once the incident closes
+- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy): severity levels, roles, and escalation
 
 ---
 

--- a/docs/pages/incident-management/incident-response-template/templates/overview.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/overview.mdx
@@ -51,6 +51,11 @@ scenario runbooks, and
 [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
 for the full response process.
 
+
+## Further Reading
+
+- [Incident Management overview](/incident-management/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/templates/overview.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/overview.mdx
@@ -30,7 +30,7 @@ Templates for incident response documentation. Copy these when needed.
 > **Review these templates before your first incident.** Familiarize yourself with the structure so you're not
 > learning the format during an emergency. Consider running a tabletop exercise to practice filling them out.
 
-## Available Templates
+## What this framework covers
 
 1. [Incident Log Template](/incident-management/incident-response-template/templates/incident-log-template):
    copy when declaring an incident.

--- a/docs/pages/incident-management/incident-response-template/templates/overview.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/overview.mdx
@@ -51,7 +51,7 @@ scenario runbooks, and
 [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
 for the full response process.
 
-## Further Reading
+## Further reading
 
 - [Incident Response Template overview](/incident-management/incident-response-template/overview): how the template pieces fit together
 - [Incident Log Template](/incident-management/incident-response-template/templates/incident-log-template): fill out during an incident

--- a/docs/pages/incident-management/incident-response-template/templates/overview.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/overview.mdx
@@ -51,10 +51,12 @@ scenario runbooks, and
 [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
 for the full response process.
 
-
 ## Further Reading
 
-- [Incident Management overview](/incident-management/overview)
+- [Incident Response Template overview](/incident-management/incident-response-template/overview): how the template pieces fit together
+- [Incident Log Template](/incident-management/incident-response-template/templates/incident-log-template): fill out during an incident
+- [Post-Mortem Template](/incident-management/incident-response-template/templates/post-mortem-template): complete after an incident
+- [Runbook Template](/incident-management/incident-response-template/templates/runbook-template): structure for writing your own runbooks
 
 ---
 

--- a/docs/pages/incident-management/incident-response-template/templates/overview.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Templates | Security Alliance"
-description: "Templates for incident response documentation. Copy these when needed."
+description: "Templates for incident response documentation. Copy these when needed. Practice incident log, post-mortem, and runbook templates before the first real"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/incident-management/incident-response-template/templates/overview.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/overview.mdx
@@ -8,7 +8,10 @@ tags:
 contributors:
   - role: wrote
     users: [hexnickk4997, n0guest]
-
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../../components'
@@ -18,6 +21,10 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../../compo
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
+> 🔑 **Key Takeaway**: Practice incident log, post-mortem, and runbook templates before the
+> first real page-out. Format familiarity under calm conditions ends format thrash
+> during emergencies.
+
 Templates for incident response documentation. Copy these when needed.
 
 > **Review these templates before your first incident.** Familiarize yourself with the structure so you're not
@@ -25,25 +32,25 @@ Templates for incident response documentation. Copy these when needed.
 
 ## Available Templates
 
-| Template | When to Use |
-| -------- | ----------- |
-| [Incident Log Template](./incident-log-template) | Copy when declaring an incident |
-| [Post-Mortem Template](./post-mortem-template) | Copy after resolving a significant incident (P1-P3) |
-| [Runbook Template](./runbook-template) | Copy when creating a new scenario-specific runbook |
+1. [Incident Log Template](/incident-management/incident-response-template/templates/incident-log-template):
+   copy when declaring an incident.
+2. [Post-Mortem Template](/incident-management/incident-response-template/templates/post-mortem-template):
+   copy after resolving a significant incident (P1-P3).
+3. [Runbook Template](/incident-management/incident-response-template/templates/runbook-template):
+   copy when creating a new scenario-specific runbook.
+4. [Example Incident Log](/incident-management/incident-response-template/templates/example-incident-log):
+   filled-out incident log for format reference.
+5. [Example Post-Mortem](/incident-management/incident-response-template/templates/example-post-mortem):
+   filled-out post-mortem for format reference.
 
-## Examples
+For communication guidance and examples, see
+[Communications](/incident-management/incident-response-template/communications).
 
-| Example | Purpose |
-| ------- | ------- |
-| [Example Incident Log](./example-incident-log) | Shows a filled-out incident log for reference |
-| [Example Post-Mortem](./example-post-mortem) | Shows a filled-out post-mortem for reference |
+See [Runbooks](/incident-management/incident-response-template/runbooks/overview) for existing
+scenario runbooks, and
+[Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
+for the full response process.
 
-For communication guidance and examples, see [Communications](../communications).
-
-## Runbook Template
-
-See [Runbooks](../runbooks/overview) for the runbook template and existing runbooks.
-
-*See [Incident Response Policy](../incident-response-policy) for the full response process.*
+---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/templates/post-mortem-template.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/post-mortem-template.mdx
@@ -16,6 +16,14 @@ contributors:
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../../components'
 
+{/*
+  content-model-exception:
+  type: template
+  reason: Reusable template body intentionally uses many H2 placeholders and static task lists for copy-paste.
+  owner: maintainers
+*/}
+
+
 # Post-Mortem Template
 
 <TagList tags={frontmatter.tags} />
@@ -112,20 +120,20 @@ See linked Incident Log for detailed timeline.
 2.
 3.
 
-## What Went Wrong
+### What Went Wrong
 
 1.
 2.
 3.
 
-## Where We Got Lucky
+### Where We Got Lucky
 
 [What fortunate circumstances helped that we shouldn't rely on next time?]
 
 1.
 2.
 
-## Action Items
+### Action Items
 
 > Every action item needs an owner and deadline.
 
@@ -135,7 +143,7 @@ See linked Incident Log for detailed timeline.
 | | | | |
 | | | | |
 
-## Lessons for Runbooks
+### Lessons for Runbooks
 
 Should we create or update a
   [runbook](/incident-management/incident-response-template/runbooks/overview) based on this incident?
@@ -146,7 +154,7 @@ Should we create or update a
 - [ ] No runbook changes needed
 </Checklist>
 
-## Detection
+### Detection
 
 | Aspect | Details |
 | ------ | ------- |
@@ -154,14 +162,14 @@ Should we create or update a
 | Time to detection | |
 | Could we detect faster? | |
 
-## Links
+### Links
 
 - Incident Log: [Link to incident log]
 - Relevant PRs:
 - Dashboards:
 - External references:
 
-## Meeting Notes
+### Meeting Notes
 
 **Attendees:**
 

--- a/docs/pages/incident-management/incident-response-template/templates/post-mortem-template.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/post-mortem-template.mdx
@@ -23,7 +23,6 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
   owner: maintainers
 */}
 
-
 # Post-Mortem Template
 
 <TagList tags={frontmatter.tags} />
@@ -120,7 +119,7 @@ See linked Incident Log for detailed timeline.
 2.
 3.
 
-### What Went Wrong
+## What Went Wrong
 
 1.
 2.
@@ -177,10 +176,12 @@ Should we create or update a
 
 *Template based on [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy#step-6-post-incident-review)*
 
-
 ## Further Reading
 
-- [Incident Management overview](/incident-management/overview)
+- [Templates overview](/incident-management/incident-response-template/templates/overview): how the templates in this section fit together
+- [Example Post-Mortem](/incident-management/incident-response-template/templates/example-post-mortem): a completed write-up to model
+- [Incident Log Template](/incident-management/incident-response-template/templates/incident-log-template): the record this draws from
+- [Lessons Learned](/incident-management/lessons-learned): turning findings into durable change
 
 ---
 

--- a/docs/pages/incident-management/incident-response-template/templates/post-mortem-template.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/post-mortem-template.mdx
@@ -148,9 +148,9 @@ Should we create or update a
   [runbook](/incident-management/incident-response-template/runbooks/overview) based on this incident?
 
 <Checklist id="lessons-for-runbooks">
-- [~] New runbook needed: [type]
-- [~] Existing runbook to update: [which one]
-- [~] No runbook changes needed
+- [ ] New runbook needed: [type]
+- [ ] Existing runbook to update: [which one]
+- [ ] No runbook changes needed
 </Checklist>
 
 ### Detection

--- a/docs/pages/incident-management/incident-response-template/templates/post-mortem-template.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/post-mortem-template.mdx
@@ -8,7 +8,10 @@ tags:
 contributors:
   - role: wrote
     users: [hexnickk4997, n0guest]
-
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../../components'
@@ -17,6 +20,10 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Complete a blameless post-mortem after P1–P3 incidents. Timeline,
+> impact, contributing factors, and tracked actions turn pain into durable process
+> improvement.
 
 Complete this after significant incidents (P1-P3). Focus on learning, not blame.
 
@@ -130,7 +137,8 @@ See linked Incident Log for detailed timeline.
 
 ## Lessons for Runbooks
 
-Should we create or update a [runbook](../runbooks/overview) based on this incident?
+Should we create or update a
+  [runbook](/incident-management/incident-response-template/runbooks/overview) based on this incident?
 
 <Checklist id="lessons-for-runbooks">
 - [ ] New runbook needed: [type]
@@ -159,6 +167,8 @@ Should we create or update a [runbook](../runbooks/overview) based on this incid
 
 **Discussion points:**
 
-*Template based on [Incident Response Policy](../incident-response-policy#step-6-post-incident-review)*
+*Template based on [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy#step-6-post-incident-review)*
+
+---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/templates/post-mortem-template.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/post-mortem-template.mdx
@@ -169,6 +169,11 @@ Should we create or update a
 
 *Template based on [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy#step-6-post-incident-review)*
 
+
+## Further Reading
+
+- [Incident Management overview](/incident-management/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/templates/post-mortem-template.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/post-mortem-template.mdx
@@ -149,9 +149,9 @@ Should we create or update a
   [runbook](/incident-management/incident-response-template/runbooks/overview) based on this incident?
 
 <Checklist id="lessons-for-runbooks">
-- [ ] New runbook needed: [type]
-- [ ] Existing runbook to update: [which one]
-- [ ] No runbook changes needed
+- [~] New runbook needed: [type]
+- [~] Existing runbook to update: [which one]
+- [~] No runbook changes needed
 </Checklist>
 
 ### Detection

--- a/docs/pages/incident-management/incident-response-template/templates/post-mortem-template.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/post-mortem-template.mdx
@@ -176,7 +176,7 @@ Should we create or update a
 
 *Template based on [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy#step-6-post-incident-review)*
 
-## Further Reading
+## Further reading
 
 - [Templates overview](/incident-management/incident-response-template/templates/overview): how the templates in this section fit together
 - [Example Post-Mortem](/incident-management/incident-response-template/templates/example-post-mortem): a completed write-up to model

--- a/docs/pages/incident-management/incident-response-template/templates/post-mortem-template.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/post-mortem-template.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Post-Mortem Template | Security Alliance"
-description: "Complete this after significant incidents (P1-P3). Focus on learning, not blame."
+description: "Complete this after significant incidents (P1-P3). Focus on learning, not blame. Timeline, impact, contributing factors, and tracked actions turn pain"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/incident-management/incident-response-template/templates/runbook-template.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/runbook-template.mdx
@@ -16,6 +16,14 @@ contributors:
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../../components'
 
+{/*
+  content-model-exception:
+  type: template
+  reason: Reusable template body intentionally uses many H2 placeholders and static task lists for copy-paste.
+  owner: maintainers
+*/}
+
+
 # Runbook Template
 
 <TagList tags={frontmatter.tags} />
@@ -135,13 +143,13 @@ Escalate to [Contacts](/incident-management/incident-response-template/contacts)
 - [ ] Post-mortem scheduled if warranted
 </Checklist>
 
-## Common Root Causes
+### Common Root Causes
 
 | Cause | Signs | Fix |
 | ----- | ----- | --- |
 | | | |
 
-## Related
+### Related
 
 - Related runbook for this scenario
 - [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)

--- a/docs/pages/incident-management/incident-response-template/templates/runbook-template.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/runbook-template.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Runbook Template | Security Alliance"
-description: "Copy this template to create runbooks for specific incident types."
+description: "Copy this template to create runbooks for specific incident types. Clone this structure for each scenario: quick reference, detection, containment"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/incident-management/incident-response-template/templates/runbook-template.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/runbook-template.mdx
@@ -146,6 +146,11 @@ Escalate to [Contacts](/incident-management/incident-response-template/contacts)
 - Related runbook for this scenario
 - [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
 
+
+## Further Reading
+
+- [Incident Management overview](/incident-management/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/incident-response-template/templates/runbook-template.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/runbook-template.mdx
@@ -23,7 +23,6 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
   owner: maintainers
 */}
 
-
 # Runbook Template
 
 <TagList tags={frontmatter.tags} />
@@ -149,15 +148,12 @@ Escalate to [Contacts](/incident-management/incident-response-template/contacts)
 | ----- | ----- | --- |
 | | | |
 
-### Related
-
-- Related runbook for this scenario
-- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
-
-
 ## Further Reading
 
-- [Incident Management overview](/incident-management/overview)
+- [Templates overview](/incident-management/incident-response-template/templates/overview): how the templates in this section fit together
+- [Runbooks overview](/incident-management/incident-response-template/runbooks/overview): how the runbooks in this section fit together
+- [Key Compromise runbook](/incident-management/incident-response-template/runbooks/key-compromise): a worked example of this structure
+- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy): severity levels, roles, and escalation
 
 ---
 

--- a/docs/pages/incident-management/incident-response-template/templates/runbook-template.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/runbook-template.mdx
@@ -50,9 +50,9 @@ Copy this template to create runbooks for specific incident types.
 ### Symptoms
 
 <Checklist id="symptoms">
-- [~] Symptom 1
-- [~] Symptom 2
-- [~] Symptom 3
+- [ ] Symptom 1
+- [ ] Symptom 2
+- [ ] Symptom 3
 </Checklist>
 
 ### Alerts
@@ -89,9 +89,9 @@ If you see [X] but not [Y], it might be [different issue] instead.
 ### Key Questions
 
 <Checklist id="key-questions">
-- [~] What is the scope?
-- [~] When did it start?
-- [~] What changed recently?
+- [ ] What is the scope?
+- [ ] When did it start?
+- [ ] What changed recently?
 </Checklist>
 
 ### Information to Gather
@@ -128,18 +128,18 @@ If you see [X] but not [Y], it might be [different issue] instead.
 Escalate to [Contacts](/incident-management/incident-response-template/contacts) if:
 
 <Checklist id="escalation">
-- [~] Mitigation doesn't work within [time]
-- [~] Impact expands
-- [~] [Condition]
+- [ ] Mitigation doesn't work within [time]
+- [ ] Impact expands
+- [ ] [Condition]
 </Checklist>
 
 ## Resolution Checklist
 
 <Checklist id="resolution-checklist">
-- [~] Mitigation verified
-- [~] Stakeholders notified
-- [~] Timeline documented in [Incident Log](/incident-management/incident-response-template/templates/incident-log-template)
-- [~] Post-mortem scheduled if warranted
+- [ ] Mitigation verified
+- [ ] Stakeholders notified
+- [ ] Timeline documented in [Incident Log](/incident-management/incident-response-template/templates/incident-log-template)
+- [ ] Post-mortem scheduled if warranted
 </Checklist>
 
 ### Common Root Causes

--- a/docs/pages/incident-management/incident-response-template/templates/runbook-template.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/runbook-template.mdx
@@ -148,7 +148,7 @@ Escalate to [Contacts](/incident-management/incident-response-template/contacts)
 | ----- | ----- | --- |
 | | | |
 
-## Further Reading
+## Further reading
 
 - [Templates overview](/incident-management/incident-response-template/templates/overview): how the templates in this section fit together
 - [Runbooks overview](/incident-management/incident-response-template/runbooks/overview): how the runbooks in this section fit together

--- a/docs/pages/incident-management/incident-response-template/templates/runbook-template.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/runbook-template.mdx
@@ -51,9 +51,9 @@ Copy this template to create runbooks for specific incident types.
 ### Symptoms
 
 <Checklist id="symptoms">
-- [ ] Symptom 1
-- [ ] Symptom 2
-- [ ] Symptom 3
+- [~] Symptom 1
+- [~] Symptom 2
+- [~] Symptom 3
 </Checklist>
 
 ### Alerts
@@ -90,9 +90,9 @@ If you see [X] but not [Y], it might be [different issue] instead.
 ### Key Questions
 
 <Checklist id="key-questions">
-- [ ] What is the scope?
-- [ ] When did it start?
-- [ ] What changed recently?
+- [~] What is the scope?
+- [~] When did it start?
+- [~] What changed recently?
 </Checklist>
 
 ### Information to Gather
@@ -129,18 +129,18 @@ If you see [X] but not [Y], it might be [different issue] instead.
 Escalate to [Contacts](/incident-management/incident-response-template/contacts) if:
 
 <Checklist id="escalation">
-- [ ] Mitigation doesn't work within [time]
-- [ ] Impact expands
-- [ ] [Condition]
+- [~] Mitigation doesn't work within [time]
+- [~] Impact expands
+- [~] [Condition]
 </Checklist>
 
 ## Resolution Checklist
 
 <Checklist id="resolution-checklist">
-- [ ] Mitigation verified
-- [ ] Stakeholders notified
-- [ ] Timeline documented in [Incident Log](/incident-management/incident-response-template/templates/incident-log-template)
-- [ ] Post-mortem scheduled if warranted
+- [~] Mitigation verified
+- [~] Stakeholders notified
+- [~] Timeline documented in [Incident Log](/incident-management/incident-response-template/templates/incident-log-template)
+- [~] Post-mortem scheduled if warranted
 </Checklist>
 
 ### Common Root Causes

--- a/docs/pages/incident-management/incident-response-template/templates/runbook-template.mdx
+++ b/docs/pages/incident-management/incident-response-template/templates/runbook-template.mdx
@@ -8,7 +8,10 @@ tags:
 contributors:
   - role: wrote
     users: [hexnickk4997, n0guest]
-
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../../components'
@@ -17,6 +20,10 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Clone this structure for each scenario: quick reference, detection,
+> containment, eradication, recovery, and communication. Fill real commands and owners
+> before an incident, not during one.
 
 Copy this template to create runbooks for specific incident types.
 
@@ -111,7 +118,7 @@ If you see [X] but not [Y], it might be [different issue] instead.
 
 ## Escalation
 
-Escalate to [Contacts](../contacts) if:
+Escalate to [Contacts](/incident-management/incident-response-template/contacts) if:
 
 <Checklist id="escalation">
 - [ ] Mitigation doesn't work within [time]
@@ -124,7 +131,7 @@ Escalate to [Contacts](../contacts) if:
 <Checklist id="resolution-checklist">
 - [ ] Mitigation verified
 - [ ] Stakeholders notified
-- [ ] Timeline documented in [Incident Log](../templates/incident-log-template)
+- [ ] Timeline documented in [Incident Log](/incident-management/incident-response-template/templates/incident-log-template)
 - [ ] Post-mortem scheduled if warranted
 </Checklist>
 
@@ -137,6 +144,8 @@ Escalate to [Contacts](../contacts) if:
 ## Related
 
 - Related runbook for this scenario
-- [Incident Response Policy](../incident-response-policy)
+- [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
+
+---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/lessons-learned.mdx
+++ b/docs/pages/incident-management/lessons-learned.mdx
@@ -68,10 +68,12 @@ For a concrete post-mortem structure and example write-up, see
 and
 [Incident Response Template: Example Post-Mortem](/incident-management/incident-response-template/templates/example-post-mortem).
 
-
 ## Further Reading
 
-- [Incident Management overview](/incident-management/overview)
+- [Incident Management overview](/incident-management/overview): how the pages of this framework fit together
+- [Post-Mortem Template](/incident-management/incident-response-template/templates/post-mortem-template): the structure for writing it up
+- [Example Post-Mortem](/incident-management/incident-response-template/templates/example-post-mortem): a completed example to model
+- [Security Metrics and KPIs](/governance/security-metrics-kpis): tracking whether lessons changed outcomes
 
 ---
 

--- a/docs/pages/incident-management/lessons-learned.mdx
+++ b/docs/pages/incident-management/lessons-learned.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Incident Lessons Learned | Security Alliance"
-description: "Conduct post-incident reviews to improve response capabilities. Document timelines, root causes, and action plans. Share lessons with the ecosystem to promote security awareness."
+description: "Conduct post-incident reviews to improve response capabilities. Document timelines, root causes, and action plans. By analyzing what went well and what"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/incident-management/lessons-learned.mdx
+++ b/docs/pages/incident-management/lessons-learned.mdx
@@ -68,6 +68,11 @@ For a concrete post-mortem structure and example write-up, see
 and
 [Incident Response Template: Example Post-Mortem](/incident-management/incident-response-template/templates/example-post-mortem).
 
+
+## Further Reading
+
+- [Incident Management overview](/incident-management/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/lessons-learned.mdx
+++ b/docs/pages/incident-management/lessons-learned.mdx
@@ -30,7 +30,7 @@ Conducting a post-incident review and identifying lessons learned will improve y
 capabilities. By analyzing what went well and what could be improved, you can enhance your readiness for future
 incidents.
 
-## Best Practices
+## Best practices
 
 1. Review the incident together with everybody involved in handling it shortly after the incident is resolved.
 2. Record details about the incident, including the timeline, root cause, impact, and response efforts.

--- a/docs/pages/incident-management/lessons-learned.mdx
+++ b/docs/pages/incident-management/lessons-learned.mdx
@@ -68,7 +68,7 @@ For a concrete post-mortem structure and example write-up, see
 and
 [Incident Response Template: Example Post-Mortem](/incident-management/incident-response-template/templates/example-post-mortem).
 
-## Further Reading
+## Further reading
 
 - [Incident Management overview](/incident-management/overview): how the pages of this framework fit together
 - [Post-Mortem Template](/incident-management/incident-response-template/templates/post-mortem-template): the structure for writing it up

--- a/docs/pages/incident-management/lessons-learned.mdx
+++ b/docs/pages/incident-management/lessons-learned.mdx
@@ -6,6 +6,13 @@ tags:
   - Operations & Strategy
   - DevOps
   - SRE
+contributors:
+  - role: wrote
+    users: []
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -14,6 +21,10 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Review every significant incident blamelessly while memory is fresh.
+> Capture timeline, root cause, and owners with deadlines so the output is procedure
+> change, not a tucked-away write-up.
 
 Conducting a post-incident review and identifying lessons learned will improve your project's incident response
 capabilities. By analyzing what went well and what could be improved, you can enhance your readiness for future

--- a/docs/pages/incident-management/overview.mdx
+++ b/docs/pages/incident-management/overview.mdx
@@ -91,13 +91,14 @@ policy, templates, and technical runbooks.
 - [DPRK IT Workers](/dprk-it-workers/overview): long-running human threat context for DPRK playbooks
 - [Supply Chain](/supply-chain/overview): dependency and pipeline incidents
 - [Infrastructure](/infrastructure/overview): DNS, DDoS, and hosting response context
-- [SEAL 911 Cert surfaces](/certs/overview): certification paths related to ops maturity
+- [SEAL Certifications](/certs/overview): certification paths related to ops maturity
 
 ## Further reading
 
-- Nested playbooks and the IR template customization checklist
-- [SEAL 911](https://securityalliance.org/seal-911)
-- [Rekt News](https://rekt.news/) for public post-mortems
+- [Incident Response Template](/incident-management/incident-response-template/overview): the customization checklist
+  for adapting these documents
+- [SEAL 911](https://securityalliance.org/seal-911): emergency response coordination
+- [Rekt News](https://rekt.news/): public post-mortems to learn from
 
 ---
 

--- a/docs/pages/incident-management/overview.mdx
+++ b/docs/pages/incident-management/overview.mdx
@@ -1,11 +1,18 @@
 ---
 title: "Incident Management | Security Alliance"
-description: "Incident Management Framework: Prepare for, detect, respond to, and recover from security incidents. Build response plans, communication strategies, playbooks, and lessons learned processes."
+description: "Incident management for Web3: prepare detection and response, communications, forensics, playbooks, SEAL 911 paths, and a customizable IR template with runbooks."
 tags:
   - Security Specialist
   - Operations & Strategy
   - DevOps
   - SRE
+contributors:
+  - role: wrote
+    users: []
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -15,19 +22,82 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Incident management involves preparing for, detecting, responding to, and recovering from security incidents. By
-thinking about incident management prior to actually experiencing an incident, you can help increase the likelihood of a
-timely recovery.
+> 🔑 **Key Takeaway**: Decide who leads, how you communicate, and what to freeze before the incident. Web3 response
+> windows are short and many losses are irreversible.
 
-## Contents
+Incident management is preparing for, detecting, responding to, and recovering from security incidents. Plans written
+under stress lose to plans practiced in calm. This framework covers communication, detection and response, forensic
+preparation, lessons learned, SEAL-oriented victim playbooks, and a full customizable incident response template with
+policy, templates, and technical runbooks.
 
-1. [Communication Strategies](/incident-management/communication-strategies)
-2. [Incident Detection and Response](/incident-management/incident-detection-and-response)
-3. [Forensic Readiness](/incident-management/forensic-readiness)
-4. [Lessons Learned](/incident-management/lessons-learned)
-5. [Playbooks](/incident-management/playbooks/overview)
+## What this framework covers
+
+1. [Communication Strategies](/incident-management/communication-strategies): spokespeople, schedules, and stakeholder
+   updates without spreading unconfirmed claims.
+2. [Incident Detection and Response](/incident-management/incident-detection-and-response): find incidents early and work
+   a basic response cycle.
+3. [Forensic Readiness](/incident-management/forensic-readiness): preserve trustworthy evidence before you need it
+   (`dev` page — in progress).
+4. [Lessons Learned](/incident-management/lessons-learned): post-incident review that improves the next response.
+5. [Playbooks](/incident-management/playbooks/overview): scenario playbooks and SEAL 911 victim guidance.
+6. [Incident Response Template](/incident-management/incident-response-template/overview): policy, roles, contacts,
+   copy-ready templates, and technical runbooks for Web3 protocols.
+
+### Playbooks subsection
+
+1. [Playbooks overview](/incident-management/playbooks/overview)
+2. [Malware Infection](/incident-management/playbooks/malware)
+3. [North Korea (DPRK) Attack](/incident-management/playbooks/hacked-dprk)
+4. [Wallet Drainer Attack](/incident-management/playbooks/hacked-drainer)
+5. [ELUSIVE COMET Attack](/incident-management/playbooks/hacked-elusive-comet)
 6. [SEAL 911 War Room Guidelines](/incident-management/playbooks/seal-911-war-room-guidelines)
-7. [Incident Response Template](/incident-management/incident-response-template/overview)
+7. [Decentralized Incident Response Framework (DeIRF)](/incident-management/playbooks/decentralized-ir)
+
+### Incident response template subsection
+
+1. [Template overview](/incident-management/incident-response-template/overview)
+2. [Incident Response Policy](/incident-management/incident-response-template/incident-response-policy)
+3. [Roles and Staffing](/incident-management/incident-response-template/roles-and-staffing)
+4. [Communications](/incident-management/incident-response-template/communications)
+5. [Contacts](/incident-management/incident-response-template/contacts)
+6. [Templates hub](/incident-management/incident-response-template/templates/overview)
+7. [Runbooks hub](/incident-management/incident-response-template/runbooks/overview)
+
+### IR templates
+
+1. [Incident Log Template](/incident-management/incident-response-template/templates/incident-log-template)
+2. [Post-Mortem Template](/incident-management/incident-response-template/templates/post-mortem-template)
+3. [Runbook Template](/incident-management/incident-response-template/templates/runbook-template)
+4. [Example Incident Log](/incident-management/incident-response-template/templates/example-incident-log)
+5. [Example Post-Mortem](/incident-management/incident-response-template/templates/example-post-mortem)
+
+### IR runbooks
+
+1. [Smart Contract Exploit](/incident-management/incident-response-template/runbooks/smart-contract-exploit)
+2. [Key Compromise](/incident-management/incident-response-template/runbooks/key-compromise)
+3. [Frontend Compromise](/incident-management/incident-response-template/runbooks/frontend-compromise)
+4. [DNS Hijack](/incident-management/incident-response-template/runbooks/dns-hijack)
+5. [CDN/Hosting Compromise](/incident-management/incident-response-template/runbooks/cdn-hosting-compromise)
+6. [Dependency Attack](/incident-management/incident-response-template/runbooks/dependency-attack)
+7. [Build Pipeline Compromise](/incident-management/incident-response-template/runbooks/build-pipeline-compromise)
+8. [DDoS Attack](/incident-management/incident-response-template/runbooks/ddos-attack)
+9. [Third-Party Outage](/incident-management/incident-response-template/runbooks/third-party-outage)
+
+## Related frameworks
+
+- [Monitoring](/monitoring/overview): signals that feed detection
+- [Multisig for Protocols](/multisig-for-protocols/overview): emergency signer and admin paths
+- [Wallet Security](/wallet-security/overview): key and signer hygiene adjacent to compromise playbooks
+- [DPRK IT Workers](/dprk-it-workers/overview): long-running human threat context for DPRK playbooks
+- [Supply Chain](/supply-chain/overview): dependency and pipeline incidents
+- [Infrastructure](/infrastructure/overview): DNS, DDoS, and hosting response context
+- [SEAL 911 Cert surfaces](/certs/overview): certification paths related to ops maturity
+
+## Further reading
+
+- Nested playbooks and the IR template customization checklist
+- [SEAL 911](https://securityalliance.org/seal-911)
+- [Rekt News](https://rekt.news/) for public post-mortems
 
 ---
 

--- a/docs/pages/incident-management/playbooks/decentralized-ir.mdx
+++ b/docs/pages/incident-management/playbooks/decentralized-ir.mdx
@@ -124,7 +124,7 @@ Keep a one-liner command ready for each action and store it in the runbook.
 
 ---
 
-### 8. Quick-Start Templates
+## 8. Quick-Start Templates
 
 | Need | Template location |
 | ------ | ------------------- |
@@ -133,7 +133,7 @@ Keep a one-liner command ready for each action and store it in the runbook.
 
 ---
 
-### 9. Pros and Cons of Decentralized IR
+## 9. Pros and Cons of Decentralized IR
 
 | Aspect | Pros | Cons |
 | -------- | ------ | ------ |
@@ -144,7 +144,7 @@ Keep a one-liner command ready for each action and store it in the runbook.
 
 ---
 
-### 10. Keep It Alive
+## 10. Keep It Alive
 
 - Run quarterly red team drills.
 - Rotate secrets on a fixed cadence.
@@ -154,10 +154,12 @@ Keep a one-liner command ready for each action and store it in the runbook.
 
 > **Remember**: Simplicity plus strong fundamentals beat heavy processes every time.
 
-
 ## Further Reading
 
-- [Incident Management overview](/incident-management/overview)
+- [Playbooks overview](/incident-management/playbooks/overview): how the playbooks in this section fit together
+- [Incident Management overview](/incident-management/overview): how the pages of this framework fit together
+- [Roles and Staffing](/incident-management/incident-response-template/roles-and-staffing): assigning response roles without a central team
+- [SEAL 911 War Room Guidelines](/incident-management/playbooks/seal-911-war-room-guidelines): reaching outside help fast
 
 ---
 

--- a/docs/pages/incident-management/playbooks/decentralized-ir.mdx
+++ b/docs/pages/incident-management/playbooks/decentralized-ir.mdx
@@ -154,6 +154,11 @@ Keep a one-liner command ready for each action and store it in the runbook.
 
 > **Remember**: Simplicity plus strong fundamentals beat heavy processes every time.
 
+
+## Further Reading
+
+- [Incident Management overview](/incident-management/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/playbooks/decentralized-ir.mdx
+++ b/docs/pages/incident-management/playbooks/decentralized-ir.mdx
@@ -154,7 +154,7 @@ Keep a one-liner command ready for each action and store it in the runbook.
 
 > **Remember**: Simplicity plus strong fundamentals beat heavy processes every time.
 
-## Further Reading
+## Further reading
 
 - [Playbooks overview](/incident-management/playbooks/overview): how the playbooks in this section fit together
 - [Incident Management overview](/incident-management/overview): how the pages of this framework fit together

--- a/docs/pages/incident-management/playbooks/decentralized-ir.mdx
+++ b/docs/pages/incident-management/playbooks/decentralized-ir.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Decentralized Incident Response | SEAL"
-description: "Decentralized Incident Response Framework (DeIRF) for security teams without a single authority. Zero-trust by default, shared responsibility, and open tooling for faster containment."
+description: "Decentralized Incident Response Framework (DeIRF) for security teams without a single authority. Zero-trust by default, shared responsibility"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/incident-management/playbooks/decentralized-ir.mdx
+++ b/docs/pages/incident-management/playbooks/decentralized-ir.mdx
@@ -124,7 +124,7 @@ Keep a one-liner command ready for each action and store it in the runbook.
 
 ---
 
-## 8. Quick-Start Templates
+### 8. Quick-Start Templates
 
 | Need | Template location |
 | ------ | ------------------- |
@@ -133,7 +133,7 @@ Keep a one-liner command ready for each action and store it in the runbook.
 
 ---
 
-## 9. Pros and Cons of Decentralized IR
+### 9. Pros and Cons of Decentralized IR
 
 | Aspect | Pros | Cons |
 | -------- | ------ | ------ |
@@ -144,7 +144,7 @@ Keep a one-liner command ready for each action and store it in the runbook.
 
 ---
 
-## 10. Keep It Alive
+### 10. Keep It Alive
 
 - Run quarterly red team drills.
 - Rotate secrets on a fixed cadence.

--- a/docs/pages/incident-management/playbooks/decentralized-ir.mdx
+++ b/docs/pages/incident-management/playbooks/decentralized-ir.mdx
@@ -9,13 +9,22 @@ tags:
 contributors:
   - role: wrote
     users: [relotnek]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
+
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
 
 # Decentralized Incident Response Framework (DeIRF)
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: DeIRF is a menu for teams without a single authority: zero-trust
+> defaults, shared responsibility, and open tooling. Prefer simple fundamentals over
+> heavy process nobody will follow.
 
 A lightweight, end-to-end scaffold for security teams that work without a single authority.
 Use it as a menu, not a mandate.

--- a/docs/pages/incident-management/playbooks/hacked-dprk.mdx
+++ b/docs/pages/incident-management/playbooks/hacked-dprk.mdx
@@ -7,6 +7,10 @@ tags:
 contributors:
   - role: wrote
     users: [SEAL]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
@@ -15,6 +19,10 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Treat a confirmed DPRK compromise as full credential and key theft.
+> Follow the malware playbook first, assume impersonation risk to contacts, and rotate
+> everything reachable from the infected host.
 
 If you’ve been sent this document, then we have very good reason to believe that you have been hacked by North Korea
 (DPRK). This document will give you some information about North Korea, why they’ve hacked you, and how they might’ve

--- a/docs/pages/incident-management/playbooks/hacked-dprk.mdx
+++ b/docs/pages/incident-management/playbooks/hacked-dprk.mdx
@@ -89,6 +89,11 @@ In this method, you are sent a link to download a report, slide deck, or other p
 If you download and run this file, you will have executed the malware. The first thing the malware does is open the PDF
 file you were expecting, so that you do not suspect you were infected.
 
+
+## Further Reading
+
+- [Incident Management overview](/incident-management/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/playbooks/hacked-dprk.mdx
+++ b/docs/pages/incident-management/playbooks/hacked-dprk.mdx
@@ -1,6 +1,6 @@
 ---
 title: "North Korea (DPRK) Attack Response | SEAL"
-description: "Respond to North Korea (DPRK) cyberattacks. Learn how hacking squads use fake video conference software and fake PDFs to steal private keys, files, and credentials. Immediate response steps included."
+description: "Respond to North Korea (DPRK) cyberattacks. Learn how hacking squads use fake video conference software and fake PDFs to steal private keys, files"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/incident-management/playbooks/hacked-dprk.mdx
+++ b/docs/pages/incident-management/playbooks/hacked-dprk.mdx
@@ -89,7 +89,7 @@ In this method, you are sent a link to download a report, slide deck, or other p
 If you download and run this file, you will have executed the malware. The first thing the malware does is open the PDF
 file you were expecting, so that you do not suspect you were infected.
 
-## Further Reading
+## Further reading
 
 - [Playbooks overview](/incident-management/playbooks/overview): how the playbooks in this section fit together
 - [DPRK IT Workers](/dprk-it-workers/overview): who the actor is and how they get hired

--- a/docs/pages/incident-management/playbooks/hacked-dprk.mdx
+++ b/docs/pages/incident-management/playbooks/hacked-dprk.mdx
@@ -89,10 +89,12 @@ In this method, you are sent a link to download a report, slide deck, or other p
 If you download and run this file, you will have executed the malware. The first thing the malware does is open the PDF
 file you were expecting, so that you do not suspect you were infected.
 
-
 ## Further Reading
 
-- [Incident Management overview](/incident-management/overview)
+- [Playbooks overview](/incident-management/playbooks/overview): how the playbooks in this section fit together
+- [DPRK IT Workers](/dprk-it-workers/overview): who the actor is and how they get hired
+- [Mitigating DPRK IT Workers](/dprk-it-workers/mitigating-dprk-it-workers): hardening and post-discovery steps
+- [SEAL 911 War Room Guidelines](/incident-management/playbooks/seal-911-war-room-guidelines): reaching outside help fast
 
 ---
 

--- a/docs/pages/incident-management/playbooks/hacked-drainer.mdx
+++ b/docs/pages/incident-management/playbooks/hacked-drainer.mdx
@@ -7,13 +7,22 @@ tags:
 contributors:
   - role: wrote
     users: [SEAL]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
+
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
 
 # Wallet Drainer Attack
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Wallet drainers abuse approvals, signatures, and account
+> upgrades—not always seed phrases. Identify the drainer type first; recovery steps
+> differ for approvals versus full key control.
 
 If you’ve been sent this document, then we believe that your funds have been stolen by a wallet drainer. This document
 will give you some information about drainers, how they work, and how you can protect yourself going forward.

--- a/docs/pages/incident-management/playbooks/hacked-drainer.mdx
+++ b/docs/pages/incident-management/playbooks/hacked-drainer.mdx
@@ -51,6 +51,11 @@ known to:
 Depending on which type of drainer affected you, you might need to take different actions to recover control of
 your wallet.
 
+
+## Further Reading
+
+- [Incident Management overview](/incident-management/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/playbooks/hacked-drainer.mdx
+++ b/docs/pages/incident-management/playbooks/hacked-drainer.mdx
@@ -51,10 +51,12 @@ known to:
 Depending on which type of drainer affected you, you might need to take different actions to recover control of
 your wallet.
 
-
 ## Further Reading
 
-- [Incident Management overview](/incident-management/overview)
+- [Playbooks overview](/incident-management/playbooks/overview): how the playbooks in this section fit together
+- [Smart Contract Interaction Security](/wallet-security/smart-contract-interaction-security): approvals and signing hygiene that prevent this
+- [Understanding Threat Vectors](/awareness/understanding-threat-vectors): how drainer lures reach users
+- [SEAL 911 War Room Guidelines](/incident-management/playbooks/seal-911-war-room-guidelines): reaching outside help fast
 
 ---
 

--- a/docs/pages/incident-management/playbooks/hacked-drainer.mdx
+++ b/docs/pages/incident-management/playbooks/hacked-drainer.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Wallet Drainer Attack Response | SEAL"
-description: "Recover from wallet drainer attacks. Understand how drainers request token approvals, DEX signatures, and 7702 wallet upgrades. Steps to recover control after different drainer types."
+description: "Recover from wallet drainer attacks. Understand how drainers request token approvals, DEX signatures, and 7702 wallet upgrades"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/incident-management/playbooks/hacked-drainer.mdx
+++ b/docs/pages/incident-management/playbooks/hacked-drainer.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Wallet Drainer Attack Response | SEAL"
-description: "Recover from wallet drainer attacks. Understand how drainers request token approvals, DEX signatures, and 7702 wallet upgrades"
+description: "Recover from a wallet drainer attack. Identify whether it took token approvals, DEX signatures, an EIP-7702 upgrade, or full key control, then act on that."
 tags:
   - Security Specialist
   - Operations & Strategy
@@ -51,7 +51,7 @@ known to:
 Depending on which type of drainer affected you, you might need to take different actions to recover control of
 your wallet.
 
-## Further Reading
+## Further reading
 
 - [Playbooks overview](/incident-management/playbooks/overview): how the playbooks in this section fit together
 - [Smart Contract Interaction Security](/wallet-security/smart-contract-interaction-security): approvals and signing hygiene that prevent this

--- a/docs/pages/incident-management/playbooks/hacked-elusive-comet.mdx
+++ b/docs/pages/incident-management/playbooks/hacked-elusive-comet.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ELUSIVE COMET Attack Response | SEAL"
-description: "Defend against ELUSIVE COMET threat actor using Zoom remote control attacks. Learn how they impersonate investors and journalists to trick victims into sharing screens and installing malware."
+description: "Defend against ELUSIVE COMET threat actor using Zoom remote control attacks. Learn how they impersonate investors and journalists to trick victims into sharing"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/incident-management/playbooks/hacked-elusive-comet.mdx
+++ b/docs/pages/incident-management/playbooks/hacked-elusive-comet.mdx
@@ -76,10 +76,12 @@ accounts and sending out phishing messages to more people.
   <p><em>A message sent from an account belonging to a victim of ELUSIVE COMET</em></p>
 </div>
 
-
 ## Further Reading
 
-- [Incident Management overview](/incident-management/overview)
+- [Playbooks overview](/incident-management/playbooks/overview): how the playbooks in this section fit together
+- [Zoom Hardening](/guides/endpoint-security/zoom-hardening): closing the vector this attack uses
+- [Malware playbook](/incident-management/playbooks/malware): response once code has run on the device
+- [SEAL 911 War Room Guidelines](/incident-management/playbooks/seal-911-war-room-guidelines): reaching outside help fast
 
 ---
 

--- a/docs/pages/incident-management/playbooks/hacked-elusive-comet.mdx
+++ b/docs/pages/incident-management/playbooks/hacked-elusive-comet.mdx
@@ -76,6 +76,11 @@ accounts and sending out phishing messages to more people.
   <p><em>A message sent from an account belonging to a victim of ELUSIVE COMET</em></p>
 </div>
 
+
+## Further Reading
+
+- [Incident Management overview](/incident-management/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/playbooks/hacked-elusive-comet.mdx
+++ b/docs/pages/incident-management/playbooks/hacked-elusive-comet.mdx
@@ -76,7 +76,7 @@ accounts and sending out phishing messages to more people.
   <p><em>A message sent from an account belonging to a victim of ELUSIVE COMET</em></p>
 </div>
 
-## Further Reading
+## Further reading
 
 - [Playbooks overview](/incident-management/playbooks/overview): how the playbooks in this section fit together
 - [Zoom Hardening](/guides/endpoint-security/zoom-hardening): closing the vector this attack uses

--- a/docs/pages/incident-management/playbooks/hacked-elusive-comet.mdx
+++ b/docs/pages/incident-management/playbooks/hacked-elusive-comet.mdx
@@ -7,13 +7,22 @@ tags:
 contributors:
   - role: wrote
     users: [SEAL]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
+
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
 
 # ELUSIVE COMET Attack
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: ELUSIVE COMET social-engineers victims on Zoom into screen share and
+> remote control. Never grant remote control or full-screen share to unsolicited
+> "investors" or "press."
 
 If you’ve been sent this, then we believe that you’ve been hacked by a threat actor we’ve identified as ELUSIVE COMET.
 This document will give you some information about drainers, how they work, and how you can protect yourself going

--- a/docs/pages/incident-management/playbooks/malware.mdx
+++ b/docs/pages/incident-management/playbooks/malware.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Malware Infection Response | Security Alliance"
-description: "Step-by-step malware infection response guide from SEAL 911. Secure crypto assets, notify colleagues, protect accounts from sweeper bots"
+description: "Step-by-step malware response from SEAL 911. Secure crypto assets against sweeper bots, notify colleagues, regain accounts, and rebuild on a clean machine."
 tags:
   - Security Specialist
   - Operations & Strategy
@@ -182,7 +182,7 @@ Here are some guides specifically for securing your:
 - [Securing Telegram](/community-management/telegram)
 - [Securing Google](/opsec/google/overview)
 
-## Further Reading
+## Further reading
 
 - [Playbooks overview](/incident-management/playbooks/overview): how the playbooks in this section fit together
 - [Endpoint Security](/opsec/endpoint/overview): device hardening that limits the blast radius

--- a/docs/pages/incident-management/playbooks/malware.mdx
+++ b/docs/pages/incident-management/playbooks/malware.mdx
@@ -7,13 +7,22 @@ tags:
 contributors:
   - role: wrote
     users: [SEAL]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
+
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
 
 # Malware Infection
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: If you suspect malware, disconnect and power off immediately, then
+> continue from a clean device. Secure crypto assets and accounts before forensic
+> curiosity costs more keys.
 
 This is a short guide prepared by SEAL that will help you navigate a malware infection. You have a limited amount of
 time to reduce the amount of damage that can be done to you. If you need help at any point, contact [**SEAL

--- a/docs/pages/incident-management/playbooks/malware.mdx
+++ b/docs/pages/incident-management/playbooks/malware.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Malware Infection Response | Security Alliance"
-description: "Step-by-step malware infection response guide from SEAL 911. Secure crypto assets, notify colleagues, protect accounts from sweeper bots, and recover from MetaMask, Ledger Live, and browser compromises."
+description: "Step-by-step malware infection response guide from SEAL 911. Secure crypto assets, notify colleagues, protect accounts from sweeper bots"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/incident-management/playbooks/malware.mdx
+++ b/docs/pages/incident-management/playbooks/malware.mdx
@@ -182,6 +182,11 @@ Here are some guides specifically for securing your:
 - [Securing Telegram](/community-management/telegram)
 - [Securing Google](/opsec/google/overview)
 
+
+## Further Reading
+
+- [Incident Management overview](/incident-management/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/playbooks/malware.mdx
+++ b/docs/pages/incident-management/playbooks/malware.mdx
@@ -182,10 +182,12 @@ Here are some guides specifically for securing your:
 - [Securing Telegram](/community-management/telegram)
 - [Securing Google](/opsec/google/overview)
 
-
 ## Further Reading
 
-- [Incident Management overview](/incident-management/overview)
+- [Playbooks overview](/incident-management/playbooks/overview): how the playbooks in this section fit together
+- [Endpoint Security](/opsec/endpoint/overview): device hardening that limits the blast radius
+- [Drainer playbook](/incident-management/playbooks/hacked-drainer): response if wallet access followed
+- [SEAL 911 War Room Guidelines](/incident-management/playbooks/seal-911-war-room-guidelines): reaching outside help fast
 
 ---
 

--- a/docs/pages/incident-management/playbooks/overview.mdx
+++ b/docs/pages/incident-management/playbooks/overview.mdx
@@ -27,7 +27,7 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 Incident response playbooks provide step-by-step procedures for handling specific security incidents.
 You cannot cover every scenario ahead of time, so prioritize the most likely and most devastating cases.
 
-## Playbooks in this section
+## What this framework covers
 
 1. [Malware Infection](/incident-management/playbooks/malware): immediate containment when a host may be
    compromised.

--- a/docs/pages/incident-management/playbooks/overview.mdx
+++ b/docs/pages/incident-management/playbooks/overview.mdx
@@ -55,7 +55,7 @@ You cannot cover every scenario ahead of time, so prioritize the most likely and
 For example incident runbooks and templates, see
 [Incident Response Template: Templates](/incident-management/incident-response-template/templates/overview).
 
-## Further Reading
+## Further reading
 
 - [Incident Management overview](/incident-management/overview): how the pages of this framework fit together
 - [SEAL 911 War Room Guidelines](/incident-management/playbooks/seal-911-war-room-guidelines): reaching outside help fast

--- a/docs/pages/incident-management/playbooks/overview.mdx
+++ b/docs/pages/incident-management/playbooks/overview.mdx
@@ -55,10 +55,12 @@ You cannot cover every scenario ahead of time, so prioritize the most likely and
 For example incident runbooks and templates, see
 [Incident Response Template: Templates](/incident-management/incident-response-template/templates/overview).
 
-
 ## Further Reading
 
-- [Incident Management overview](/incident-management/overview)
+- [Incident Management overview](/incident-management/overview): how the pages of this framework fit together
+- [SEAL 911 War Room Guidelines](/incident-management/playbooks/seal-911-war-room-guidelines): reaching outside help fast
+- [Incident Response Template overview](/incident-management/incident-response-template/overview): how the template pieces fit together
+- [Incident Detection and Response](/incident-management/incident-detection-and-response): the detection step before any playbook
 
 ---
 

--- a/docs/pages/incident-management/playbooks/overview.mdx
+++ b/docs/pages/incident-management/playbooks/overview.mdx
@@ -4,6 +4,13 @@ description: "Create step-by-step incident response playbooks for stolen funds, 
 tags:
   - Security Specialist
   - Operations & Strategy
+contributors:
+  - role: wrote
+    users: []
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
@@ -13,15 +20,33 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Generally speaking, incident response playbooks aim to provide detailed, step-by-step procedures for handling specific
-types of security incidents. Obviously, it's not possible to have thought about every possible scenario ahead of time,
-but one could create documentation for the most likely or devastating scenarios.
+> 🔑 **Key Takeaway**: Write playbooks for your most likely and most devastating scenarios
+> before they hit. Each playbook should cover detection IOCs, containment, eradication,
+> recovery, and a lessons-learned loop.
+
+Incident response playbooks provide step-by-step procedures for handling specific security incidents.
+You cannot cover every scenario ahead of time, so prioritize the most likely and most devastating cases.
+
+## Playbooks in this section
+
+1. [Malware Infection](/incident-management/playbooks/malware): immediate containment when a host may be
+   compromised.
+2. [North Korea (DPRK) Attack](/incident-management/playbooks/hacked-dprk): victim guidance for confirmed
+   DPRK compromise paths.
+3. [Wallet Drainer Attack](/incident-management/playbooks/hacked-drainer): recover control after approval
+   or signature drainage.
+4. [ELUSIVE COMET Attack](/incident-management/playbooks/hacked-elusive-comet): Zoom remote-control social
+   engineering response.
+5. [SEAL 911 War Room Guidelines](/incident-management/playbooks/seal-911-war-room-guidelines): how to
+   engage SEAL 911 and run a crisis channel.
+6. [Decentralized Incident Response Framework (DeIRF)](/incident-management/playbooks/decentralized-ir):
+   IR scaffold for teams without a single authority.
 
 ## Best Practices
 
 1. Define the type of incident the playbook addresses (e.g., stolen funds, data breach, DDoS attack).
-2. Outline the steps for detecting and analyzing the incident, including key indicators of compromise (IOCs) and tools
-to use.
+2. Outline the steps for detecting and analyzing the incident, including key indicators of compromise
+   (IOCs) and tools to use.
 3. Describe immediate actions to contain the incident and prevent further damage.
 4. Provide detailed steps for eradicating the root cause of the incident.
 5. Outline procedures for restoring everything affected to normal operation.

--- a/docs/pages/incident-management/playbooks/overview.mdx
+++ b/docs/pages/incident-management/playbooks/overview.mdx
@@ -55,6 +55,11 @@ You cannot cover every scenario ahead of time, so prioritize the most likely and
 For example incident runbooks and templates, see
 [Incident Response Template: Templates](/incident-management/incident-response-template/templates/overview).
 
+
+## Further Reading
+
+- [Incident Management overview](/incident-management/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/playbooks/overview.mdx
+++ b/docs/pages/incident-management/playbooks/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Incident Response Playbooks | Security Alliance"
-description: "Create step-by-step incident response playbooks for stolen funds, data breaches, and DDoS attacks. Define indicators of compromise (IOCs), containment actions, and recovery procedures."
+description: "Create step-by-step incident response playbooks for stolen funds, data breaches, and DDoS attacks. Define indicators of compromise (IOCs), containment actions"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/incident-management/playbooks/overview.mdx
+++ b/docs/pages/incident-management/playbooks/overview.mdx
@@ -42,7 +42,7 @@ You cannot cover every scenario ahead of time, so prioritize the most likely and
 6. [Decentralized Incident Response Framework (DeIRF)](/incident-management/playbooks/decentralized-ir):
    IR scaffold for teams without a single authority.
 
-## Best Practices
+## Best practices
 
 1. Define the type of incident the playbook addresses (e.g., stolen funds, data breach, DDoS attack).
 2. Outline the steps for detecting and analyzing the incident, including key indicators of compromise

--- a/docs/pages/incident-management/playbooks/seal-911-war-room-guidelines.mdx
+++ b/docs/pages/incident-management/playbooks/seal-911-war-room-guidelines.mdx
@@ -291,6 +291,11 @@ Funds at Risk: [Estimated Amount in USD or Token]
 [Brief Description of the incident]
 ```
 
+
+## Further Reading
+
+- [Incident Management overview](/incident-management/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/incident-management/playbooks/seal-911-war-room-guidelines.mdx
+++ b/docs/pages/incident-management/playbooks/seal-911-war-room-guidelines.mdx
@@ -291,7 +291,7 @@ Funds at Risk: [Estimated Amount in USD or Token]
 [Brief Description of the incident]
 ```
 
-## Further Reading
+## Further reading
 
 - [Playbooks overview](/incident-management/playbooks/overview): how the playbooks in this section fit together
 - [Incident Management overview](/incident-management/overview): how the pages of this framework fit together

--- a/docs/pages/incident-management/playbooks/seal-911-war-room-guidelines.mdx
+++ b/docs/pages/incident-management/playbooks/seal-911-war-room-guidelines.mdx
@@ -7,6 +7,10 @@ tags:
 contributors:
   - role: wrote
     users: [SEAL]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../components'
@@ -15,6 +19,10 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: SEAL 911 coordinates trusted researchers via the Telegram bot under
+> a strict code of conduct. Bring complete incident facts early so responders avoid
+> duplicated work during a crisis.
 
 SEAL 911 is a project designed to give users, developers, and even other security researchers an accessible method to
 contact a small group of highly trusted security researchers. The group can be reached via the [Telegram

--- a/docs/pages/incident-management/playbooks/seal-911-war-room-guidelines.mdx
+++ b/docs/pages/incident-management/playbooks/seal-911-war-room-guidelines.mdx
@@ -1,6 +1,6 @@
 ---
 title: "SEAL 911 War Room Guidelines | SEAL"
-description: "SEAL 911 War Room guidelines for smart contract hack response. Create incident channels, assign key roles, gather attack transactions, pause contracts, and coordinate recovery with the Telegram bot."
+description: "SEAL 911 War Room guidelines for smart contract hack response. Create incident channels, assign key roles, gather attack transactions, pause contracts"
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/incident-management/playbooks/seal-911-war-room-guidelines.mdx
+++ b/docs/pages/incident-management/playbooks/seal-911-war-room-guidelines.mdx
@@ -291,10 +291,12 @@ Funds at Risk: [Estimated Amount in USD or Token]
 [Brief Description of the incident]
 ```
 
-
 ## Further Reading
 
-- [Incident Management overview](/incident-management/overview)
+- [Playbooks overview](/incident-management/playbooks/overview): how the playbooks in this section fit together
+- [Incident Management overview](/incident-management/overview): how the pages of this framework fit together
+- [Contacts template](/incident-management/incident-response-template/contacts): the contact list to have ready before you need it
+- [Communications template](/incident-management/incident-response-template/communications): coordinating public messaging during the incident
 
 ---
 


### PR DESCRIPTION
## Scope
Normalize content chrome for `docs/pages/incident-management/**` only (SEAL frameworks content model). No other frameworks.

## Why
Align Incident Management pages with canonical Key Takeaway format, contributor roles, nested overview page maps, footer separators, and absolute internal links—matching prior framework normalize PRs.

## Content model applied
- Canonical `> 🔑 **Key Takeaway**:` (colon outside bold) from existing page substance
- Frontmatter `contributors` with `wrote` / `reviewed` / `fact-checked` (preserve usernames; empty arrays OK)
- Brief intro after KT when page previously jumped straight to `##`
- Nested overviews get sidebar-aligned page maps with absolute links
- `---` before `<ContributeFooter />`
- Prefer absolute internal links when links were touched
- Do not edit generated `index.mdx`

## Changes
- Framework overview page map (already drafted): top-level pages, playbooks, IR template/templates/runbooks hubs
- Nested overviews: playbooks, IR template, templates hub, runbooks hub—child lists + absolute links
- Leaf pages across playbooks, policy/roles/comms/contacts, templates, and runbooks: KT + chrome only
- Relative internal links converted to absolute where chrome touched; MD013 wraps applied

## Substantive security guidance changes
None. Procedures, checklists, runbook steps, and template bodies preserved.

## Intentionally unchanged
- Generated `index.mdx` files
- Other frameworks
- `.mailmap`
- Security procedure content (not rewritten)
- Forensic Readiness body (already had KT/chrome; no substantive chrome delta vs base)

## Validation
```
npx --yes markdownlint-cli2 "docs/pages/incident-management/**/*.mdx"  # 0 issues
pnpm exec cspell --no-progress "docs/pages/incident-management/**/*.mdx"  # 0 issues
```

## Dependencies
Depends on content-model direction from #561 by reference only (no hard merge block intended beyond develop base).

## Reviewer focus
- Key Takeaways accurate to page substance (no invented guidance)
- Nested page maps match `vocs.config.ts` sidebar children
- Absolute links correct
- No accidental procedure body rewrites
- Authors preserved in contributors