### PR TITLE
docs(devsecops): normalize structure and wording

### DIFF
--- a/docs/pages/devsecops/code-signing.mdx
+++ b/docs/pages/devsecops/code-signing.mdx
@@ -12,7 +12,6 @@ contributors:
     users: [scode2277]
   - role: fact-checked
     users: []
-
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'

--- a/docs/pages/devsecops/code-signing.mdx
+++ b/docs/pages/devsecops/code-signing.mdx
@@ -78,13 +78,13 @@ Good key management is the foundation of code signing. A poorly managed key unde
 Use RSA 4096 or Ed25519 (the latter is modern, fast, and secure):
 
 ```bash
- # Ed25519 (recommended for modern setups)
+# Ed25519 (recommended for modern setups)
 gpg --full-generate-key
- # Choose Ed25519 when prompted, or: gpg --quick-gen-key your@email.com ed25519 sign,auth cert never
+# Choose Ed25519 when prompted, or: gpg --quick-gen-key your@email.com ed25519 sign,auth cert never
 
- # RSA 4096 (legacy compatibility)
+# RSA 4096 (legacy compatibility)
 gpg --full-generate-key
- # Choose RSA 4096
+# Choose RSA 4096
 ```
 
 #### Using subkeys for separation of duties
@@ -93,14 +93,14 @@ Create separate subkeys for signing and encryption. This lets you keep the maste
 key completely offline while using subkeys daily:
 
 ```bash
- # Add a signing subkey
+# Add a signing subkey
 gpg --edit-key YOUR_KEYID
 gpg> addkey
- # Choose: RSA 4096, Sign only, expiry 1-2 years
+# Choose: RSA 4096, Sign only, expiry 1-2 years
 
- # Add an encryption subkey (separate from any encryption subkey you already have)
+# Add an encryption subkey (separate from any encryption subkey you already have)
 gpg> addkey
- # Choose: RSA 4096, Encrypt only, expiry 1-2 years
+# Choose: RSA 4096, Encrypt only, expiry 1-2 years
 
 gpg> save
 ```
@@ -115,13 +115,13 @@ Generate GPG keys directly on the YubiKey so the private key material never
 touches the host system:
 
 ```bash
- # Initialize the YubiKey OpenPGP applet
+# Initialize the YubiKey OpenPGP applet
 gpg --card-edit
 gpg> admin
 gpg> generate
- # Choose a touch policy (require touch for signing operations)
+# Choose a touch policy (require touch for signing operations)
 
- # Or move existing subkeys to the YubiKey:
+# Or move existing subkeys to the YubiKey:
 gpg --edit-key YOUR_KEYID
 gpg> key 1        # Select the signing subkey
 gpg> keytocard    # Move it to YubiKey
@@ -140,7 +140,7 @@ Protect GPG keys with a strong passphrase (20+ characters, random). Use `gpg-age
 caching to avoid re-entering it constantly:
 
 ```bash
- # In ~/.gnupg/gpg-agent.conf:
+# In ~/.gnupg/gpg-agent.conf:
 pinentry-program /usr/bin/pinentry-tty
 default-cache-ttl 86400      # Cache for 24 hours
 max-cache-ttl 604800         # Expire after 1 week
@@ -168,21 +168,21 @@ a stolen key means forged commits.
 **Backup the master key:**
 
 ```bash
- # Export to an encrypted file
+# Export to an encrypted file
 gpg --export-secret-keys --armor YOUR_KEYID | \
   gpg --symmetric --cipher-algo AES256 \
   --output master-key-backup.gpg
 
- # Store on: encrypted USB (LUKS), paper (print the ASCII armor and seal in a safe),
- # or a password manager as an encrypted attachment
+# Store on: encrypted USB (LUKS), paper (print the ASCII armor and seal in a safe),
+# or a password manager as an encrypted attachment
 ```
 
 **Generate and store revocation certificates immediately:**
 
 ```bash
 gpg --gen-revoke YOUR_KEYID > revocation-certificate.asc
- # Store this certificate alongside the backup. If you lose access to the key,
- # publishing the revocation certificate invalidates the compromised key.
+# Store this certificate alongside the backup. If you lose access to the key,
+# publishing the revocation certificate invalidates the compromised key.
 ```
 
 **Recovery test:** Periodically verify you can decrypt using your backup

--- a/docs/pages/devsecops/code-signing.mdx
+++ b/docs/pages/devsecops/code-signing.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Implementing Code Signing | Security Alliance"
-description: "Verify code integrity with GPG-signed commits and pull requests. Best practices for key management, MFA with Yubikeys, mandatory code reviews, key rotation, and establishing a chain of trust from commit to deployment."
+description: "Verify code integrity with GPG-signed commits and tags, hardware-backed MFA, key rotation, and branch rules that reject unsigned history changes."
 tags:
   - Engineer/Developer
   - Security Specialist
@@ -10,6 +10,9 @@ contributors:
     users: [mattaereal]
   - role: reviewed
     users: [scode2277]
+  - role: fact-checked
+    users: []
+
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -271,7 +274,7 @@ Real-world implications:
 | Generate revocation cert | `gpg --gen-revoke <FINGERPRINT> > revoke.asc` |
 | Upload to keyserver | `gpg --keyserver keys.openpgp.org --send-keys <FINGERPRINT>` |
 
-## References
+## Further reading
 
 - [GitHub Docs: Managing commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification)
 - [GitHub Docs: About signature verification for commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)

--- a/docs/pages/devsecops/code-signing.mdx
+++ b/docs/pages/devsecops/code-signing.mdx
@@ -78,13 +78,13 @@ Good key management is the foundation of code signing. A poorly managed key unde
 Use RSA 4096 or Ed25519 (the latter is modern, fast, and secure):
 
 ```bash
-# Ed25519 (recommended for modern setups)
+ # Ed25519 (recommended for modern setups)
 gpg --full-generate-key
-# Choose Ed25519 when prompted, or: gpg --quick-gen-key your@email.com ed25519 sign,auth cert never
+ # Choose Ed25519 when prompted, or: gpg --quick-gen-key your@email.com ed25519 sign,auth cert never
 
-# RSA 4096 (legacy compatibility)
+ # RSA 4096 (legacy compatibility)
 gpg --full-generate-key
-# Choose RSA 4096
+ # Choose RSA 4096
 ```
 
 #### Using subkeys for separation of duties
@@ -93,14 +93,14 @@ Create separate subkeys for signing and encryption. This lets you keep the maste
 key completely offline while using subkeys daily:
 
 ```bash
-# Add a signing subkey
+ # Add a signing subkey
 gpg --edit-key YOUR_KEYID
 gpg> addkey
-# Choose: RSA 4096, Sign only, expiry 1-2 years
+ # Choose: RSA 4096, Sign only, expiry 1-2 years
 
-# Add an encryption subkey (separate from any encryption subkey you already have)
+ # Add an encryption subkey (separate from any encryption subkey you already have)
 gpg> addkey
-# Choose: RSA 4096, Encrypt only, expiry 1-2 years
+ # Choose: RSA 4096, Encrypt only, expiry 1-2 years
 
 gpg> save
 ```
@@ -115,13 +115,13 @@ Generate GPG keys directly on the YubiKey so the private key material never
 touches the host system:
 
 ```bash
-# Initialize the YubiKey OpenPGP applet
+ # Initialize the YubiKey OpenPGP applet
 gpg --card-edit
 gpg> admin
 gpg> generate
-# Choose a touch policy (require touch for signing operations)
+ # Choose a touch policy (require touch for signing operations)
 
-# Or move existing subkeys to the YubiKey:
+ # Or move existing subkeys to the YubiKey:
 gpg --edit-key YOUR_KEYID
 gpg> key 1        # Select the signing subkey
 gpg> keytocard    # Move it to YubiKey
@@ -140,7 +140,7 @@ Protect GPG keys with a strong passphrase (20+ characters, random). Use `gpg-age
 caching to avoid re-entering it constantly:
 
 ```bash
-# In ~/.gnupg/gpg-agent.conf:
+ # In ~/.gnupg/gpg-agent.conf:
 pinentry-program /usr/bin/pinentry-tty
 default-cache-ttl 86400      # Cache for 24 hours
 max-cache-ttl 604800         # Expire after 1 week
@@ -168,21 +168,21 @@ a stolen key means forged commits.
 **Backup the master key:**
 
 ```bash
-# Export to an encrypted file
+ # Export to an encrypted file
 gpg --export-secret-keys --armor YOUR_KEYID | \
   gpg --symmetric --cipher-algo AES256 \
   --output master-key-backup.gpg
 
-# Store on: encrypted USB (LUKS), paper (print the ASCII armor and seal in a safe),
-# or a password manager as an encrypted attachment
+ # Store on: encrypted USB (LUKS), paper (print the ASCII armor and seal in a safe),
+ # or a password manager as an encrypted attachment
 ```
 
 **Generate and store revocation certificates immediately:**
 
 ```bash
 gpg --gen-revoke YOUR_KEYID > revocation-certificate.asc
-# Store this certificate alongside the backup. If you lose access to the key,
-# publishing the revocation certificate invalidates the compromised key.
+ # Store this certificate alongside the backup. If you lose access to the key,
+ # publishing the revocation certificate invalidates the compromised key.
 ```
 
 **Recovery test:** Periodically verify you can decrypt using your backup

--- a/docs/pages/devsecops/continuous-integration-continuous-deployment.mdx
+++ b/docs/pages/devsecops/continuous-integration-continuous-deployment.mdx
@@ -13,7 +13,6 @@ contributors:
     users: [scode2277]
   - role: fact-checked
     users: []
-
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'

--- a/docs/pages/devsecops/continuous-integration-continuous-deployment.mdx
+++ b/docs/pages/devsecops/continuous-integration-continuous-deployment.mdx
@@ -171,7 +171,7 @@ for build integrity. GitHub Actions can generate provenance using the
 `slsa-framework/slsa-github-generator` action:
 
 ```yaml
- # In your release workflow
+# In your release workflow
 - name: Generate SLSA provenance
   uses: slsa-framework/slsa-github-generator@v2.0.0
   with:
@@ -184,7 +184,7 @@ Provenance attestation links the artifact to the exact source commit, builder
 identity, and build process. Verify provenance before deployment:
 
 ```bash
- # Verify with Cosign (if using Cosign for image signing)
+# Verify with Cosign (if using Cosign for image signing)
 cosign verify-attestation \
   --certificate-identity=https://github.com/<org>/<repo>.github/workflows/<workflow>@refs/tags/<tag> \
   --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
@@ -208,7 +208,7 @@ A Software Bill of Materials (SBOM) enumerates all dependencies and their versio
 enabling rapid vulnerability response when a CVE is disclosed.
 
 ```yaml
- # Generate SBOM with Syft in CI
+# Generate SBOM with Syft in CI
 - name: Generate SBOM
   uses: anchore/sbom-action@v0
   with:
@@ -216,7 +216,7 @@ enabling rapid vulnerability response when a CVE is disclosed.
     format: spdx-json
     output-file: sbom.spdx.json
 
- # Upload as artifact
+# Upload as artifact
 - name: Upload SBOM
   uses: actions/upload-artifact@v4
   with:
@@ -237,7 +237,7 @@ eliminates them entirely by granting short-lived, scoped tokens on demand.
 **GitHub Actions → AWS:**
 
 ```yaml
- # In your workflow
+# In your workflow
 - name: Configure AWS credentials
   uses: aws-actions/configure-aws-credentials@v4
   with:

--- a/docs/pages/devsecops/continuous-integration-continuous-deployment.mdx
+++ b/docs/pages/devsecops/continuous-integration-continuous-deployment.mdx
@@ -171,7 +171,7 @@ for build integrity. GitHub Actions can generate provenance using the
 `slsa-framework/slsa-github-generator` action:
 
 ```yaml
-# In your release workflow
+ # In your release workflow
 - name: Generate SLSA provenance
   uses: slsa-framework/slsa-github-generator@v2.0.0
   with:
@@ -184,7 +184,7 @@ Provenance attestation links the artifact to the exact source commit, builder
 identity, and build process. Verify provenance before deployment:
 
 ```bash
-# Verify with Cosign (if using Cosign for image signing)
+ # Verify with Cosign (if using Cosign for image signing)
 cosign verify-attestation \
   --certificate-identity=https://github.com/<org>/<repo>.github/workflows/<workflow>@refs/tags/<tag> \
   --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
@@ -208,7 +208,7 @@ A Software Bill of Materials (SBOM) enumerates all dependencies and their versio
 enabling rapid vulnerability response when a CVE is disclosed.
 
 ```yaml
-# Generate SBOM with Syft in CI
+ # Generate SBOM with Syft in CI
 - name: Generate SBOM
   uses: anchore/sbom-action@v0
   with:
@@ -216,7 +216,7 @@ enabling rapid vulnerability response when a CVE is disclosed.
     format: spdx-json
     output-file: sbom.spdx.json
 
-# Upload as artifact
+ # Upload as artifact
 - name: Upload SBOM
   uses: actions/upload-artifact@v4
   with:
@@ -237,7 +237,7 @@ eliminates them entirely by granting short-lived, scoped tokens on demand.
 **GitHub Actions → AWS:**
 
 ```yaml
-# In your workflow
+ # In your workflow
 - name: Configure AWS credentials
   uses: aws-actions/configure-aws-credentials@v4
   with:

--- a/docs/pages/devsecops/continuous-integration-continuous-deployment.mdx
+++ b/docs/pages/devsecops/continuous-integration-continuous-deployment.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Securing CI/CD Pipelines | Security Alliance"
-description: "Build secure CI/CD pipelines with GitHub Actions: unit tests, integration tests, vulnerability scanning, deterministic builds, secret management, and strict access controls for pipeline configurations."
+description: "Secure CI/CD with required checks, dependency and secret scans, ephemeral runners, scoped secrets, and deterministic build and deploy paths."
 tags:
   - Engineer/Developer
   - Security Specialist
@@ -11,6 +11,9 @@ contributors:
     users: [mattaereal]
   - role: reviewed
     users: [scode2277]
+  - role: fact-checked
+    users: []
+
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -332,7 +335,7 @@ to CI/CD pipeline security.
 | Sign artifacts | Cosign for containers, GPG for tags, SLSA provenance |
 | Audit workflow changes | CODEOWNERS on `.github/workflows/` |
 
-## References
+## Further reading
 
 - [SLSA Specification v1.0](https://slsa.dev/spec/v1.0/)
 - [NIST SP 800-218, Secure Software Development Framework](https://csrc.nist.gov/pubs/sp/800/218/final)

--- a/docs/pages/devsecops/data-security-upgrade-checklist.mdx
+++ b/docs/pages/devsecops/data-security-upgrade-checklist.mdx
@@ -8,9 +8,10 @@ tags:
 contributors:
   - role: wrote
     users: [quillaudits, dickson]
+  - role: reviewed
+    users: []
   - role: fact-checked
     users: [mattaereal]
-
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../components'

--- a/docs/pages/devsecops/data-security-upgrade-checklist.mdx
+++ b/docs/pages/devsecops/data-security-upgrade-checklist.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Data Security Checklist | Security Alliance"
-description: "Comprehensive checklist covering data security best practices for Web3 projects, including backup strategies, encryption, and third-party integration security."
+description: "Checklist for Web3 data security: encrypted tested backups, access controls, encryption at rest and in transit, and third-party data clauses."
 tags:
   - Engineer/Developer
   - Operations & Strategy
@@ -10,6 +10,7 @@ contributors:
     users: [quillaudits, dickson]
   - role: fact-checked
     users: [mattaereal]
+
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../components'
@@ -18,6 +19,15 @@ import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Protect Web3 operational data with encrypted, tested
+> backups; strong access and encryption controls; and contractual plus
+> technical limits on third parties that touch production or off-chain state.
+
+Use this checklist when standing up or reviewing controls for critical databases,
+configurations, off-chain indexers, and third-party integrations. Items are
+grouped by concern; complete each group for high-value systems before go-live
+and re-check after material architecture changes.
 
 ## 1. Data Backup & Disaster Recovery
 

--- a/docs/pages/devsecops/data-security-upgrade-checklist.mdx
+++ b/docs/pages/devsecops/data-security-upgrade-checklist.mdx
@@ -181,6 +181,11 @@ securing these integrations prevents supply chain attacks and data breaches.
     Data Processing Agreements (DPAs). Review contracts annually and before renewals.
 </Checklist>
 
+
+## Further Reading
+
+- [Devsecops overview](/devsecops/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/devsecops/data-security-upgrade-checklist.mdx
+++ b/docs/pages/devsecops/data-security-upgrade-checklist.mdx
@@ -181,10 +181,12 @@ securing these integrations prevents supply chain attacks and data breaches.
     Data Processing Agreements (DPAs). Review contracts annually and before renewals.
 </Checklist>
 
+## Further reading
 
-## Further Reading
-
-- [Devsecops overview](/devsecops/overview)
+- [DevSecOps overview](/devsecops/overview): how the pages of this framework fit together
+- [Full Disk Encryption](/encryption/full-disk-encryption): protecting the backups this checklist creates
+- [Vendor Risk Management](/supply-chain/vendor-risk-management): assessing the third-party integrations listed here
+- [Cloud Infrastructure](/infrastructure/cloud): storage, key management, and access controls in the provider
 
 ---
 

--- a/docs/pages/devsecops/governance-proposal-security.mdx
+++ b/docs/pages/devsecops/governance-proposal-security.mdx
@@ -648,6 +648,11 @@ Stage 3 of this page's checklists are designed to prevent.
 These incidents highlight why rigorous testing, specifically applied to governance proposals and their associated
 deployment scripts, is essential for safe upgrades.
 
+
+## Further Reading
+
+- [Devsecops overview](/devsecops/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/devsecops/governance-proposal-security.mdx
+++ b/docs/pages/devsecops/governance-proposal-security.mdx
@@ -8,9 +8,10 @@ tags:
 contributors:
   - role: wrote
     users: [quillaudits, dickson, ElliotFriedman]
+  - role: reviewed
+    users: []
   - role: fact-checked
     users: [mattaereal]
-
 ---
 
 import { TagList, AttributionList, ContributeFooter, GovernanceSDLCPipeline, GovernanceChecklistItem } from '../../../components'

--- a/docs/pages/devsecops/governance-proposal-security.mdx
+++ b/docs/pages/devsecops/governance-proposal-security.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Governance Proposal Security Across the SDLC | Security Alliance"
-description: "Threat-model guide to smart contract upgrade governance across the proposal lifecycle: supply chain, invariants, reproducible calldata, execution, and monitoring."
+title: "Governance Proposal Security Across the SDLC | SEAL"
+description: "Threat-model guide to smart contract upgrade governance across the proposal lifecycle: supply chain, invariants, reproducible calldata, and monitoring."
 tags:
   - Engineer/Developer
   - Operations & Strategy
@@ -10,6 +10,7 @@ contributors:
     users: [quillaudits, dickson, ElliotFriedman]
   - role: fact-checked
     users: [mattaereal]
+
 ---
 
 import { TagList, AttributionList, ContributeFooter, GovernanceSDLCPipeline, GovernanceChecklistItem } from '../../../components'

--- a/docs/pages/devsecops/governance-proposal-security.mdx
+++ b/docs/pages/devsecops/governance-proposal-security.mdx
@@ -648,10 +648,12 @@ Stage 3 of this page's checklists are designed to prevent.
 These incidents highlight why rigorous testing, specifically applied to governance proposals and their associated
 deployment scripts, is essential for safe upgrades.
 
+## Further reading
 
-## Further Reading
-
-- [Devsecops overview](/devsecops/overview)
+- [DevSecOps overview](/devsecops/overview): how the pages of this framework fit together
+- [Governance](/governance/overview): the decision-making process these proposals move through
+- [Security Council Best Practices](/governance/council-best-practices): emergency powers alongside normal governance
+- [Multisig for Protocols](/multisig-for-protocols/overview): executing approved proposals on-chain
 
 ---
 

--- a/docs/pages/devsecops/integrated-development-environments.mdx
+++ b/docs/pages/devsecops/integrated-development-environments.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Securing Development Environments | SEAL"
-description: "Secure your IDE with plugins from trusted sources only, restricted mode for untrusted projects, static code analysis tools, and isolation from production environments."
+description: "Secure IDEs with trusted extensions only, restricted mode for untrusted projects, built-in static analysis, least privilege, and isolation from production."
 tags:
   - Engineer/Developer
   - Security Specialist
@@ -8,6 +8,9 @@ tags:
 contributors:
   - role: wrote
     users: [mattaereal, fredriksvantes, ElliotFriedman]
+  - role: fact-checked
+    users: []
+
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -17,8 +20,13 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Integrated Development Environments (IDEs) are essential tools for developers, but they also need to be secured.
-Consider implementing the following best practices:
+> 🔑 **Key Takeaway**: Treat the IDE as part of the attack surface: install
+> extensions only after publisher and source verification, keep tooling
+> patched, enable in-editor security analysis, and keep development
+> environments isolated from production.
+
+Integrated Development Environments (IDEs) are essential tools for developers,
+but they also need to be secured. Implement the following practices:
 
 1. Install plugins and extensions only from trusted sources, and verify each one through multiple independent channels
   before installing:
@@ -35,6 +43,14 @@ Consider implementing the following best practices:
 3. Integrate static code analysis tools within the IDE to catch security issues early in the development process.
 4. Configure IDEs to follow the principle of least privilege, limiting access to sensitive information and systems.
 5. Ensure that potential development environments are isolated from production environments.
+
+## Related frameworks
+
+- [Developer Machine Confinement](/devsecops/isolation/developer-machine-sandboxing) —
+  confine agent and IDE workloads on the laptop
+- [Repository Hardening](/devsecops/repository-hardening) — controls for the code the IDE
+  pushes
+- [Security Testing](/devsecops/security-testing) — pipeline counterparts to IDE analysis
 
 ---
 

--- a/docs/pages/devsecops/integrated-development-environments.mdx
+++ b/docs/pages/devsecops/integrated-development-environments.mdx
@@ -44,13 +44,13 @@ but they also need to be secured. Implement the following practices:
 4. Configure IDEs to follow the principle of least privilege, limiting access to sensitive information and systems.
 5. Ensure that potential development environments are isolated from production environments.
 
-## Related frameworks
+## Further reading
 
-- [Developer Machine Confinement](/devsecops/isolation/developer-machine-sandboxing) —
-  confine agent and IDE workloads on the laptop
-- [Repository Hardening](/devsecops/repository-hardening) — controls for the code the IDE
-  pushes
-- [Security Testing](/devsecops/security-testing) — pipeline counterparts to IDE analysis
+- [DevSecOps overview](/devsecops/overview): how the pages of this framework fit together
+- [Developer Machine Confinement](/devsecops/isolation/developer-machine-sandboxing): confining agent and IDE
+  workloads on the laptop
+- [Repository Hardening](/devsecops/repository-hardening): controls for the code the IDE pushes
+- [Security Testing](/devsecops/security-testing): pipeline counterparts to IDE analysis
 
 ---
 

--- a/docs/pages/devsecops/integrated-development-environments.mdx
+++ b/docs/pages/devsecops/integrated-development-environments.mdx
@@ -8,9 +8,10 @@ tags:
 contributors:
   - role: wrote
     users: [mattaereal, fredriksvantes, ElliotFriedman]
+  - role: reviewed
+    users: []
   - role: fact-checked
     users: []
-
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'

--- a/docs/pages/devsecops/isolation/capability-based-isolation.mdx
+++ b/docs/pages/devsecops/isolation/capability-based-isolation.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Capability-Based Isolation | SEAL"
-description: "Capability-scoped isolation patterns that replace broad runtime privileges with explicit, auditable permissions."
+description: "Replace ambient admin rights with short-lived, task-scoped capabilities so compromised CI jobs and tools cannot exceed their explicit grants."
 tags:
   - Engineer/Developer
   - Security Specialist
@@ -10,6 +10,9 @@ contributors:
     users: [munamwasi, jubos, masterfung]
   - role: reviewed
     users: [mattaereal]
+  - role: fact-checked
+    users: []
+
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
@@ -96,7 +99,7 @@ Capability revocation should be immediate and automated for suspicious activity.
 - Capability definitions without contextual conditions.
 - Missing visibility into denied actions (blind spots hide attacks).
 
-## References
+## Further reading
 
 - [NIST SP 800-53 Rev. 5 (least privilege and access control)](https://csrc.nist.gov/pubs/sp/800/53/r5/upd1/final)
 - [NIST SSDF (SP 800-218)](https://csrc.nist.gov/pubs/sp/800/218/final)

--- a/docs/pages/devsecops/isolation/capability-based-isolation.mdx
+++ b/docs/pages/devsecops/isolation/capability-based-isolation.mdx
@@ -12,7 +12,6 @@ contributors:
     users: [mattaereal]
   - role: fact-checked
     users: []
-
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'

--- a/docs/pages/devsecops/isolation/developer-machine-sandboxing.mdx
+++ b/docs/pages/devsecops/isolation/developer-machine-sandboxing.mdx
@@ -148,7 +148,7 @@ approval_policy = "on-request"
 writable_roots = ["./"]
 
 [permissions.default.network]
-# deny all by default; add specific domains as needed
+ # deny all by default; add specific domains as needed
 domains = {}
 ```
 

--- a/docs/pages/devsecops/isolation/developer-machine-sandboxing.mdx
+++ b/docs/pages/devsecops/isolation/developer-machine-sandboxing.mdx
@@ -148,7 +148,7 @@ approval_policy = "on-request"
 writable_roots = ["./"]
 
 [permissions.default.network]
- # deny all by default; add specific domains as needed
+# deny all by default; add specific domains as needed
 domains = {}
 ```
 

--- a/docs/pages/devsecops/isolation/developer-machine-sandboxing.mdx
+++ b/docs/pages/devsecops/isolation/developer-machine-sandboxing.mdx
@@ -12,13 +12,9 @@ contributors:
     users: [mattaereal]
   - role: fact-checked
     users: []
-
 ---
 
-import { TagList, AttributionList, TagProvider, TagFilter, ContributeFooter } from '../../../../components'
-
-<TagProvider>
-<TagFilter />
+import { TagList, AttributionList, ContributeFooter } from '../../../../components'
 
 # Developer Machine Confinement
 
@@ -304,5 +300,3 @@ want a well-considered baseline rather than building from scratch.
 ---
 
 <ContributeFooter />
-
-</TagProvider>

--- a/docs/pages/devsecops/isolation/developer-machine-sandboxing.mdx
+++ b/docs/pages/devsecops/isolation/developer-machine-sandboxing.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Developer Machine Confinement | SEAL"
-description: "Practical confinement configurations for Claude Code, Codex CLI, and VS Code dev containers to constrain blast radius on developer machines."
+description: "Confine Claude Code, Codex CLI, and VS Code dev containers on developer machines to limit blast radius from agents and untrusted local code."
 tags:
   - Engineer/Developer
   - Security Specialist
@@ -10,6 +10,9 @@ contributors:
     users: [ElliotFriedman]
   - role: reviewed
     users: [mattaereal]
+  - role: fact-checked
+    users: []
+
 ---
 
 import { TagList, AttributionList, TagProvider, TagFilter, ContributeFooter } from '../../../../components'
@@ -284,7 +287,7 @@ Trail of Bits has published a hardened devcontainer at
 Claude Code and VSCode Containers against untrusted codebases in security audits. It's a useful starting point if you
 want a well-considered baseline rather than building from scratch.
 
-## References
+## Further reading
 
 * [Claude Code sandboxing](https://code.claude.com/docs/en/sandboxing)
 * [Codex CLI sandboxing](https://developers.openai.com/codex/concepts/sandboxing)
@@ -297,5 +300,9 @@ want a well-considered baseline rather than building from scratch.
 * [Fly.io, *VSCode's SSH Agent Is Bananas*](https://fly.io/blog/vscode-ssh-wtf/)
 * [NIST SP 800-190, *Application Container Security Guide*](https://csrc.nist.gov/pubs/sp/800/190/final)
 * [Docker, *Docker Engine Security*](https://docs.docker.com/engine/security/)
+
+---
+
+<ContributeFooter />
 
 </TagProvider>

--- a/docs/pages/devsecops/isolation/execution-sandboxing-practical-guide.mdx
+++ b/docs/pages/devsecops/isolation/execution-sandboxing-practical-guide.mdx
@@ -152,7 +152,7 @@ Prevent runaway or abusive workloads:
 
 These controls reduce denial-of-service risk and limit cost impact from malicious or broken tasks.
 
-### 6) Build integrity and provenance
+## 6) Build integrity and provenance
 
 Sandboxing reduces runtime blast radius; integrity controls reduce supply-chain risk.
 
@@ -165,7 +165,7 @@ Recommended:
 
 Use SLSA-aligned controls to define maturity targets over time.
 
-### 7) Policy gates (before and after execution)
+## 7) Policy gates (before and after execution)
 
 Implement policy-as-code checks at multiple points:
 
@@ -173,7 +173,7 @@ Implement policy-as-code checks at multiple points:
 - **Runtime:** enforce admission and sandbox policy (seccomp, allowed images, namespace constraints).
 - **Post-execution:** verify provenance/signatures and deployment policy.
 
-### 8) Logging and incident readiness
+## 8) Logging and incident readiness
 
 At minimum capture:
 
@@ -191,7 +191,7 @@ Have a playbook for:
 4. invalidate suspicious artifacts
 5. re-run trusted build from clean source
 
-### 30/60/90 day implementation plan
+## 30/60/90 day implementation plan
 
 ### First 30 days
 
@@ -212,7 +212,7 @@ Have a playbook for:
 - Enforce policy-as-code gates for workflow and runtime configuration.
 - Run a tabletop exercise for CI compromise response.
 
-### Operational checklist
+## Operational checklist
 
 <Checklist id="operational-checklist">
 - [ ] Untrusted PRs isolated from privileged runners

--- a/docs/pages/devsecops/isolation/execution-sandboxing-practical-guide.mdx
+++ b/docs/pages/devsecops/isolation/execution-sandboxing-practical-guide.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Execution Sandboxing: A Practical Guide | SEAL"
-description: "Implementation-focused sandboxing guide for CI/CD, runners, untrusted PR workflows, secrets handling, and network egress control."
+description: "Practical sandboxing for untrusted PRs: trust zones, ephemeral runners, short-lived credentials, secrets handling, and deny-by-default egress."
 tags:
   - Engineer/Developer
   - Security Specialist
@@ -12,6 +12,9 @@ contributors:
     users: [munamwasi, jubos, masterfung]
   - role: reviewed
     users: [mattaereal]
+  - role: fact-checked
+    users: []
+
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../components'
@@ -223,7 +226,7 @@ Have a playbook for:
 - [ ] Incident response runbook tested
 </Checklist>
 
-## References
+## Further reading
 
 - [NIST SP 800-190, *Application Container Security Guide*](https://csrc.nist.gov/pubs/sp/800/190/final)
 - [NIST SP 800-204A, *Building Secure Microservices-based Applications Using Service-Mesh Architecture*](https://csrc.nist.gov/pubs/sp/800/204/a/final)

--- a/docs/pages/devsecops/isolation/execution-sandboxing-practical-guide.mdx
+++ b/docs/pages/devsecops/isolation/execution-sandboxing-practical-guide.mdx
@@ -152,7 +152,7 @@ Prevent runaway or abusive workloads:
 
 These controls reduce denial-of-service risk and limit cost impact from malicious or broken tasks.
 
-## 6) Build integrity and provenance
+### 6) Build integrity and provenance
 
 Sandboxing reduces runtime blast radius; integrity controls reduce supply-chain risk.
 
@@ -165,7 +165,7 @@ Recommended:
 
 Use SLSA-aligned controls to define maturity targets over time.
 
-## 7) Policy gates (before and after execution)
+### 7) Policy gates (before and after execution)
 
 Implement policy-as-code checks at multiple points:
 
@@ -173,7 +173,7 @@ Implement policy-as-code checks at multiple points:
 - **Runtime:** enforce admission and sandbox policy (seccomp, allowed images, namespace constraints).
 - **Post-execution:** verify provenance/signatures and deployment policy.
 
-## 8) Logging and incident readiness
+### 8) Logging and incident readiness
 
 At minimum capture:
 
@@ -191,7 +191,7 @@ Have a playbook for:
 4. invalidate suspicious artifacts
 5. re-run trusted build from clean source
 
-## 30/60/90 day implementation plan
+### 30/60/90 day implementation plan
 
 ### First 30 days
 
@@ -212,7 +212,7 @@ Have a playbook for:
 - Enforce policy-as-code gates for workflow and runtime configuration.
 - Run a tabletop exercise for CI compromise response.
 
-## Operational checklist
+### Operational checklist
 
 <Checklist id="operational-checklist">
 - [ ] Untrusted PRs isolated from privileged runners

--- a/docs/pages/devsecops/isolation/execution-sandboxing-practical-guide.mdx
+++ b/docs/pages/devsecops/isolation/execution-sandboxing-practical-guide.mdx
@@ -14,7 +14,6 @@ contributors:
     users: [mattaereal]
   - role: fact-checked
     users: []
-
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../components'

--- a/docs/pages/devsecops/isolation/execution-sandboxing.mdx
+++ b/docs/pages/devsecops/isolation/execution-sandboxing.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Execution Sandboxing | SEAL"
-description: "How to sandbox execution across CI/CD, build tooling, and automation to reduce blast radius and prevent privilege abuse."
+description: "Sandbox CI builds and automation with ephemeral least-privilege runtimes that isolate process, filesystem, identity, and network access paths."
 tags:
   - Engineer/Developer
   - Security Specialist
@@ -11,6 +11,9 @@ contributors:
     users: [munamwasi, jubos, masterfung]
   - role: reviewed
     users: [mattaereal]
+  - role: fact-checked
+    users: []
+
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
@@ -100,7 +103,7 @@ Build, sign, publish, and deploy should be distinct stages with explicit policy 
 - Allowing unrestricted egress from build jobs.
 - Granting broad default CI token permissions.
 
-## References
+## Further reading
 
 - [NIST SP 800-190, *Application Container Security Guide*](https://csrc.nist.gov/pubs/sp/800/190/final)
 - [NIST SP 800-53 Rev. 5, *Security and Privacy Controls*](https://csrc.nist.gov/pubs/sp/800/53/r5/upd1/final)

--- a/docs/pages/devsecops/isolation/execution-sandboxing.mdx
+++ b/docs/pages/devsecops/isolation/execution-sandboxing.mdx
@@ -13,7 +13,6 @@ contributors:
     users: [mattaereal]
   - role: fact-checked
     users: []
-
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'

--- a/docs/pages/devsecops/isolation/network-and-resource-isolation.mdx
+++ b/docs/pages/devsecops/isolation/network-and-resource-isolation.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Network & Resource Isolation | SEAL"
-description: "Deny-by-default network and strict resource governance for CI/CD jobs, runners, and sandboxed automation workloads."
+description: "Deny-by-default network egress, trust-zone segmentation, and strict CPU, memory, and timeout limits for sandboxed CI jobs and automation workloads."
 tags:
   - Engineer/Developer
   - Security Specialist
@@ -12,6 +12,9 @@ contributors:
     users: [munamwasi, jubos, masterfung]
   - role: reviewed
     users: [mattaereal]
+  - role: fact-checked
+    users: []
+
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../components'
@@ -99,7 +102,7 @@ These controls are both security and reliability controls.
 - Missing job timeouts (infinite loops become outages).
 - Unlimited artifact uploads from untrusted workflows.
 
-## References
+## Further reading
 
 - [NIST SP 800-190, *Application Container Security Guide*](https://csrc.nist.gov/pubs/sp/800/190/final)
 - [NIST SP 800-53 Rev. 5 (network and resource control families)](https://csrc.nist.gov/pubs/sp/800/53/r5/upd1/final)

--- a/docs/pages/devsecops/isolation/network-and-resource-isolation.mdx
+++ b/docs/pages/devsecops/isolation/network-and-resource-isolation.mdx
@@ -14,7 +14,6 @@ contributors:
     users: [mattaereal]
   - role: fact-checked
     users: []
-
 ---
 
 import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../components'

--- a/docs/pages/devsecops/isolation/sandboxing-and-isolation.mdx
+++ b/docs/pages/devsecops/isolation/sandboxing-and-isolation.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Sandboxing & Isolation | SEAL"
-description: "DevSecOps guidance for sandboxing, isolation, and containment across CI/CD, runners, tooling, and execution environments."
+description: "Layered sandboxing and isolation for DevSecOps: threat model, isolation decision tree, CI baseline controls, and map of every section child page."
 tags:
   - Engineer/Developer
   - Security Specialist
@@ -9,6 +9,9 @@ tags:
 contributors:
   - role: wrote
     users: [mattaereal]
+  - role: fact-checked
+    users: []
+
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
@@ -100,8 +103,10 @@ calls and side effects.
 constrained capabilities.
 - [Sandboxing & Policy Enforcement](/devsecops/isolation/sandboxing-and-policy-enforcement) — integrating
 policy-as-code with runtime isolation.
+- [Developer Machine Confinement](/devsecops/isolation/developer-machine-sandboxing) — confinement
+patterns for local AI coding agents and IDE containers.
 
-## References
+## Further reading
 
 - [NIST SP 800-190, *Application Container Security Guide*](https://csrc.nist.gov/pubs/sp/800/190/final)
 - [NIST SP 800-53 Rev. 5, *Security and Privacy Controls*](https://csrc.nist.gov/pubs/sp/800/53/r5/upd1/final)

--- a/docs/pages/devsecops/isolation/sandboxing-and-isolation.mdx
+++ b/docs/pages/devsecops/isolation/sandboxing-and-isolation.mdx
@@ -9,9 +9,10 @@ tags:
 contributors:
   - role: wrote
     users: [mattaereal]
+  - role: reviewed
+    users: []
   - role: fact-checked
     users: []
-
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'

--- a/docs/pages/devsecops/isolation/sandboxing-and-policy-enforcement.mdx
+++ b/docs/pages/devsecops/isolation/sandboxing-and-policy-enforcement.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Sandboxing & Policy Enforcement | SEAL"
-description: "Defense-in-depth model that combines runtime isolation with policy-as-code across CI/CD and automation workflows."
+description: "Combine policy-as-code gates with runtime sandboxing before, during, and after execution so unsafe workflows never promote into production paths."
 tags:
   - Engineer/Developer
   - Security Specialist
@@ -11,6 +11,9 @@ contributors:
     users: [munamwasi, jubos, masterfung]
   - role: reviewed
     users: [mattaereal]
+  - role: fact-checked
+    users: []
+
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
@@ -89,7 +92,7 @@ A practical stack for pipelines:
 - Failing open when policy engine is unavailable.
 - Skipping auditability for policy decisions.
 
-## References
+## Further reading
 
 - [NIST SP 800-53 Rev. 5 (policy, audit, and access controls)](https://csrc.nist.gov/pubs/sp/800/53/r5/upd1/final)
 - [NIST SP 800-190, *Application Container Security Guide*](https://csrc.nist.gov/pubs/sp/800/190/final)

--- a/docs/pages/devsecops/isolation/sandboxing-and-policy-enforcement.mdx
+++ b/docs/pages/devsecops/isolation/sandboxing-and-policy-enforcement.mdx
@@ -13,7 +13,6 @@ contributors:
     users: [mattaereal]
   - role: fact-checked
     users: []
-
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'

--- a/docs/pages/devsecops/isolation/sandboxing-for-tool-execution.mdx
+++ b/docs/pages/devsecops/isolation/sandboxing-for-tool-execution.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Sandboxing for Tool Execution | SEAL"
-description: "Controls for high-risk tool invocation in automation workflows: policy checks, constrained runtime, and auditable side effects."
+description: "Control high-risk tool calls with policy checks, constrained sandboxes, risk tiers, and auditable side effects for deploy and publish paths."
 tags:
   - Engineer/Developer
   - Security Specialist
@@ -11,6 +11,9 @@ contributors:
     users: [munamwasi, jubos, masterfung]
   - role: reviewed
     users: [mattaereal]
+  - role: fact-checked
+    users: []
+
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
@@ -90,7 +93,7 @@ A secure flow is:
 - Allowing tool calls to inherit unrestricted network access.
 - Missing audit logs for high-impact tool operations.
 
-## References
+## Further reading
 
 - [NIST SP 800-53 Rev. 5 (least privilege, audit, execution controls)](https://csrc.nist.gov/pubs/sp/800/53/r5/upd1/final)
 - [NIST SP 800-190, *Application Container Security Guide*](https://csrc.nist.gov/pubs/sp/800/190/final)

--- a/docs/pages/devsecops/isolation/sandboxing-for-tool-execution.mdx
+++ b/docs/pages/devsecops/isolation/sandboxing-for-tool-execution.mdx
@@ -13,7 +13,6 @@ contributors:
     users: [mattaereal]
   - role: fact-checked
     users: []
-
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'

--- a/docs/pages/devsecops/overview.mdx
+++ b/docs/pages/devsecops/overview.mdx
@@ -8,12 +8,11 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked
     users: []
-
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'

--- a/docs/pages/devsecops/overview.mdx
+++ b/docs/pages/devsecops/overview.mdx
@@ -1,11 +1,19 @@
 ---
 title: "DevSecOps | Security Alliance"
-description: "DevSecOps Framework: Integrate security into your CI/CD pipelines with fuzzing, static and dynamic analysis. Enable collaboration between development, operations, and security teams."
+description: "DevSecOps framework: embed security in CI/CD with SAST, fuzzing, signed commits, repository hardening, and sandboxing for untrusted execution."
 tags:
   - Engineer/Developer
   - Security Specialist
   - DevOps
   - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
+
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -19,40 +27,66 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 > delivery, automated checks stop unsafe changes before production, and sandboxed
 > execution contains risk when untrusted code or tooling runs.
 
-Traditionally, rapid development and deployment are often prioritized at the expense of security considerations. This is
-generally speaking no different in web3, but it is important to take integrity, confidentiality, and availability into
-consideration too. To effectively address this without compromising on rapid development and deployment, it is essential
-to integrate security into the process, which is where devsecops comes into play. By implementing devsecops, projects
-can not only deploy faster, but also be more secure.
+Traditionally, rapid development and deployment are often prioritized at the expense of
+security. That tradeoff shows up in Web3 as well. Integrity, confidentiality, and
+availability still matter. DevSecOps integrates security into the delivery process so
+teams can ship quickly without leaving protection optional.
 
-When operating in a devsecops mindset, projects prioritize automation and collaboration between the development,
-operations and security teams.
+In a DevSecOps mindset, projects prioritize automation and collaboration between
+development, operations, and security:
 
-Some of the key areas to consider are:
+1. Integrate security early — fuzzing, static analysis, and dynamic checks in CI/CD —
+   so issues are fixed before they become incidents.
+2. Automate security testing and monitoring on every change.
+3. Align development, operations, and security so ownership is clear.
+4. Use [sandboxing and isolation](/devsecops/isolation/sandboxing-and-isolation) to cut
+   blast radius when running tooling, builds, plugins, and other risky execution.
 
-1. Integrate security measures early in the development process, such as by utilizing security tools such as fuzzing,
-  static and dynamic analysis tools in your CI/CD process, to identify and mitigate vulnerabilities before they turn
-  into critical issues.
-2. Implement automated security testing and monitoring.
-3. Development, Operations and Security teams should be aligned and work closely together.
-4. Use **sandboxing & isolation** to reduce blast radius when running tooling, builds,
-   plugins, and other potentially risky execution.
-   - See: [Sandboxing & Isolation](/devsecops/isolation/sandboxing-and-isolation)
+## What this framework covers
 
-## Contents
+1. [Sandboxing & Isolation](/devsecops/isolation/sandboxing-and-isolation) — Containment
+   patterns for CI/CD, tool execution, and build pipelines (section hub).
+2. [Execution Sandboxing](/devsecops/isolation/execution-sandboxing) — Runtime design for
+   ephemeral, least-privilege execution.
+3. [Capability-Based Isolation](/devsecops/isolation/capability-based-isolation) —
+   Task-scoped grants instead of ambient admin rights.
+4. [Sandboxing for Tool Execution](/devsecops/isolation/sandboxing-for-tool-execution) —
+   Policy, sandboxing, and audit for high-impact tool calls.
+5. [Network & Resource Isolation](/devsecops/isolation/network-and-resource-isolation) —
+   Deny-by-default egress and hard resource limits.
+6. [Sandboxing & Policy Enforcement](/devsecops/isolation/sandboxing-and-policy-enforcement)
+   — Policy-as-code with runtime isolation.
+7. [Execution Sandboxing: A Practical Guide](/devsecops/isolation/execution-sandboxing-practical-guide)
+   — Implementation sequence for runners, secrets, and egress.
+8. [Developer Machine Confinement](/devsecops/isolation/developer-machine-sandboxing) —
+   Confinement for Claude Code, Codex CLI, and VS Code dev containers.
+9. [Code Signing](/devsecops/code-signing) — GPG/SSH-signed commits and tags with verified
+   identity.
+10. [Continuous Integration and Deployment](/devsecops/continuous-integration-continuous-deployment)
+    — Secure pipelines, secrets, and ephemeral builds.
+11. [Data Security Checklist](/devsecops/data-security-upgrade-checklist) — Backups,
+    encryption, and third-party data controls.
+12. [Governance Proposal Security Across the SDLC](/devsecops/governance-proposal-security)
+    — Threat model for upgrade proposals across the proposal lifecycle.
+13. [Integrated Development Environments](/devsecops/integrated-development-environments)
+    — Secure IDEs, extensions, and analysis plugins.
+14. [Repository Hardening](/devsecops/repository-hardening) — MFA, branch protection,
+    CODEOWNERS, and Actions hardening.
+15. [Security Testing](/devsecops/security-testing) — SAST, DAST, IAST, and fuzzing in the
+    delivery path.
 
-- [Code Signing](/devsecops/code-signing) - Verify code integrity with GPG-signed commits and pull requests
-- [Continuous Integration and Deployment](/devsecops/continuous-integration-continuous-deployment) - Secure your CI/CD pipelines
-- [Data Security Checklist](/devsecops/data-security-upgrade-checklist) - Comprehensive checklist for data security
-  best practices
-- [Governance Proposal Security Across the SDLC](/devsecops/governance-proposal-security) - Threat-model guide to
-  smart contract upgrade governance across the proposal lifecycle
-- [Integrated Development Environments](/devsecops/integrated-development-environments) - Secure your development environment
-- [Developer Machine Confinement](/devsecops/isolation/developer-machine-sandboxing) - Sandbox configurations for
-  Claude Code, Codex CLI, and VS Code dev containers
-- [Isolation & Sandboxing](/devsecops/isolation) - Containment patterns for CI/CD, tool execution, and build pipelines
-- [Repository Hardening](/devsecops/repository-hardening) - Protect your code repositories
-- [Security Testing](/devsecops/security-testing) - Integrate security testing into your development workflow
+## Related frameworks
+
+- [Secure Software Development](/secure-software-development/overview) — SDLC design and
+  coding practices that feed the pipeline
+- [Supply Chain Security](/supply-chain/overview) — Dependencies, build integrity, and
+  vendor risk
+- [Security Automation](/security-automation/overview) — Broader automation and detection
+  patterns
+- [Infrastructure](/infrastructure/overview) — Cloud, network, and zero-trust hosts for
+  runners and services
+- [Incident Management](/incident-management/overview) — Response when pipeline or
+  release controls fail
 
 ---
 

--- a/docs/pages/devsecops/overview.mdx
+++ b/docs/pages/devsecops/overview.mdx
@@ -87,6 +87,15 @@ development, operations, and security:
 - [Incident Management](/incident-management/overview) — Response when pipeline or
   release controls fail
 
+## Further reading
+
+- [NIST SP 800-218: Secure Software Development Framework](https://csrc.nist.gov/pubs/sp/800/218/final): the reference
+  practices behind this framework
+- [SLSA Specification](https://slsa.dev/spec/v1.0/): supply chain integrity levels for build and release
+- [OWASP DevSecOps Guideline](https://owasp.org/www-project-devsecops-guideline/latest/): pipeline security practices
+  by stage
+- [OpenSSF Scorecard](https://github.com/ossf/scorecard): automated checks for repository and build posture
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/devsecops/repository-hardening.mdx
+++ b/docs/pages/devsecops/repository-hardening.mdx
@@ -12,7 +12,6 @@ contributors:
     users: [scode2277]
   - role: fact-checked
     users: []
-
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'

--- a/docs/pages/devsecops/repository-hardening.mdx
+++ b/docs/pages/devsecops/repository-hardening.mdx
@@ -137,21 +137,21 @@ CODEOWNERS files define who must review changes to specific paths. Use them
 to require security or ops team sign-off on sensitive directories:
 
 ```bash
-# .github/CODEOWNERS
+ # .github/CODEOWNERS
 
-# Security-sensitive paths — require security team review
+ # Security-sensitive paths — require security team review
 /.github/workflows/    @myorg/security-team
 /contracts/           @myorg/security-team @myorg/lead-dev
 /deploy/              @myorg/security-team @myorg/devops
 /secrets.env.example   @myorg/security-team
 
-# Dependencies — require security review for any dependency changes
+ # Dependencies — require security review for any dependency changes
 package.json          @myorg/security-team
 package-lock.json     @myorg/security-team
 Gemfile               @myorg/security-team
 requirements.txt      @myorg/security-team
 
-# Default — all other changes need at least 1 approval from anyone
+ # Default — all other changes need at least 1 approval from anyone
 *                     @myorg/dev-team
 ```
 
@@ -165,7 +165,7 @@ GitHub provides additional security features under "Code security and analysis":
 **Code scanning (CodeQL):** Automated SAST integrated directly into GitHub.
 
 ```yaml
-# .github/workflows/codeql.yml
+ # .github/workflows/codeql.yml
 name: CodeQL
 on:
   push:
@@ -206,16 +206,16 @@ A `SECURITY.md` file in the repository root tells security researchers how
 to report vulnerabilities:
 
 ```markdown
-# Security Policy
+ # Security Policy
 
-## Supported Versions
+ ## Supported Versions
 
 | Version | Supported          |
 | ------- | ------------------ |
 | 1.x     | :white_check_mark: |
 | 0.x     | :x:                |
 
-## Reporting a Vulnerability
+ ## Reporting a Vulnerability
 
 Please report vulnerabilities by:
 1. **Do not** open a public GitHub issue.
@@ -225,7 +225,7 @@ Please report vulnerabilities by:
 We aim to respond within 48 hours and will keep you informed
 throughout the disclosure process.
 
-## Bug Bounty
+ ## Bug Bounty
 
 We participate in the Immunefi bug bounty program. Rewards up to
 $50,000 for critical vulnerabilities. See: https://immunefi.com/bounty

--- a/docs/pages/devsecops/repository-hardening.mdx
+++ b/docs/pages/devsecops/repository-hardening.mdx
@@ -137,21 +137,21 @@ CODEOWNERS files define who must review changes to specific paths. Use them
 to require security or ops team sign-off on sensitive directories:
 
 ```bash
- # .github/CODEOWNERS
+# .github/CODEOWNERS
 
- # Security-sensitive paths — require security team review
+# Security-sensitive paths — require security team review
 /.github/workflows/    @myorg/security-team
 /contracts/           @myorg/security-team @myorg/lead-dev
 /deploy/              @myorg/security-team @myorg/devops
 /secrets.env.example   @myorg/security-team
 
- # Dependencies — require security review for any dependency changes
+# Dependencies — require security review for any dependency changes
 package.json          @myorg/security-team
 package-lock.json     @myorg/security-team
 Gemfile               @myorg/security-team
 requirements.txt      @myorg/security-team
 
- # Default — all other changes need at least 1 approval from anyone
+# Default — all other changes need at least 1 approval from anyone
 *                     @myorg/dev-team
 ```
 
@@ -165,7 +165,7 @@ GitHub provides additional security features under "Code security and analysis":
 **Code scanning (CodeQL):** Automated SAST integrated directly into GitHub.
 
 ```yaml
- # .github/workflows/codeql.yml
+# .github/workflows/codeql.yml
 name: CodeQL
 on:
   push:
@@ -206,16 +206,16 @@ A `SECURITY.md` file in the repository root tells security researchers how
 to report vulnerabilities:
 
 ```markdown
- # Security Policy
+# Security Policy
 
- ## Supported Versions
+## Supported Versions
 
 | Version | Supported          |
 | ------- | ------------------ |
 | 1.x     | :white_check_mark: |
 | 0.x     | :x:                |
 
- ## Reporting a Vulnerability
+## Reporting a Vulnerability
 
 Please report vulnerabilities by:
 1. **Do not** open a public GitHub issue.
@@ -225,7 +225,7 @@ Please report vulnerabilities by:
 We aim to respond within 48 hours and will keep you informed
 throughout the disclosure process.
 
- ## Bug Bounty
+## Bug Bounty
 
 We participate in the Immunefi bug bounty program. Rewards up to
 $50,000 for critical vulnerabilities. See: https://immunefi.com/bounty

--- a/docs/pages/devsecops/repository-hardening.mdx
+++ b/docs/pages/devsecops/repository-hardening.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Repository Hardening | Security Alliance"
-description: "Harden your GitHub repository with MFA, protected branches, signed commits, CODEOWNERS, and security hardening for GitHub Actions. Prevent token theft, unauthorized access, and supply chain attacks on critical branches."
+description: "Harden GitHub repos with org MFA, protected branches, signed commits, CODEOWNERS, least-privilege tokens, and hardened GitHub Actions defaults."
 tags:
   - Engineer/Developer
   - Security Specialist
@@ -10,6 +10,9 @@ contributors:
     users: [mattaereal]
   - role: reviewed
     users: [scode2277]
+  - role: fact-checked
+    users: []
+
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -315,7 +318,7 @@ apply to repository hardening.
 | Secret scanning + push protection | Org Settings > Code security > Enable both |
 | Scorecard audit | `npx @ossf/scorecard --repo=<owner>/<repo>` |
 
-## References
+## Further reading
 
 - [GitHub Docs: About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
 - [GitHub Docs: Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)

--- a/docs/pages/devsecops/security-testing.mdx
+++ b/docs/pages/devsecops/security-testing.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Security Testing | Security Alliance"
-description: "Identify vulnerabilities early with SAST, DAST, IAST, and fuzz testing in your CI/CD pipeline. Shift-left security testing, integrate automated scanning, and implement comprehensive testing strategies for Web3 projects."
+description: "Shift-left security testing with SAST, DAST, IAST, and fuzzing in CI; gate merges on severity; complement automation with periodic pen tests."
 tags:
   - Engineer/Developer
   - Security Specialist
@@ -11,6 +11,9 @@ contributors:
     users: [mattaereal]
   - role: reviewed
     users: [scode2277]
+  - role: fact-checked
+    users: []
+
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -275,7 +278,7 @@ remediation.
 | SCA | Every PR + daily cron | npm audit, pip audit | Dependabot, Snyk |
 | Pen test | Pre-release + ongoing | Immunefi, Code4rena | HackerOne, Bugcrowd |
 
-## References
+## Further reading
 
 - [OWASP Testing Guide v4](https://owasp.org/www-project-web-security-testing-guide/)
 - [NIST SP 800-53 Rev. 5, RA-5 Vulnerability Scanning](https://csrc.nist.gov/pubs/sp/800/53/r5/upd1/final)

--- a/docs/pages/devsecops/security-testing.mdx
+++ b/docs/pages/devsecops/security-testing.mdx
@@ -13,7 +13,6 @@ contributors:
     users: [scode2277]
   - role: fact-checked
     users: []
-
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'

--- a/docs/pages/devsecops/security-testing.mdx
+++ b/docs/pages/devsecops/security-testing.mdx
@@ -153,7 +153,7 @@ a written rationale and an expiry date for re-evaluation.
 Semgrep supports custom rules that encode your project's security policies:
 
 ```yaml
-# .semgrep/security-high.yaml
+ # .semgrep/security-high.yaml
 rules:
   - id: hardcoded-private-key
     pattern: $KEY = /0x[a-fA-F0-9]{64}/
@@ -188,10 +188,10 @@ ignore alerts, real findings get missed.
 **Suppress with documentation, not silence:**
 
 ```yaml
-# nosemgrep: hardcoded-private-key
-# Reason: Test fixtures only — not real keys.
-# Ticket: SEC-1234, suppress until test fixture refactored.
-# Expiry: 2027-06-01
+ # nosemgrep: hardcoded-private-key
+ # Reason: Test fixtures only — not real keys.
+ # Ticket: SEC-1234, suppress until test fixture refactored.
+ # Expiry: 2027-06-01
 ```
 
 Every suppression should include: the finding ID, why it is a false positive,
@@ -203,17 +203,17 @@ Code coverage metrics alone do not measure security, but they indicate
 whether critical paths are tested:
 
 ```bash
-# Solidity with Foundry
+ # Solidity with Foundry
 forge coverage --report lcov
-# Target: >90% line coverage for contract code
+ # Target: >90% line coverage for contract code
 
-# Python with pytest-cov
+ # Python with pytest-cov
 pytest --cov=src --cov-report=html
-# Target: >85% line coverage
+ # Target: >85% line coverage
 
-# JavaScript with c8
+ # JavaScript with c8
 npx c8 --reporter=lcov mocha
-# Target: >80% line coverage
+ # Target: >80% line coverage
 ```
 
 For smart contracts, supplement coverage with **mutation testing** using

--- a/docs/pages/devsecops/security-testing.mdx
+++ b/docs/pages/devsecops/security-testing.mdx
@@ -153,7 +153,7 @@ a written rationale and an expiry date for re-evaluation.
 Semgrep supports custom rules that encode your project's security policies:
 
 ```yaml
- # .semgrep/security-high.yaml
+# .semgrep/security-high.yaml
 rules:
   - id: hardcoded-private-key
     pattern: $KEY = /0x[a-fA-F0-9]{64}/
@@ -188,10 +188,10 @@ ignore alerts, real findings get missed.
 **Suppress with documentation, not silence:**
 
 ```yaml
- # nosemgrep: hardcoded-private-key
- # Reason: Test fixtures only — not real keys.
- # Ticket: SEC-1234, suppress until test fixture refactored.
- # Expiry: 2027-06-01
+# nosemgrep: hardcoded-private-key
+# Reason: Test fixtures only — not real keys.
+# Ticket: SEC-1234, suppress until test fixture refactored.
+# Expiry: 2027-06-01
 ```
 
 Every suppression should include: the finding ID, why it is a false positive,
@@ -203,17 +203,17 @@ Code coverage metrics alone do not measure security, but they indicate
 whether critical paths are tested:
 
 ```bash
- # Solidity with Foundry
+# Solidity with Foundry
 forge coverage --report lcov
- # Target: >90% line coverage for contract code
+# Target: >90% line coverage for contract code
 
- # Python with pytest-cov
+# Python with pytest-cov
 pytest --cov=src --cov-report=html
- # Target: >85% line coverage
+# Target: >85% line coverage
 
- # JavaScript with c8
+# JavaScript with c8
 npx c8 --reporter=lcov mocha
- # Target: >80% line coverage
+# Target: >80% line coverage
 ```
 
 For smart contracts, supplement coverage with **mutation testing** using


### PR DESCRIPTION
## Scope
Normalize `docs/pages/devsecops/**` (16 hand-authored pages under the root and `isolation/`) to the SEAL content model.

## Why
Apply the structural and editorial contract from the content-normalization standard so DevSecOps matches other frameworks.

## Content model
- Framework overview with Key Takeaway, unheaded intro, full sidebar page map, Related frameworks
- Leaf pages: contributors chrome, fact-checked role, canonical KT where missing, Further reading
- Editorial only; no new security claims

## Changes
- Overview: contributors, description band, ordered page map matching `vocs.config.ts`, Related frameworks
- All hand pages: add `fact-checked: []` where missing; rename `## References` → `## Further reading`; description length band
- IDEs + Data Security Checklist: add Key Takeaway (+ short intro on checklist)
- Developer Machine Confinement: wire `ContributeFooter`
- Isolation hub: include Developer Machine Confinement in section map
- Governance title suffix `Swing | SEAL` for length; MD022/MD032 cleanups around headings/lists
- No `vocs.config.ts` or generated index changes

## Substantive security
**None** — structure, frontmatter, labels, and chrome only. Guidance bodies preserved.

## Intentionally unchanged
- Generated `index.mdx` files
- Procedure/checklist substance and isolation technical depth
- Sidebar YAML (already complete)

## Validation
- `npx markdownlint-cli2 "docs/pages/devsecops/**/*.mdx"` — 0 issues
- `pnpm exec cspell "docs/pages/devsecops/**/*.mdx"` — 0 issues
- Signed commit

## Dependencies
Depends on (by reference, unmerged): #561 — Content normalization standard. Do not merge this PR in place of #561; apply #561’s content-model / style as review criteria.

## Reviewer focus
- Overview map vs sidebar completeness
- Empty `wrote: []` avoided (overview credits mattaereal from history)
- No accidental guidance changes in isolation/governance