### PR TITLE
docs(opsec): normalize structure and wording

### DIFF
--- a/docs/pages/opsec/appendices/case-studies.mdx
+++ b/docs/pages/opsec/appendices/case-studies.mdx
@@ -1,11 +1,18 @@
 ---
 title: "OpSec Case Studies | Security Alliance"
-description: "Real-world OpSec case studies: private key compromise in DeFi, Discord social engineering attacks. Tabletop exercises for wallet security incidents, smart contract vulnerabilities, and device compromise."
+description: "OpSec case studies and tabletops: private-key compromise, Discord social engineering, wallet incidents, and device compromise response practice."
 tags:
   - Security Specialist
   - Operations & Strategy
   - DevOps
   - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
@@ -14,6 +21,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Case studies and tabletop exercises turn past Web3 incidents into practice so teams rehearse
+> detection, communication, and recovery before they need them live.
 
 This section provides real-world case studies and tabletop exercises that organizations can use to learn from past
 incidents and test their security readiness. These examples illustrate common security challenges and effective response

--- a/docs/pages/opsec/appendices/case-studies.mdx
+++ b/docs/pages/opsec/appendices/case-studies.mdx
@@ -231,6 +231,11 @@ These case studies and exercises provide practical examples and scenarios that o
 incidents and test their security readiness. By regularly conducting such exercises, teams can identify weaknesses in
 their security posture and improve their ability to respond effectively to incidents.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/appendices/case-studies.mdx
+++ b/docs/pages/opsec/appendices/case-studies.mdx
@@ -8,7 +8,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/opsec/appendices/case-studies.mdx
+++ b/docs/pages/opsec/appendices/case-studies.mdx
@@ -231,10 +231,12 @@ These case studies and exercises provide practical examples and scenarios that o
 incidents and test their security readiness. By regularly conducting such exercises, teams can identify weaknesses in
 their security posture and improve their ability to respond effectively to incidents.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [Appendices overview](/opsec/appendices/overview): how the reference material fits together
+- [Lessons Learned](/incident-management/lessons-learned): turning incidents into durable change
+- [Incident Playbooks](/incident-management/playbooks/overview): response guides for the scenarios described here
+- [OpSec overview](/opsec/overview): how the pages of this framework fit together
 
 ---
 

--- a/docs/pages/opsec/appendices/glossary.mdx
+++ b/docs/pages/opsec/appendices/glossary.mdx
@@ -232,6 +232,11 @@ This glossary provides a common language for discussing operational security con
 essential for effective communication about security risks, controls, and practices in both traditional and Web3
 environments.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/appendices/glossary.mdx
+++ b/docs/pages/opsec/appendices/glossary.mdx
@@ -1,11 +1,18 @@
 ---
 title: "Security Glossary | Security Alliance"
-description: "Security glossary: definitions for access control, authentication, MFA, vulnerability, risk management, and Web3 terms like cold storage, hardware wallets, multisig, smart contracts, and seed phrases."
+description: "OpSec glossary: access control, authentication, MFA, risk, plus Web3 terms like cold storage, hardware wallets, multisig, seed phrases, and smart contracts."
 tags:
   - Security Specialist
   - Operations & Strategy
   - DevOps
   - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
@@ -14,6 +21,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: A shared glossary keeps OpSec discussions precise across general security terms and
+> Web3-specific vocabulary used throughout the framework.
 
 This glossary provides definitions for key terms used throughout the Operational Security framework. It includes both
 general security terminology and Web3-specific concepts to help ensure a common understanding of security concepts.

--- a/docs/pages/opsec/appendices/glossary.mdx
+++ b/docs/pages/opsec/appendices/glossary.mdx
@@ -8,7 +8,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/opsec/appendices/glossary.mdx
+++ b/docs/pages/opsec/appendices/glossary.mdx
@@ -232,10 +232,12 @@ This glossary provides a common language for discussing operational security con
 essential for effective communication about security risks, controls, and practices in both traditional and Web3
 environments.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [Appendices overview](/opsec/appendices/overview): how the reference material fits together
+- [OpSec overview](/opsec/overview): how the pages of this framework fit together
+- [Security Fundamentals](/opsec/core-concepts/security-fundamentals): the concepts these terms describe
+- [Overview of Each Framework](/intro/overview-of-each-framework): where each term is applied in depth
 
 ---
 

--- a/docs/pages/opsec/appendices/overview.mdx
+++ b/docs/pages/opsec/appendices/overview.mdx
@@ -82,6 +82,11 @@ to:
 By contributing to these resources, you help strengthen the operational security practices of the broader Web3
 community.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/appendices/overview.mdx
+++ b/docs/pages/opsec/appendices/overview.mdx
@@ -1,11 +1,18 @@
 ---
 title: "OpSec Resources & Appendices | Security Alliance"
-description: "OpSec appendices: policy templates, case studies, tabletop exercises, and security glossary. Ready-to-use resources for implementing operational security practices in Web3 environments."
+description: "OpSec appendices: policy templates, case studies, tabletop exercises, and a glossary to support operational security implementation in Web3 teams."
 tags:
   - Security Specialist
   - Operations & Strategy
   - DevOps
   - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
@@ -14,6 +21,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Appendices package reusable policies, case studies, exercises, and glossary terms so teams can
+> operationalize OpSec guidance beyond conceptual overviews.
 
 The appendices provide additional resources, templates, and reference materials to support the implementation of
 operational security practices. These materials complement the guidance provided in the main framework sections.

--- a/docs/pages/opsec/appendices/overview.mdx
+++ b/docs/pages/opsec/appendices/overview.mdx
@@ -8,7 +8,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/opsec/appendices/overview.mdx
+++ b/docs/pages/opsec/appendices/overview.mdx
@@ -38,7 +38,7 @@ The appendices are organized into the following sections:
 
 These resources are designed to be practical tools that organizations can adapt to their specific needs and contexts.
 
-## Section Outline
+## What this framework covers
 
 - [Case Studies & Exercises](/opsec/appendices/case-studies) — scenario walk-throughs and retrospectives to train teams.
 - [Glossary](/opsec/appendices/glossary) — quick reference for OpSec and Web3 terminology.

--- a/docs/pages/opsec/appendices/overview.mdx
+++ b/docs/pages/opsec/appendices/overview.mdx
@@ -82,10 +82,12 @@ to:
 By contributing to these resources, you help strengthen the operational security practices of the broader Web3
 community.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [OpSec overview](/opsec/overview): how the pages of this framework fit together
+- [Glossary](/opsec/appendices/glossary): shared vocabulary used across the framework
+- [Policies](/opsec/appendices/policies): policy templates to adapt
+- [Case Studies](/opsec/appendices/case-studies): worked examples of the controls in practice
 
 ---
 

--- a/docs/pages/opsec/appendices/policies.mdx
+++ b/docs/pages/opsec/appendices/policies.mdx
@@ -34,18 +34,18 @@ documentation.
 ### Information Security Policy
 
 ```markdown
- # Information Security Policy
+# Information Security Policy
 
- ## Purpose
+## Purpose
 
 This policy establishes the framework for protecting information assets and technology resources of [ORGANIZATION NAME].
 
- ## Scope
+## Scope
 
 This policy applies to all employees, contractors, consultants, temporary staff, and other workers at [ORGANIZATION
 NAME], including personnel affiliated with third parties.
 
- ## Policy Statements
+## Policy Statements
 
 1. [ORGANIZATION NAME] shall maintain an information security program that:
    - Protects the confidentiality, integrity, and availability of information
@@ -65,15 +65,15 @@ NAME], including personnel affiliated with third parties.
    - Enforce compliance with security policies
    - Support continuous improvement of security practices
 
- ## Roles and Responsibilities
+## Roles and Responsibilities
 
 [Define specific security roles and responsibilities]
 
- ## Compliance
+## Compliance
 
 Violations of this policy may result in disciplinary action, up to and including termination of employment or contract.
 
- ## Related Documents
+## Related Documents
 
 - Acceptable Use Policy
 - Access Control Policy
@@ -83,17 +83,17 @@ Violations of this policy may result in disciplinary action, up to and including
 ### Access Control Policy
 
 ```markdown
- # Access Control Policy
+# Access Control Policy
 
- ## Purpose
+## Purpose
 
 This policy establishes requirements for controlling access to [ORGANIZATION NAME]'s information systems and data.
 
- ## Scope
+## Scope
 
 This policy applies to all systems, data, and users within [ORGANIZATION NAME].
 
- ## Policy Statements
+## Policy Statements
 
 1. Access Control Principles
    - All access shall be granted based on the principle of least privilege
@@ -110,11 +110,11 @@ This policy applies to all systems, data, and users within [ORGANIZATION NAME].
    - Users shall protect their authentication information
    - Users shall not share access credentials
 
- ## Implementation Guidelines
+## Implementation Guidelines
 
 [Specific implementation guidelines for access control]
 
- ## Exceptions
+## Exceptions
 
 Exceptions to this policy must be documented and approved by [ROLE].
 ```
@@ -124,19 +124,19 @@ Exceptions to this policy must be documented and approved by [ROLE].
 ### Cryptocurrency Key Management Policy
 
 ```markdown
- # Cryptocurrency Key Management Policy
+# Cryptocurrency Key Management Policy
 
- ## Purpose
+## Purpose
 
 This policy establishes requirements for the secure management of cryptographic keys used for cryptocurrency
 transactions and operations.
 
- ## Scope
+## Scope
 
 This policy applies to all cryptographic keys used to secure cryptocurrency assets and operations at [ORGANIZATION
 NAME].
 
- ## Policy Statements
+## Policy Statements
 
 1. Key Generation and Storage
    - Private keys shall be generated using secure methods
@@ -153,11 +153,11 @@ NAME].
    - Recovery procedures shall be documented and tested
    - No single individual shall have access to full recovery information
 
- ## Implementation Guidelines
+## Implementation Guidelines
 
 [Specific implementation guidelines for key management]
 
- ## Roles and Responsibilities
+## Roles and Responsibilities
 
 [Define specific roles and responsibilities for key management]
 ```
@@ -165,17 +165,17 @@ NAME].
 ### Smart Contract Deployment Policy
 
 ```markdown
- # Smart Contract Deployment Policy
+# Smart Contract Deployment Policy
 
- ## Purpose
+## Purpose
 
 This policy establishes requirements for the secure development and deployment of smart contracts.
 
- ## Scope
+## Scope
 
 This policy applies to all smart contracts developed, deployed, or maintained by [ORGANIZATION NAME].
 
- ## Policy Statements
+## Policy Statements
 
 1. Development Requirements
    - Smart contracts shall follow secure coding guidelines
@@ -197,11 +197,11 @@ This policy applies to all smart contracts developed, deployed, or maintained by
    - Security updates shall follow a defined process
    - Upgrade mechanisms shall be secured with appropriate controls
 
- ## Implementation Guidelines
+## Implementation Guidelines
 
 [Specific implementation guidelines for smart contract deployment]
 
- ## Roles and Responsibilities
+## Roles and Responsibilities
 
 [Define specific roles and responsibilities for contract deployment]
 ```
@@ -211,13 +211,13 @@ This policy applies to all smart contracts developed, deployed, or maintained by
 ### Incident Response Procedure
 
 ```markdown
- # Security Incident Response Procedure
+# Security Incident Response Procedure
 
- ## Purpose
+## Purpose
 
 This procedure outlines the steps to be followed when responding to security incidents.
 
- ## Incident Detection and Reporting
+## Incident Detection and Reporting
 
 1. Detection Sources
    - Automated alerts from monitoring systems
@@ -229,7 +229,7 @@ This procedure outlines the steps to be followed when responding to security inc
    - Required information for incident reports
    - Escalation criteria and process
 
- ## Incident Response Phases
+## Incident Response Phases
 
 1. Preparation
    - Necessary tools and resources
@@ -261,11 +261,11 @@ This procedure outlines the steps to be followed when responding to security inc
    - Documentation requirements
    - Improvement implementation
 
- ## Communication Guidelines
+## Communication Guidelines
 
 [Guidelines for internal and external communication during incidents]
 
- ## Specific Incident Types
+## Specific Incident Types
 
 [Specific procedures for different types of incidents]
 ```
@@ -273,13 +273,13 @@ This procedure outlines the steps to be followed when responding to security inc
 ### Key Ceremony Procedure
 
 ```markdown
- # Cryptocurrency Key Ceremony Procedure
+# Cryptocurrency Key Ceremony Procedure
 
- ## Purpose
+## Purpose
 
 This procedure outlines the steps for generating and securing cryptographic keys for cryptocurrency operations.
 
- ## Preparation
+## Preparation
 
 1. Required Materials
    - Hardware wallets or HSMs
@@ -297,7 +297,7 @@ This procedure outlines the steps for generating and securing cryptographic keys
    - Network isolation measures
    - Environmental controls
 
- ## Key Generation Process
+## Key Generation Process
 
 1. Device Preparation
    - Verification of device authenticity
@@ -314,7 +314,7 @@ This procedure outlines the steps for generating and securing cryptographic keys
    - Backup verification
    - Secure storage preparation
 
- ## Security Controls
+## Security Controls
 
 1. Physical Security
    - Access control to ceremony location
@@ -331,7 +331,7 @@ This procedure outlines the steps for generating and securing cryptographic keys
    - Signature requirements
    - Storage of ceremony documentation
 
- ## Post-Ceremony Actions
+## Post-Ceremony Actions
 
 [Actions to be taken after the ceremony is complete]
 ```
@@ -341,16 +341,16 @@ This procedure outlines the steps for generating and securing cryptographic keys
 ### Security Assessment Checklist
 
 ```markdown
- # Security Assessment Checklist
+# Security Assessment Checklist
 
- ## System Information
+## System Information
 
 - System Name: ________________
 - System Owner: ________________
 - Assessment Date: ________________
 - Assessor: ________________
 
- ## Access Controls
+## Access Controls
 
 - [ ] User access is based on least privilege
 - [ ] Strong authentication is enforced
@@ -358,7 +358,7 @@ This procedure outlines the steps for generating and securing cryptographic keys
 - [ ] Access is reviewed regularly
 - [ ] Password policies are enforced
 
- ## Network Security
+## Network Security
 
 - [ ] Firewalls are properly configured
 - [ ] Network traffic is monitored
@@ -366,7 +366,7 @@ This procedure outlines the steps for generating and securing cryptographic keys
 - [ ] Network segmentation is implemented
 - [ ] Encrypted protocols are used for sensitive data
 
- ## Data Protection
+## Data Protection
 
 - [ ] Sensitive data is identified and classified
 - [ ] Data encryption is implemented
@@ -374,7 +374,7 @@ This procedure outlines the steps for generating and securing cryptographic keys
 - [ ] Data retention policies are enforced
 - [ ] Data destruction procedures are in place
 
- ## System Security
+## System Security
 
 - [ ] Systems are patched regularly
 - [ ] Antimalware protection is implemented
@@ -382,7 +382,7 @@ This procedure outlines the steps for generating and securing cryptographic keys
 - [ ] System logs are collected and reviewed
 - [ ] Change management processes are followed
 
- ## Physical Security
+## Physical Security
 
 - [ ] Physical access controls are in place
 - [ ] Environmental controls are implemented
@@ -390,7 +390,7 @@ This procedure outlines the steps for generating and securing cryptographic keys
 - [ ] Media is securely handled and disposed of
 - [ ] Physical security incidents are monitored
 
- ## Incident Response
+## Incident Response
 
 - [ ] Incident response procedures are documented
 - [ ] Staff is trained on incident response
@@ -398,7 +398,7 @@ This procedure outlines the steps for generating and securing cryptographic keys
 - [ ] Post-incident reviews are conducted
 - [ ] Lessons learned are implemented
 
- ## Additional Notes
+## Additional Notes
 
 [Space for assessment notes and observations]
 ```
@@ -407,10 +407,14 @@ These templates provide starting points for developing comprehensive security po
 should customize these templates to address their specific security requirements, organizational structure, and risk
 profile.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [Appendices overview](/opsec/appendices/overview): how the reference material fits together
+- [Organizational Controls overview](/opsec/control-domains/organizational/overview): the organizational domain this
+  belongs to
+- [Governance](/governance/overview): approving and maintaining policy
+- [Security Policies and Procedures](/external-security-reviews/security-policies-procedures): what reviewers expect to
+  see
 
 ---
 

--- a/docs/pages/opsec/appendices/policies.mdx
+++ b/docs/pages/opsec/appendices/policies.mdx
@@ -407,6 +407,11 @@ These templates provide starting points for developing comprehensive security po
 should customize these templates to address their specific security requirements, organizational structure, and risk
 profile.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/appendices/policies.mdx
+++ b/docs/pages/opsec/appendices/policies.mdx
@@ -1,11 +1,18 @@
 ---
 title: "Security Policy Templates | Security Alliance"
-description: "Security policy templates: Information Security Policy, Access Control Policy, Cryptocurrency Key Management, Smart Contract Deployment, Incident Response Procedures, and Key Ceremony templates."
+description: "Policy templates for OpSec: information security, access control, key management, smart-contract deployment, incident response, and key-ceremony docs."
 tags:
   - Security Specialist
   - Operations & Strategy
   - DevOps
   - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
@@ -14,6 +21,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Policy templates give teams adaptable starting points for information security, access control,
+> key management, deployments, incident response, and ceremonies.
 
 This library provides templates and examples of security policies, procedures, and other documents that organizations
 can adapt to their specific needs. These templates serve as starting points for developing comprehensive security

--- a/docs/pages/opsec/appendices/policies.mdx
+++ b/docs/pages/opsec/appendices/policies.mdx
@@ -8,7 +8,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/opsec/appendices/policies.mdx
+++ b/docs/pages/opsec/appendices/policies.mdx
@@ -34,18 +34,18 @@ documentation.
 ### Information Security Policy
 
 ```markdown
-# Information Security Policy
+ # Information Security Policy
 
-## Purpose
+ ## Purpose
 
 This policy establishes the framework for protecting information assets and technology resources of [ORGANIZATION NAME].
 
-## Scope
+ ## Scope
 
 This policy applies to all employees, contractors, consultants, temporary staff, and other workers at [ORGANIZATION
 NAME], including personnel affiliated with third parties.
 
-## Policy Statements
+ ## Policy Statements
 
 1. [ORGANIZATION NAME] shall maintain an information security program that:
    - Protects the confidentiality, integrity, and availability of information
@@ -65,15 +65,15 @@ NAME], including personnel affiliated with third parties.
    - Enforce compliance with security policies
    - Support continuous improvement of security practices
 
-## Roles and Responsibilities
+ ## Roles and Responsibilities
 
 [Define specific security roles and responsibilities]
 
-## Compliance
+ ## Compliance
 
 Violations of this policy may result in disciplinary action, up to and including termination of employment or contract.
 
-## Related Documents
+ ## Related Documents
 
 - Acceptable Use Policy
 - Access Control Policy
@@ -83,17 +83,17 @@ Violations of this policy may result in disciplinary action, up to and including
 ### Access Control Policy
 
 ```markdown
-# Access Control Policy
+ # Access Control Policy
 
-## Purpose
+ ## Purpose
 
 This policy establishes requirements for controlling access to [ORGANIZATION NAME]'s information systems and data.
 
-## Scope
+ ## Scope
 
 This policy applies to all systems, data, and users within [ORGANIZATION NAME].
 
-## Policy Statements
+ ## Policy Statements
 
 1. Access Control Principles
    - All access shall be granted based on the principle of least privilege
@@ -110,11 +110,11 @@ This policy applies to all systems, data, and users within [ORGANIZATION NAME].
    - Users shall protect their authentication information
    - Users shall not share access credentials
 
-## Implementation Guidelines
+ ## Implementation Guidelines
 
 [Specific implementation guidelines for access control]
 
-## Exceptions
+ ## Exceptions
 
 Exceptions to this policy must be documented and approved by [ROLE].
 ```
@@ -124,19 +124,19 @@ Exceptions to this policy must be documented and approved by [ROLE].
 ### Cryptocurrency Key Management Policy
 
 ```markdown
-# Cryptocurrency Key Management Policy
+ # Cryptocurrency Key Management Policy
 
-## Purpose
+ ## Purpose
 
 This policy establishes requirements for the secure management of cryptographic keys used for cryptocurrency
 transactions and operations.
 
-## Scope
+ ## Scope
 
 This policy applies to all cryptographic keys used to secure cryptocurrency assets and operations at [ORGANIZATION
 NAME].
 
-## Policy Statements
+ ## Policy Statements
 
 1. Key Generation and Storage
    - Private keys shall be generated using secure methods
@@ -153,11 +153,11 @@ NAME].
    - Recovery procedures shall be documented and tested
    - No single individual shall have access to full recovery information
 
-## Implementation Guidelines
+ ## Implementation Guidelines
 
 [Specific implementation guidelines for key management]
 
-## Roles and Responsibilities
+ ## Roles and Responsibilities
 
 [Define specific roles and responsibilities for key management]
 ```
@@ -165,17 +165,17 @@ NAME].
 ### Smart Contract Deployment Policy
 
 ```markdown
-# Smart Contract Deployment Policy
+ # Smart Contract Deployment Policy
 
-## Purpose
+ ## Purpose
 
 This policy establishes requirements for the secure development and deployment of smart contracts.
 
-## Scope
+ ## Scope
 
 This policy applies to all smart contracts developed, deployed, or maintained by [ORGANIZATION NAME].
 
-## Policy Statements
+ ## Policy Statements
 
 1. Development Requirements
    - Smart contracts shall follow secure coding guidelines
@@ -197,11 +197,11 @@ This policy applies to all smart contracts developed, deployed, or maintained by
    - Security updates shall follow a defined process
    - Upgrade mechanisms shall be secured with appropriate controls
 
-## Implementation Guidelines
+ ## Implementation Guidelines
 
 [Specific implementation guidelines for smart contract deployment]
 
-## Roles and Responsibilities
+ ## Roles and Responsibilities
 
 [Define specific roles and responsibilities for contract deployment]
 ```
@@ -211,13 +211,13 @@ This policy applies to all smart contracts developed, deployed, or maintained by
 ### Incident Response Procedure
 
 ```markdown
-# Security Incident Response Procedure
+ # Security Incident Response Procedure
 
-## Purpose
+ ## Purpose
 
 This procedure outlines the steps to be followed when responding to security incidents.
 
-## Incident Detection and Reporting
+ ## Incident Detection and Reporting
 
 1. Detection Sources
    - Automated alerts from monitoring systems
@@ -229,7 +229,7 @@ This procedure outlines the steps to be followed when responding to security inc
    - Required information for incident reports
    - Escalation criteria and process
 
-## Incident Response Phases
+ ## Incident Response Phases
 
 1. Preparation
    - Necessary tools and resources
@@ -261,11 +261,11 @@ This procedure outlines the steps to be followed when responding to security inc
    - Documentation requirements
    - Improvement implementation
 
-## Communication Guidelines
+ ## Communication Guidelines
 
 [Guidelines for internal and external communication during incidents]
 
-## Specific Incident Types
+ ## Specific Incident Types
 
 [Specific procedures for different types of incidents]
 ```
@@ -273,13 +273,13 @@ This procedure outlines the steps to be followed when responding to security inc
 ### Key Ceremony Procedure
 
 ```markdown
-# Cryptocurrency Key Ceremony Procedure
+ # Cryptocurrency Key Ceremony Procedure
 
-## Purpose
+ ## Purpose
 
 This procedure outlines the steps for generating and securing cryptographic keys for cryptocurrency operations.
 
-## Preparation
+ ## Preparation
 
 1. Required Materials
    - Hardware wallets or HSMs
@@ -297,7 +297,7 @@ This procedure outlines the steps for generating and securing cryptographic keys
    - Network isolation measures
    - Environmental controls
 
-## Key Generation Process
+ ## Key Generation Process
 
 1. Device Preparation
    - Verification of device authenticity
@@ -314,7 +314,7 @@ This procedure outlines the steps for generating and securing cryptographic keys
    - Backup verification
    - Secure storage preparation
 
-## Security Controls
+ ## Security Controls
 
 1. Physical Security
    - Access control to ceremony location
@@ -331,7 +331,7 @@ This procedure outlines the steps for generating and securing cryptographic keys
    - Signature requirements
    - Storage of ceremony documentation
 
-## Post-Ceremony Actions
+ ## Post-Ceremony Actions
 
 [Actions to be taken after the ceremony is complete]
 ```
@@ -341,16 +341,16 @@ This procedure outlines the steps for generating and securing cryptographic keys
 ### Security Assessment Checklist
 
 ```markdown
-# Security Assessment Checklist
+ # Security Assessment Checklist
 
-## System Information
+ ## System Information
 
 - System Name: ________________
 - System Owner: ________________
 - Assessment Date: ________________
 - Assessor: ________________
 
-## Access Controls
+ ## Access Controls
 
 - [ ] User access is based on least privilege
 - [ ] Strong authentication is enforced
@@ -358,7 +358,7 @@ This procedure outlines the steps for generating and securing cryptographic keys
 - [ ] Access is reviewed regularly
 - [ ] Password policies are enforced
 
-## Network Security
+ ## Network Security
 
 - [ ] Firewalls are properly configured
 - [ ] Network traffic is monitored
@@ -366,7 +366,7 @@ This procedure outlines the steps for generating and securing cryptographic keys
 - [ ] Network segmentation is implemented
 - [ ] Encrypted protocols are used for sensitive data
 
-## Data Protection
+ ## Data Protection
 
 - [ ] Sensitive data is identified and classified
 - [ ] Data encryption is implemented
@@ -374,7 +374,7 @@ This procedure outlines the steps for generating and securing cryptographic keys
 - [ ] Data retention policies are enforced
 - [ ] Data destruction procedures are in place
 
-## System Security
+ ## System Security
 
 - [ ] Systems are patched regularly
 - [ ] Antimalware protection is implemented
@@ -382,7 +382,7 @@ This procedure outlines the steps for generating and securing cryptographic keys
 - [ ] System logs are collected and reviewed
 - [ ] Change management processes are followed
 
-## Physical Security
+ ## Physical Security
 
 - [ ] Physical access controls are in place
 - [ ] Environmental controls are implemented
@@ -390,7 +390,7 @@ This procedure outlines the steps for generating and securing cryptographic keys
 - [ ] Media is securely handled and disposed of
 - [ ] Physical security incidents are monitored
 
-## Incident Response
+ ## Incident Response
 
 - [ ] Incident response procedures are documented
 - [ ] Staff is trained on incident response
@@ -398,7 +398,7 @@ This procedure outlines the steps for generating and securing cryptographic keys
 - [ ] Post-incident reviews are conducted
 - [ ] Lessons learned are implemented
 
-## Additional Notes
+ ## Additional Notes
 
 [Space for assessment notes and observations]
 ```

--- a/docs/pages/opsec/browser/overview.mdx
+++ b/docs/pages/opsec/browser/overview.mdx
@@ -1,8 +1,16 @@
 ---
 title: "Browser Security | Security Alliance"
+description: "Browser security guidance for Web3 operators: harden extensions, isolate sessions, and reduce phishing and infostealer risk in daily web workflows."
 tags:
   - Security Specialist
   - Operations & Strategy
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
@@ -12,6 +20,18 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-Placeholder for Browser Security content
+> ⚠️ Stub/in progress, help contribute/expand.
+
+{/* stub-kt-sep */}
+
+> 🔑 **Key Takeaway**: Browser security reduces phishing and malware risk through extension control, safer defaults,
+> and isolating high-value sessions from everyday browsing.
+
+This page is a placeholder in the Operational Security framework. Planned content will expand the topic above using
+existing SEAL guidance patterns.
+
+Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
+
+---
 
 <ContributeFooter />

--- a/docs/pages/opsec/browser/overview.mdx
+++ b/docs/pages/opsec/browser/overview.mdx
@@ -6,7 +6,7 @@ tags:
   - Operations & Strategy
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/opsec/browser/overview.mdx
+++ b/docs/pages/opsec/browser/overview.mdx
@@ -15,6 +15,13 @@ contributors:
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
 
+{/*
+  content-model-exception:
+  type: project-doc
+  reason: Nested OpSec overview; child map lives in parent IA / sidebar until section pages stabilize.
+  owner: maintainers
+*/}
+
 # Browser Security
 
 <TagList tags={frontmatter.tags} />

--- a/docs/pages/opsec/browser/overview.mdx
+++ b/docs/pages/opsec/browser/overview.mdx
@@ -32,6 +32,11 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/browser/overview.mdx
+++ b/docs/pages/opsec/browser/overview.mdx
@@ -39,10 +39,12 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [OpSec overview](/opsec/overview): how the pages of this framework fit together
+- [Endpoint Security](/opsec/endpoint/overview): the device the browser runs on
+- [Secure Browsing](/privacy/secure-browsing): privacy-side browsing practice
+- [Common Vulnerabilities](/front-end-web-app/common-vulnerabilities): what hostile pages actually try
 
 ---
 

--- a/docs/pages/opsec/continuous-improvement-metrics.mdx
+++ b/docs/pages/opsec/continuous-improvement-metrics.mdx
@@ -179,10 +179,12 @@ Continuous improvement in security requires a systematic approach to learning, m
 robust metrics, assessment processes, and a culture of security awareness, organizations can evolve their security
 practices to address emerging threats and changing environments.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [OpSec overview](/opsec/overview): how the pages of this framework fit together
+- [Security KPIs](/opsec/improvement/security-kpis): the specific measures to track
+- [Post-Mortem](/opsec/improvement/post-mortem): the review that feeds improvement
+- [Security Metrics and KPIs](/governance/security-metrics-kpis): reporting these upward
 
 ---
 

--- a/docs/pages/opsec/continuous-improvement-metrics.mdx
+++ b/docs/pages/opsec/continuous-improvement-metrics.mdx
@@ -1,11 +1,18 @@
 ---
 title: "Security Improvement Metrics | SEAL"
-description: "Measure security effectiveness with KPIs: Time to Detect, Time to Respond, Mean Time to Recovery, and vulnerability management. Conduct post-mortems and build a security-conscious culture."
+description: "Measure OpSec with KPIs like time-to-detect, time-to-respond, and MTTR; run post-mortems and continuous assessment to improve Web3 security culture."
 tags:
   - Security Specialist
   - Operations & Strategy
   - DevOps
   - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../components'
@@ -14,6 +21,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Security improves when teams measure detection and response, learn from incidents and
+> near-misses without blame, and keep refining controls as threats and systems change.
 
 Operational security is not a static state but rather a continuous process of assessment, improvement, and adaptation.
 This section outlines approaches to continuously improve security practices and measure their effectiveness.

--- a/docs/pages/opsec/continuous-improvement-metrics.mdx
+++ b/docs/pages/opsec/continuous-improvement-metrics.mdx
@@ -179,6 +179,11 @@ Continuous improvement in security requires a systematic approach to learning, m
 robust metrics, assessment processes, and a culture of security awareness, organizations can evolve their security
 practices to address emerging threats and changing environments.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/continuous-improvement-metrics.mdx
+++ b/docs/pages/opsec/continuous-improvement-metrics.mdx
@@ -8,7 +8,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/opsec/control-domains/organizational/compliance-regulatory-alignment.mdx
+++ b/docs/pages/opsec/control-domains/organizational/compliance-regulatory-alignment.mdx
@@ -34,6 +34,11 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/control-domains/organizational/compliance-regulatory-alignment.mdx
+++ b/docs/pages/opsec/control-domains/organizational/compliance-regulatory-alignment.mdx
@@ -8,7 +8,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/opsec/control-domains/organizational/compliance-regulatory-alignment.mdx
+++ b/docs/pages/opsec/control-domains/organizational/compliance-regulatory-alignment.mdx
@@ -34,10 +34,13 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [Organizational Controls overview](/opsec/control-domains/organizational/overview): the organizational domain this
+  belongs to
+- [Compliance with Regulatory Requirements](/governance/compliance-regulatory-requirements): the frameworks that apply
+- [Policies](/opsec/appendices/policies): templates to document the alignment
+- [Security Policies and Procedures](/external-security-reviews/security-policies-procedures): what auditors ask for
 
 ---
 

--- a/docs/pages/opsec/control-domains/organizational/compliance-regulatory-alignment.mdx
+++ b/docs/pages/opsec/control-domains/organizational/compliance-regulatory-alignment.mdx
@@ -1,1 +1,39 @@
+---
+title: "Compliance & Regulatory Alignment | SEAL"
+description: "Stub: map OpSec controls to applicable regulations and standards, close gaps, and monitor compliance continuously across Web3 organizations."
+tags:
+  - Security Specialist
+  - Operations & Strategy
+  - DevOps
+  - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
+---
+
+import { TagList, AttributionList, ContributeFooter } from '../../../../../components'
+
 # Compliance & regulatory alignment
+
+<TagList tags={frontmatter.tags} />
+<AttributionList contributors={frontmatter.contributors} />
+
+> ⚠️ Stub/in progress, help contribute/expand.
+
+{/* stub-kt-sep */}
+
+> 🔑 **Key Takeaway**: Compliance alignment maps required laws and standards to concrete controls, then tracks gaps and
+> remediation instead of treating audits as one-off events.
+
+This page is a placeholder in the Operational Security framework. Planned content will expand the topic above using
+existing SEAL guidance patterns.
+
+Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
+
+---
+
+<ContributeFooter />

--- a/docs/pages/opsec/control-domains/organizational/overview.mdx
+++ b/docs/pages/opsec/control-domains/organizational/overview.mdx
@@ -125,10 +125,13 @@ Effective organizational controls provide the structure needed to implement and 
 your organization. By establishing clear governance, compliance processes, and supply chain controls, you create a
 foundation for all other security measures.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [Control Domains overview](/opsec/control-domains/overview): how the four control domains fit together
+- [Compliance and Regulatory Alignment](/opsec/control-domains/organizational/compliance-regulatory-alignment): mapping
+  obligations to controls
+- [Supply Chain Security](/opsec/control-domains/organizational/supply-chain-security): vendor and dependency risk
+- [Governance](/governance/overview): the decision structures behind these controls
 
 ---
 

--- a/docs/pages/opsec/control-domains/organizational/overview.mdx
+++ b/docs/pages/opsec/control-domains/organizational/overview.mdx
@@ -1,11 +1,18 @@
 ---
-title: "Organizational Security Controls | Security Alliance"
-description: "Organizational controls: regulatory compliance, supply chain security, vendor assessments, and security governance. Web3 guidance for DAOs and multisig."
+title: "Organizational Security Controls | SEAL"
+description: "Organizational OpSec controls: compliance alignment, supply-chain security, vendor assurance, and governance structures that sustain the program."
 tags:
   - Security Specialist
   - Operations & Strategy
   - DevOps
   - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../../components'
@@ -14,6 +21,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../../compo
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Organizational controls set policies, compliance mapping, and third-party assurance so technical
+> and people controls have durable ownership and funding.
 
 Organizational controls form the foundation of an operational security program. These controls establish the governance
 structures, policies, and processes necessary to implement and maintain security throughout the organization.

--- a/docs/pages/opsec/control-domains/organizational/overview.mdx
+++ b/docs/pages/opsec/control-domains/organizational/overview.mdx
@@ -118,6 +118,11 @@ Effective organizational controls provide the structure needed to implement and 
 your organization. By establishing clear governance, compliance processes, and supply chain controls, you create a
 foundation for all other security measures.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/control-domains/organizational/overview.mdx
+++ b/docs/pages/opsec/control-domains/organizational/overview.mdx
@@ -8,7 +8,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/opsec/control-domains/organizational/overview.mdx
+++ b/docs/pages/opsec/control-domains/organizational/overview.mdx
@@ -17,6 +17,13 @@ contributors:
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../../components'
 
+{/*
+  content-model-exception:
+  type: project-doc
+  reason: Nested OpSec overview; child map lives in parent IA / sidebar until section pages stabilize.
+  owner: maintainers
+*/}
+
 # Organizational Controls
 
 <TagList tags={frontmatter.tags} />

--- a/docs/pages/opsec/control-domains/organizational/supply-chain-security.mdx
+++ b/docs/pages/opsec/control-domains/organizational/supply-chain-security.mdx
@@ -34,10 +34,13 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [Organizational Controls overview](/opsec/control-domains/organizational/overview): the organizational domain this
+  belongs to
+- [Supply Chain](/supply-chain/overview): the dedicated framework for this risk
+- [Vendor Risk Management](/supply-chain/vendor-risk-management): assessing third parties
+- [DevSecOps](/devsecops/overview): build and delivery integrity
 
 ---
 

--- a/docs/pages/opsec/control-domains/organizational/supply-chain-security.mdx
+++ b/docs/pages/opsec/control-domains/organizational/supply-chain-security.mdx
@@ -34,6 +34,11 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/control-domains/organizational/supply-chain-security.mdx
+++ b/docs/pages/opsec/control-domains/organizational/supply-chain-security.mdx
@@ -8,7 +8,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/opsec/control-domains/organizational/supply-chain-security.mdx
+++ b/docs/pages/opsec/control-domains/organizational/supply-chain-security.mdx
@@ -1,1 +1,39 @@
+---
+title: "Supply-Chain Security | Security Alliance"
+description: "Stub: secure vendor and software supply chains with assessments, contractual controls, and ongoing monitoring of third-party operational risk."
+tags:
+  - Security Specialist
+  - Operations & Strategy
+  - DevOps
+  - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
+---
+
+import { TagList, AttributionList, ContributeFooter } from '../../../../../components'
+
 # Supply-chain security
+
+<TagList tags={frontmatter.tags} />
+<AttributionList contributors={frontmatter.contributors} />
+
+> ⚠️ Stub/in progress, help contribute/expand.
+
+{/* stub-kt-sep */}
+
+> 🔑 **Key Takeaway**: Supply-chain security extends OpSec to vendors and dependencies so third parties cannot quietly
+> become the weakest path into critical operations.
+
+This page is a placeholder in the Operational Security framework. Planned content will expand the topic above using
+existing SEAL guidance patterns.
+
+Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
+
+---
+
+<ContributeFooter />

--- a/docs/pages/opsec/control-domains/overview.mdx
+++ b/docs/pages/opsec/control-domains/overview.mdx
@@ -50,7 +50,7 @@ Effective operational security requires a balanced approach across all control d
 3. **Continuous Evaluation**: Regularly assess the effectiveness of controls against evolving threats
 4. **Adaptability**: Adjust controls based on changes in technology, threats, and organizational needs
 
-## Section Outline
+## What this framework covers
 
 - [Organizational Controls](/opsec/control-domains/organizational/overview) — governance, compliance, and third-party assurance.
   - [Compliance & Regulatory Alignment](/opsec/control-domains/organizational/compliance-regulatory-alignment)

--- a/docs/pages/opsec/control-domains/overview.mdx
+++ b/docs/pages/opsec/control-domains/overview.mdx
@@ -96,10 +96,14 @@ In Web3 environments, control implementation must address unique challenges:
 The following sections detail the specific controls within each domain, providing guidance on implementation and best
 practices tailored to Web3 organizations.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [Technical Controls overview](/opsec/control-domains/technical/overview): the technical domain this belongs to
+- [People Controls overview](/opsec/control-domains/people/overview): the people domain this belongs to
+- [Organizational Controls overview](/opsec/control-domains/organizational/overview): the organizational domain this
+  belongs to
+- [Physical & Environmental overview](/opsec/control-domains/physical-environmental/overview): the physical domain this
+  belongs to
 
 ---
 

--- a/docs/pages/opsec/control-domains/overview.mdx
+++ b/docs/pages/opsec/control-domains/overview.mdx
@@ -1,11 +1,18 @@
 ---
 title: "OpSec Control Domains | Security Alliance"
-description: "OpSec control domains: organizational policies, people and personnel security, physical and environmental protection, and technical controls. Build layered defense-in-depth for Web3 environments."
+description: "OpSec control domains: organizational policy, people and culture, physical and environmental protection, and technical controls for defense in depth."
 tags:
   - Security Specialist
   - Operations & Strategy
   - DevOps
   - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
@@ -14,6 +21,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Organize OpSec into organizational, people, physical/environmental, and technical domains so
+> layered controls cover process, humans, places, and systems.
 
 Operational security controls are organized into domains that address different aspects of security. This section
 provides an overview of these domains and how they work together to create a comprehensive security posture.

--- a/docs/pages/opsec/control-domains/overview.mdx
+++ b/docs/pages/opsec/control-domains/overview.mdx
@@ -8,7 +8,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/opsec/control-domains/overview.mdx
+++ b/docs/pages/opsec/control-domains/overview.mdx
@@ -96,6 +96,11 @@ In Web3 environments, control implementation must address unique challenges:
 The following sections detail the specific controls within each domain, providing guidance on implementation and best
 practices tailored to Web3 organizations.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/control-domains/people/insider-threat-mitigation.mdx
+++ b/docs/pages/opsec/control-domains/people/insider-threat-mitigation.mdx
@@ -34,6 +34,11 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/control-domains/people/insider-threat-mitigation.mdx
+++ b/docs/pages/opsec/control-domains/people/insider-threat-mitigation.mdx
@@ -8,7 +8,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/opsec/control-domains/people/insider-threat-mitigation.mdx
+++ b/docs/pages/opsec/control-domains/people/insider-threat-mitigation.mdx
@@ -34,10 +34,13 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [People Controls overview](/opsec/control-domains/people/overview): the people domain this belongs to
+- [DPRK IT Workers](/dprk-it-workers/overview): the best-documented insider threat in Web3
+- [Access Management](/iam/access-management): least privilege and offboarding
+- [Security Training and Culture](/opsec/control-domains/people/security-training-culture): the reporting culture that
+  surfaces concerns
 
 ---
 

--- a/docs/pages/opsec/control-domains/people/insider-threat-mitigation.mdx
+++ b/docs/pages/opsec/control-domains/people/insider-threat-mitigation.mdx
@@ -1,1 +1,39 @@
+---
+title: "Insider-Threat Mitigation | Security Alliance"
+description: "Stub: mitigate insider threat with least privilege, monitoring, joiner-mover-leaver processes, and clear reporting paths across Web3 organizations."
+tags:
+  - Security Specialist
+  - Operations & Strategy
+  - DevOps
+  - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
+---
+
+import { TagList, AttributionList, ContributeFooter } from '../../../../../components'
+
 # Insider-threat mitigation
+
+<TagList tags={frontmatter.tags} />
+<AttributionList contributors={frontmatter.contributors} />
+
+> ⚠️ Stub/in progress, help contribute/expand.
+
+{/* stub-kt-sep */}
+
+> 🔑 **Key Takeaway**: Insider-threat mitigation combines least privilege, access lifecycle hygiene, monitoring, and
+> safe reporting so trusted access is harder to abuse.
+
+This page is a placeholder in the Operational Security framework. Planned content will expand the topic above using
+existing SEAL guidance patterns.
+
+Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
+
+---
+
+<ContributeFooter />

--- a/docs/pages/opsec/control-domains/people/overview.mdx
+++ b/docs/pages/opsec/control-domains/people/overview.mdx
@@ -17,6 +17,13 @@ contributors:
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../../components'
 
+{/*
+  content-model-exception:
+  type: project-doc
+  reason: Nested OpSec overview; child map lives in parent IA / sidebar until section pages stabilize.
+  owner: maintainers
+*/}
+
 # People & Personnel Controls
 
 <TagList tags={frontmatter.tags} />

--- a/docs/pages/opsec/control-domains/people/overview.mdx
+++ b/docs/pages/opsec/control-domains/people/overview.mdx
@@ -1,11 +1,18 @@
 ---
 title: "Personnel Security Controls | Security Alliance"
-description: "People controls: defend against social engineering, mitigate insider threats, build security training programs, and establish personnel security measures for Web3 teams with distributed contributors."
+description: "People OpSec controls: social-engineering defense, insider-threat mitigation, security training, and culture practices for distributed Web3 teams."
 tags:
   - Security Specialist
   - Operations & Strategy
   - DevOps
   - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../../components'
@@ -14,6 +21,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../../compo
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: People controls reduce human-targeted risk through training, social-engineering defenses,
+> insider-threat measures, and a culture that makes secure behavior normal.
 
 People are both the greatest asset and potentially the greatest vulnerability in any security program. This section
 outlines controls to mitigate human-related security risks while fostering a security-aware culture.

--- a/docs/pages/opsec/control-domains/people/overview.mdx
+++ b/docs/pages/opsec/control-domains/people/overview.mdx
@@ -153,10 +153,12 @@ Effective people and personnel controls recognize that security is fundamentally
 engineering, insider threats, and security awareness, organizations can transform their people from potential
 vulnerabilities into a critical line of defense.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [Control Domains overview](/opsec/control-domains/overview): how the four control domains fit together
+- [Insider Threat Mitigation](/opsec/control-domains/people/insider-threat-mitigation): risk from trusted access
+- [Security Training and Culture](/opsec/control-domains/people/security-training-culture): building durable habits
+- [Social Engineering Defense](/opsec/control-domains/people/social-engineering-defense): resisting manipulation
 
 ---
 

--- a/docs/pages/opsec/control-domains/people/overview.mdx
+++ b/docs/pages/opsec/control-domains/people/overview.mdx
@@ -8,7 +8,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/opsec/control-domains/people/overview.mdx
+++ b/docs/pages/opsec/control-domains/people/overview.mdx
@@ -146,6 +146,11 @@ Effective people and personnel controls recognize that security is fundamentally
 engineering, insider threats, and security awareness, organizations can transform their people from potential
 vulnerabilities into a critical line of defense.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/control-domains/people/security-training-culture.mdx
+++ b/docs/pages/opsec/control-domains/people/security-training-culture.mdx
@@ -34,10 +34,14 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [People Controls overview](/opsec/control-domains/people/overview): the people domain this belongs to
+- [Staying Informed and Continuous Learning](/awareness/staying-informed-and-continuous-learning): keeping training
+  current
+- [Security Training](/user-team-security/security-training): role-based curriculum design
+- [Social Engineering Defense](/opsec/control-domains/people/social-engineering-defense): the skill training most needs
+  to build
 
 ---
 

--- a/docs/pages/opsec/control-domains/people/security-training-culture.mdx
+++ b/docs/pages/opsec/control-domains/people/security-training-culture.mdx
@@ -34,6 +34,11 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/control-domains/people/security-training-culture.mdx
+++ b/docs/pages/opsec/control-domains/people/security-training-culture.mdx
@@ -8,7 +8,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/opsec/control-domains/people/security-training-culture.mdx
+++ b/docs/pages/opsec/control-domains/people/security-training-culture.mdx
@@ -1,1 +1,39 @@
+---
+title: "Security Training & Culture | Security Alliance"
+description: "Stub: build security training programs and culture so Web3 contributors practice secure habits every day and escalate concerns early and often."
+tags:
+  - Security Specialist
+  - Operations & Strategy
+  - DevOps
+  - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
+---
+
+import { TagList, AttributionList, ContributeFooter } from '../../../../../components'
+
 # Security training & culture
+
+<TagList tags={frontmatter.tags} />
+<AttributionList contributors={frontmatter.contributors} />
+
+> ⚠️ Stub/in progress, help contribute/expand.
+
+{/* stub-kt-sep */}
+
+> 🔑 **Key Takeaway**: Security training and culture turn policies into daily habits—regular practice, clear
+> expectations, and recognition beat one-time awareness slides.
+
+This page is a placeholder in the Operational Security framework. Planned content will expand the topic above using
+existing SEAL guidance patterns.
+
+Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
+
+---
+
+<ContributeFooter />

--- a/docs/pages/opsec/control-domains/people/social-engineering-defense.mdx
+++ b/docs/pages/opsec/control-domains/people/social-engineering-defense.mdx
@@ -34,10 +34,12 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [People Controls overview](/opsec/control-domains/people/overview): the people domain this belongs to
+- [Understanding Threat Vectors](/awareness/understanding-threat-vectors): the tactics being defended against
+- [Phishing and Social Engineering](/user-team-security/phishing-social-engineering): team-level defenses
+- [Security Training and Culture](/opsec/control-domains/people/security-training-culture): embedding this in practice
 
 ---
 

--- a/docs/pages/opsec/control-domains/people/social-engineering-defense.mdx
+++ b/docs/pages/opsec/control-domains/people/social-engineering-defense.mdx
@@ -1,1 +1,39 @@
+---
+title: "Social-Engineering Defense | Security Alliance"
+description: "Stub: defend against phishing and social engineering with awareness training, verification procedures, simulations, and clear reporting channels."
+tags:
+  - Security Specialist
+  - Operations & Strategy
+  - DevOps
+  - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
+---
+
+import { TagList, AttributionList, ContributeFooter } from '../../../../../components'
+
 # Social-engineering defense
+
+<TagList tags={frontmatter.tags} />
+<AttributionList contributors={frontmatter.contributors} />
+
+> ⚠️ Stub/in progress, help contribute/expand.
+
+{/* stub-kt-sep */}
+
+> 🔑 **Key Takeaway**: Social-engineering defense pairs awareness with verification procedures, practice simulations,
+> and easy reporting when something feels wrong.
+
+This page is a placeholder in the Operational Security framework. Planned content will expand the topic above using
+existing SEAL guidance patterns.
+
+Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
+
+---
+
+<ContributeFooter />

--- a/docs/pages/opsec/control-domains/people/social-engineering-defense.mdx
+++ b/docs/pages/opsec/control-domains/people/social-engineering-defense.mdx
@@ -34,6 +34,11 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/control-domains/people/social-engineering-defense.mdx
+++ b/docs/pages/opsec/control-domains/people/social-engineering-defense.mdx
@@ -8,7 +8,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/opsec/control-domains/physical-environmental/overview.mdx
+++ b/docs/pages/opsec/control-domains/physical-environmental/overview.mdx
@@ -148,10 +148,13 @@ counter-surveillance, and supply-chain tamper evidence — see the
 [Physical Security](/physical-security/overview) framework. That domain covers physical threats to people and assets
 that complement the OpSec controls described here.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [Control Domains overview](/opsec/control-domains/overview): how the four control domains fit together
+- [Secure Workspace and Travel](/opsec/control-domains/physical-environmental/secure-workspace-travel): protecting where
+  work happens
+- [Tamper Evidence](/opsec/control-domains/physical-environmental/tamper-evidence): detecting physical interference
+- [Physical Security](/physical-security/overview): the dedicated framework for physical threats
 
 ---
 

--- a/docs/pages/opsec/control-domains/physical-environmental/overview.mdx
+++ b/docs/pages/opsec/control-domains/physical-environmental/overview.mdx
@@ -17,6 +17,13 @@ contributors:
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../../components'
 
+{/*
+  content-model-exception:
+  type: project-doc
+  reason: Nested OpSec overview; child map lives in parent IA / sidebar until section pages stabilize.
+  owner: maintainers
+*/}
+
 # Physical & Environmental Controls
 
 <TagList tags={frontmatter.tags} />

--- a/docs/pages/opsec/control-domains/physical-environmental/overview.mdx
+++ b/docs/pages/opsec/control-domains/physical-environmental/overview.mdx
@@ -141,6 +141,11 @@ counter-surveillance, and supply-chain tamper evidence — see the
 [Physical Security](/physical-security/overview) framework. That domain covers physical threats to people and assets
 that complement the OpSec controls described here.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/control-domains/physical-environmental/overview.mdx
+++ b/docs/pages/opsec/control-domains/physical-environmental/overview.mdx
@@ -1,12 +1,18 @@
 ---
-title: "Physical & Environmental Security | Security Alliance"
-description: "Physical security controls: secure workspaces, travel security, tamper-evidence measures against evil-maid attacks. Protect hardware wallets, cold storage, seed phrases, and validator infrastructure."
+title: "Physical & Environmental Security | SEAL"
+description: "Physical OpSec controls: secure workspaces, travel practices, and tamper-evidence against evil-maid attacks on wallets, backups, and devices."
 tags:
   - Security Specialist
   - Operations & Strategy
   - DevOps
   - SRE
-
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../../components'
@@ -15,6 +21,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../../compo
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Physical and environmental controls protect workspaces, travel, and unattended devices so theft,
+> tampering, and hostile environments cannot bypass digital OpSec.
 
 Physical security is a crucial component of operational security that is often overlooked in digital-focused
 organizations. This section covers controls to protect physical assets, secure workspaces, and address travel security

--- a/docs/pages/opsec/control-domains/physical-environmental/overview.mdx
+++ b/docs/pages/opsec/control-domains/physical-environmental/overview.mdx
@@ -8,7 +8,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/opsec/control-domains/physical-environmental/secure-workspace-travel.mdx
+++ b/docs/pages/opsec/control-domains/physical-environmental/secure-workspace-travel.mdx
@@ -34,10 +34,14 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [Physical & Environmental overview](/opsec/control-domains/physical-environmental/overview): the physical domain this
+  belongs to
+- [Travel overview](/opsec/travel/overview): the detailed travel guidance
+- [Physical Security](/physical-security/overview): coercion, facility and surveillance risk
+- [Tamper Evidence](/opsec/control-domains/physical-environmental/tamper-evidence): detecting interference with devices
+  left behind
 
 ---
 

--- a/docs/pages/opsec/control-domains/physical-environmental/secure-workspace-travel.mdx
+++ b/docs/pages/opsec/control-domains/physical-environmental/secure-workspace-travel.mdx
@@ -34,6 +34,11 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/control-domains/physical-environmental/secure-workspace-travel.mdx
+++ b/docs/pages/opsec/control-domains/physical-environmental/secure-workspace-travel.mdx
@@ -8,7 +8,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/opsec/control-domains/physical-environmental/secure-workspace-travel.mdx
+++ b/docs/pages/opsec/control-domains/physical-environmental/secure-workspace-travel.mdx
@@ -1,1 +1,39 @@
+---
+title: "Secure Workspace & Travel | Security Alliance"
+description: "Stub: secure offices and travel with access control, clean-desk habits, device safeguards, and destination risk assessment for field operators."
+tags:
+  - Security Specialist
+  - Operations & Strategy
+  - DevOps
+  - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
+---
+
+import { TagList, AttributionList, ContributeFooter } from '../../../../../components'
+
 # Secure workspace & travel security
+
+<TagList tags={frontmatter.tags} />
+<AttributionList contributors={frontmatter.contributors} />
+
+> ⚠️ Stub/in progress, help contribute/expand.
+
+{/* stub-kt-sep */}
+
+> 🔑 **Key Takeaway**: Secure workspace and travel practices protect devices and conversations away from controlled
+> environments—through access control, habits, and trip preparation.
+
+This page is a placeholder in the Operational Security framework. Planned content will expand the topic above using
+existing SEAL guidance patterns.
+
+Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
+
+---
+
+<ContributeFooter />

--- a/docs/pages/opsec/control-domains/physical-environmental/tamper-evidence.mdx
+++ b/docs/pages/opsec/control-domains/physical-environmental/tamper-evidence.mdx
@@ -1,1 +1,39 @@
+---
+title: "Tamper-Evidence & Evil-Maid | SEAL"
+description: "Stub: detect evil-maid device tampering with seals, integrity checks, secure storage, chain-of-custody rules, and clear incident response procedures."
+tags:
+  - Security Specialist
+  - Operations & Strategy
+  - DevOps
+  - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
+---
+
+import { TagList, AttributionList, ContributeFooter } from '../../../../../components'
+
 # Tamper-evidence & "evil-maid"
+
+<TagList tags={frontmatter.tags} />
+<AttributionList contributors={frontmatter.contributors} />
+
+> ⚠️ Stub/in progress, help contribute/expand.
+
+{/* stub-kt-sep */}
+
+> 🔑 **Key Takeaway**: Tamper-evidence and evil-maid defenses make unattended device interference visible and provide a
+> clear response when integrity can no longer be trusted.
+
+This page is a placeholder in the Operational Security framework. Planned content will expand the topic above using
+existing SEAL guidance patterns.
+
+Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
+
+---
+
+<ContributeFooter />

--- a/docs/pages/opsec/control-domains/physical-environmental/tamper-evidence.mdx
+++ b/docs/pages/opsec/control-domains/physical-environmental/tamper-evidence.mdx
@@ -34,6 +34,11 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/control-domains/physical-environmental/tamper-evidence.mdx
+++ b/docs/pages/opsec/control-domains/physical-environmental/tamper-evidence.mdx
@@ -34,10 +34,15 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [Physical & Environmental overview](/opsec/control-domains/physical-environmental/overview): the physical domain this
+  belongs to
+- [Supply Chain Physical Integrity](/physical-security/supply-chain-physical-integrity/overview): hardware provenance
+  and interdiction
+- [Seed Phrase Management](/wallet-security/seed-phrase-management): tamper-evident storage for key material
+- [Secure Workspace and Travel](/opsec/control-domains/physical-environmental/secure-workspace-travel): where devices
+  are most exposed
 
 ---
 

--- a/docs/pages/opsec/control-domains/physical-environmental/tamper-evidence.mdx
+++ b/docs/pages/opsec/control-domains/physical-environmental/tamper-evidence.mdx
@@ -8,7 +8,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/opsec/control-domains/technical/cryptocurrency-controls.mdx
+++ b/docs/pages/opsec/control-domains/technical/cryptocurrency-controls.mdx
@@ -34,6 +34,11 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/control-domains/technical/cryptocurrency-controls.mdx
+++ b/docs/pages/opsec/control-domains/technical/cryptocurrency-controls.mdx
@@ -1,1 +1,39 @@
+---
+title: "Cryptocurrency-Specific Controls | SEAL"
+description: "Stub: cryptocurrency OpSec controls covering cold storage, multisig, key ceremonies, and operational safeguards around digital asset movement."
+tags:
+  - Security Specialist
+  - Operations & Strategy
+  - DevOps
+  - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
+---
+
+import { TagList, AttributionList, ContributeFooter } from '../../../../../components'
+
 # Cryptocurrency-specific controls
+
+<TagList tags={frontmatter.tags} />
+<AttributionList contributors={frontmatter.contributors} />
+
+> ⚠️ Stub/in progress, help contribute/expand.
+
+{/* stub-kt-sep */}
+
+> 🔑 **Key Takeaway**: Cryptocurrency-specific controls cover custody, signing, and transfer workflows so digital
+> assets are not protected only by generic IT security patterns.
+
+This page is a placeholder in the Operational Security framework. Planned content will expand the topic above using
+existing SEAL guidance patterns.
+
+Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
+
+---
+
+<ContributeFooter />

--- a/docs/pages/opsec/control-domains/technical/cryptocurrency-controls.mdx
+++ b/docs/pages/opsec/control-domains/technical/cryptocurrency-controls.mdx
@@ -8,7 +8,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/opsec/control-domains/technical/cryptocurrency-controls.mdx
+++ b/docs/pages/opsec/control-domains/technical/cryptocurrency-controls.mdx
@@ -34,10 +34,12 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [Technical Controls overview](/opsec/control-domains/technical/overview): the technical domain this belongs to
+- [Wallet Security](/wallet-security/overview): custody design and signing practice
+- [Secure Multisig Best Practices](/wallet-security/secure-multisig-best-practices): distributing signing authority
+- [Treasury Operations](/treasury-operations/overview): organizational controls around funds
 
 ---
 

--- a/docs/pages/opsec/control-domains/technical/device-hardening.mdx
+++ b/docs/pages/opsec/control-domains/technical/device-hardening.mdx
@@ -1,1 +1,39 @@
+---
+title: "Device Hardening | Security Alliance"
+description: "Stub: harden operator devices with secure configuration baselines, endpoint protection, patching, least local privilege, and host firewall rules."
+tags:
+  - Security Specialist
+  - Operations & Strategy
+  - DevOps
+  - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
+---
+
+import { TagList, AttributionList, ContributeFooter } from '../../../../../components'
+
 # Device hardening
+
+<TagList tags={frontmatter.tags} />
+<AttributionList contributors={frontmatter.contributors} />
+
+> ⚠️ Stub/in progress, help contribute/expand.
+
+{/* stub-kt-sep */}
+
+> 🔑 **Key Takeaway**: Device hardening shrinks endpoint attack surface through secure baselines, prompt patching,
+> endpoint protection, and removing unnecessary local privilege.
+
+This page is a placeholder in the Operational Security framework. Planned content will expand the topic above using
+existing SEAL guidance patterns.
+
+Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
+
+---
+
+<ContributeFooter />

--- a/docs/pages/opsec/control-domains/technical/device-hardening.mdx
+++ b/docs/pages/opsec/control-domains/technical/device-hardening.mdx
@@ -34,10 +34,12 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [Technical Controls overview](/opsec/control-domains/technical/overview): the technical domain this belongs to
+- [Endpoint Security](/opsec/endpoint/overview): the endpoint posture this supports
+- [Secure Operating Systems](/opsec/secure-operating-systems): hardened OS options for high-risk roles
+- [Operating System Security](/infrastructure/operating-system-security): server-side counterpart
 
 ---
 

--- a/docs/pages/opsec/control-domains/technical/device-hardening.mdx
+++ b/docs/pages/opsec/control-domains/technical/device-hardening.mdx
@@ -34,6 +34,11 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/control-domains/technical/device-hardening.mdx
+++ b/docs/pages/opsec/control-domains/technical/device-hardening.mdx
@@ -8,7 +8,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/opsec/control-domains/technical/encrypted-storage-backups.mdx
+++ b/docs/pages/opsec/control-domains/technical/encrypted-storage-backups.mdx
@@ -34,6 +34,11 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/control-domains/technical/encrypted-storage-backups.mdx
+++ b/docs/pages/opsec/control-domains/technical/encrypted-storage-backups.mdx
@@ -34,10 +34,12 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [Technical Controls overview](/opsec/control-domains/technical/overview): the technical domain this belongs to
+- [Full Disk Encryption](/encryption/full-disk-encryption): the mechanics of encryption at rest
+- [Seed Phrase Management](/wallet-security/seed-phrase-management): the most sensitive material to back up
+- [Data Security Checklist](/devsecops/data-security-upgrade-checklist): backup and recovery testing
 
 ---
 

--- a/docs/pages/opsec/control-domains/technical/encrypted-storage-backups.mdx
+++ b/docs/pages/opsec/control-domains/technical/encrypted-storage-backups.mdx
@@ -8,7 +8,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/opsec/control-domains/technical/encrypted-storage-backups.mdx
+++ b/docs/pages/opsec/control-domains/technical/encrypted-storage-backups.mdx
@@ -1,1 +1,39 @@
+---
+title: "Encrypted Storage & Backups | SEAL"
+description: "Stub: encrypt sensitive storage and backups, protect keys separately, and test recovery so ransomware or loss does not end critical operations."
+tags:
+  - Security Specialist
+  - Operations & Strategy
+  - DevOps
+  - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
+---
+
+import { TagList, AttributionList, ContributeFooter } from '../../../../../components'
+
 # Encrypted storage & backups
+
+<TagList tags={frontmatter.tags} />
+<AttributionList contributors={frontmatter.contributors} />
+
+> ⚠️ Stub/in progress, help contribute/expand.
+
+{/* stub-kt-sep */}
+
+> 🔑 **Key Takeaway**: Encrypted storage and backups protect data at rest only when keys are separated, access is
+> controlled, and restores are tested before you need them.
+
+This page is a placeholder in the Operational Security framework. Planned content will expand the topic above using
+existing SEAL guidance patterns.
+
+Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
+
+---
+
+<ContributeFooter />

--- a/docs/pages/opsec/control-domains/technical/network-communication-security.mdx
+++ b/docs/pages/opsec/control-domains/technical/network-communication-security.mdx
@@ -1,1 +1,39 @@
+---
+title: "Network & Communication Security | SEAL"
+description: "Stub: secure networks and communications with encryption in transit, safer messaging choices, and controlled remote-access patterns for operators."
+tags:
+  - Security Specialist
+  - Operations & Strategy
+  - DevOps
+  - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
+---
+
+import { TagList, AttributionList, ContributeFooter } from '../../../../../components'
+
 # Network & communication security
+
+<TagList tags={frontmatter.tags} />
+<AttributionList contributors={frontmatter.contributors} />
+
+> ⚠️ Stub/in progress, help contribute/expand.
+
+{/* stub-kt-sep */}
+
+> 🔑 **Key Takeaway**: Network and communication security protects data in motion and coordination channels so
+> interception, spoofing, and unsafe remote access are harder.
+
+This page is a placeholder in the Operational Security framework. Planned content will expand the topic above using
+existing SEAL guidance patterns.
+
+Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
+
+---
+
+<ContributeFooter />

--- a/docs/pages/opsec/control-domains/technical/network-communication-security.mdx
+++ b/docs/pages/opsec/control-domains/technical/network-communication-security.mdx
@@ -34,10 +34,12 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [Technical Controls overview](/opsec/control-domains/technical/overview): the technical domain this belongs to
+- [VPN Services](/privacy/vpns/overview): when a tunnel helps and when it does not
+- [Network Security](/infrastructure/network-security): infrastructure-side controls
+- [Communication Encryption](/encryption/communication-encryption): protecting message content
 
 ---
 

--- a/docs/pages/opsec/control-domains/technical/network-communication-security.mdx
+++ b/docs/pages/opsec/control-domains/technical/network-communication-security.mdx
@@ -34,6 +34,11 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/control-domains/technical/network-communication-security.mdx
+++ b/docs/pages/opsec/control-domains/technical/network-communication-security.mdx
@@ -8,7 +8,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/opsec/control-domains/technical/overview.mdx
+++ b/docs/pages/opsec/control-domains/technical/overview.mdx
@@ -185,10 +185,13 @@ Effective technical and digital controls provide a strong foundation for operati
 comprehensive device, network, data, and authentication protections, organizations can significantly reduce their attack
 surface and better protect their digital assets.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [Control Domains overview](/opsec/control-domains/overview): how the four control domains fit together
+- [Device Hardening](/opsec/control-domains/technical/device-hardening): securing the endpoints
+- [Network and Communication Security](/opsec/control-domains/technical/network-communication-security): protecting
+  traffic and channels
+- [Encrypted Storage and Backups](/opsec/control-domains/technical/encrypted-storage-backups): protecting data at rest
 
 ---
 

--- a/docs/pages/opsec/control-domains/technical/overview.mdx
+++ b/docs/pages/opsec/control-domains/technical/overview.mdx
@@ -17,6 +17,13 @@ contributors:
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../../components'
 
+{/*
+  content-model-exception:
+  type: project-doc
+  reason: Nested OpSec overview; child map lives in parent IA / sidebar until section pages stabilize.
+  owner: maintainers
+*/}
+
 # Technical & Digital Controls
 
 <TagList tags={frontmatter.tags} />

--- a/docs/pages/opsec/control-domains/technical/overview.mdx
+++ b/docs/pages/opsec/control-domains/technical/overview.mdx
@@ -8,7 +8,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/opsec/control-domains/technical/overview.mdx
+++ b/docs/pages/opsec/control-domains/technical/overview.mdx
@@ -178,6 +178,11 @@ Effective technical and digital controls provide a strong foundation for operati
 comprehensive device, network, data, and authentication protections, organizations can significantly reduce their attack
 surface and better protect their digital assets.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/control-domains/technical/overview.mdx
+++ b/docs/pages/opsec/control-domains/technical/overview.mdx
@@ -1,11 +1,18 @@
 ---
 title: "Technical Security Controls | Security Alliance"
-description: "Technical controls: device hardening, network security, encrypted storage, MFA with hardware keys, cold storage, and multisig wallet security for Web3."
+description: "Technical OpSec controls: device hardening, network security, encrypted storage, hardware MFA, and cryptocurrency-specific custody patterns."
 tags:
   - Security Specialist
   - Operations & Strategy
   - DevOps
   - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../../components'
@@ -14,6 +21,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../../compo
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Technical controls harden devices, networks, storage, authentication, and crypto-asset handling
+> so digital attack paths are reduced and monitored.
 
 Technical controls form the backbone of operational security, protecting systems, networks, and data from digital
 threats. This section outlines key technical controls that should be implemented as part of a comprehensive security

--- a/docs/pages/opsec/control-domains/technical/two-factor-hardware-auth.mdx
+++ b/docs/pages/opsec/control-domains/technical/two-factor-hardware-auth.mdx
@@ -1,1 +1,39 @@
+---
+title: "Two-Factor & Hardware Auth | SEAL"
+description: "Stub: deploy phishing-resistant multi-factor authentication with hardware security keys for admins and high-value roles on critical systems."
+tags:
+  - Security Specialist
+  - Operations & Strategy
+  - DevOps
+  - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
+---
+
+import { TagList, AttributionList, ContributeFooter } from '../../../../../components'
+
 # Two-factor & hardware authentication
+
+<TagList tags={frontmatter.tags} />
+<AttributionList contributors={frontmatter.contributors} />
+
+> ⚠️ Stub/in progress, help contribute/expand.
+
+{/* stub-kt-sep */}
+
+> 🔑 **Key Takeaway**: Hardware-backed second factors raise the cost of account takeover for admins and high-value
+> roles far above SMS or easily phished one-time codes.
+
+This page is a placeholder in the Operational Security framework. Planned content will expand the topic above using
+existing SEAL guidance patterns.
+
+Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
+
+---
+
+<ContributeFooter />

--- a/docs/pages/opsec/control-domains/technical/two-factor-hardware-auth.mdx
+++ b/docs/pages/opsec/control-domains/technical/two-factor-hardware-auth.mdx
@@ -34,6 +34,11 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/control-domains/technical/two-factor-hardware-auth.mdx
+++ b/docs/pages/opsec/control-domains/technical/two-factor-hardware-auth.mdx
@@ -8,7 +8,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/opsec/control-domains/technical/two-factor-hardware-auth.mdx
+++ b/docs/pages/opsec/control-domains/technical/two-factor-hardware-auth.mdx
@@ -34,10 +34,12 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [Technical Controls overview](/opsec/control-domains/technical/overview): the technical domain this belongs to
+- [Multi-Factor Authentication](/opsec/mfa/overview): choosing and rolling out factors
+- [Hardware Security Keys](/guides/endpoint-security/hardware-security-keys): step-by-step key setup
+- [Secure Authentication](/iam/secure-authentication): authentication across the organization
 
 ---
 

--- a/docs/pages/opsec/core-concepts/implementation-process.mdx
+++ b/docs/pages/opsec/core-concepts/implementation-process.mdx
@@ -1,6 +1,6 @@
 ---
 title: "OpSec Implementation Process | SEAL"
-description: "Five-phase OpSec implementation: critical asset identification, practical threat analysis, actionable vulnerability assessment, contextual risk evaluation, and targeted control deployment."
+description: "Five-phase OpSec implementation: identify critical assets, analyze threats, assess vulnerabilities, evaluate risk in context, and deploy targeted controls."
 tags:
   - Security Specialist
   - Operations & Strategy
@@ -20,9 +20,8 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> 🔑 **Key Takeaway**: Operational security is implemented through a practical five-phase process: critical asset
-> identification, practical threat analysis, actionable vulnerability assessment, contextual risk evaluation, and
-> targeted control deployment.
+> 🔑 **Key Takeaway**: Implement OpSec through five phases: critical asset identification, practical threat analysis,
+> vulnerability assessment, contextual risk evaluation, and targeted control deployment.
 
 ## Relationship to Security Fundamentals
 

--- a/docs/pages/opsec/core-concepts/implementation-process.mdx
+++ b/docs/pages/opsec/core-concepts/implementation-process.mdx
@@ -163,6 +163,11 @@ Implement security controls that address prioritized risks while minimizing oper
    - Monitoring and alerting
    - Incident response when controls fail
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/core-concepts/implementation-process.mdx
+++ b/docs/pages/opsec/core-concepts/implementation-process.mdx
@@ -163,10 +163,12 @@ Implement security controls that address prioritized risks while minimizing oper
    - Monitoring and alerting
    - Incident response when controls fail
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [OpSec overview](/opsec/overview): how the pages of this framework fit together
+- [Five Steps](/opsec/principles/five-steps): the OPSEC process in short form
+- [Security Fundamentals](/opsec/core-concepts/security-fundamentals): the concepts this process applies
+- [Control Domains overview](/opsec/control-domains/overview): how the four control domains fit together
 
 ---
 

--- a/docs/pages/opsec/core-concepts/security-fundamentals.mdx
+++ b/docs/pages/opsec/core-concepts/security-fundamentals.mdx
@@ -214,10 +214,12 @@ Maintain ongoing awareness of your security posture through active monitoring, t
    - Disseminate actionable intelligence to appropriate teams
    - Use threat intelligence to drive security improvements
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [OpSec overview](/opsec/overview): how the pages of this framework fit together
+- [Principles](/opsec/principles/principles): the principles built on these fundamentals
+- [Implementation Process](/opsec/core-concepts/implementation-process): putting them into practice
+- [Web3 Considerations](/opsec/core-concepts/web3-considerations): what changes in Web3
 
 ---
 

--- a/docs/pages/opsec/core-concepts/security-fundamentals.mdx
+++ b/docs/pages/opsec/core-concepts/security-fundamentals.mdx
@@ -214,6 +214,11 @@ Maintain ongoing awareness of your security posture through active monitoring, t
    - Disseminate actionable intelligence to appropriate teams
    - Use threat intelligence to drive security improvements
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/core-concepts/security-fundamentals.mdx
+++ b/docs/pages/opsec/core-concepts/security-fundamentals.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Security Fundamentals | Security Alliance"
-description: "Five OpSec fundamentals: layered protection, minimal access scopes, information flow control, system isolation, and continuous visibility. Practical application examples for Web3 DeFi protocols."
+description: "Five OpSec fundamentals: layered protection, minimal access, information-flow control, system isolation, and continuous visibility—with Web3/DeFi examples."
 tags:
   - Security Specialist
   - Operations & Strategy
@@ -20,9 +20,8 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> 🔑 **Key Takeaway**: Effective security operations are built on five practical fundamentals: layered protective
-> measures, minimized access scopes, controlled information flows, system isolation, and continuous visibility — working
-> together to secure critical assets in dynamic environments.
+> 🔑 **Key Takeaway**: Effective security operations rest on five fundamentals: layered protection, minimized access
+> scopes, controlled information flows, system isolation, and continuous visibility.
 
 ## Relationship to Implementation Process
 

--- a/docs/pages/opsec/core-concepts/web3-considerations.mdx
+++ b/docs/pages/opsec/core-concepts/web3-considerations.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Web3 Security Considerations | Security Alliance"
-description: "Web3 OpSec: balance blockchain transparency with privacy, manage self-custody, secure decentralized operations, address smart contract immutability, and implement multi-signature transaction verification."
+description: "Web3 OpSec: balance chain transparency with privacy, manage self-custody, secure distributed ops, account for immutability, and strengthen multi-party controls."
 tags:
   - Security Specialist
   - Operations & Strategy
@@ -20,9 +20,8 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> 🔑 **Key Takeaway**: Web3 environments require specialized security approaches that balance blockchain transparency
-> with privacy, address immutability risks, manage self-custody responsibilities, secure decentralized operations,
-> mitigate smart contract vulnerabilities, and navigate community-driven security challenges.
+> 🔑 **Key Takeaway**: Web3 OpSec must balance transparency with privacy, self-custody duties, decentralized
+> operations, smart-contract immutability, and multi-party verification of high-impact actions.
 
 In addition to traditional OpSec principles, Web3 environments require consideration of unique challenges. Many
 organizations claim to be backed only by decentralized technologies, but they later realize that part of their process

--- a/docs/pages/opsec/core-concepts/web3-considerations.mdx
+++ b/docs/pages/opsec/core-concepts/web3-considerations.mdx
@@ -176,6 +176,11 @@ Managing security in open, community-driven projects.
    - Responsible disclosure policies and timelines
    - Public security incident post-mortems (with appropriate redactions)
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/core-concepts/web3-considerations.mdx
+++ b/docs/pages/opsec/core-concepts/web3-considerations.mdx
@@ -176,10 +176,13 @@ Managing security in open, community-driven projects.
    - Responsible disclosure policies and timelines
    - Public security incident post-mortems (with appropriate redactions)
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [OpSec overview](/opsec/overview): how the pages of this framework fit together
+- [Security Fundamentals](/opsec/core-concepts/security-fundamentals): the general concepts these extend
+- [Wallet Security](/wallet-security/overview): the custody problem at the centre of Web3 OpSec
+- [Cryptocurrency Controls](/opsec/control-domains/technical/cryptocurrency-controls): operational controls for on-chain
+  activity
 
 ---
 

--- a/docs/pages/opsec/endpoint/overview.mdx
+++ b/docs/pages/opsec/endpoint/overview.mdx
@@ -16,6 +16,13 @@ contributors:
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
 
+{/*
+  content-model-exception:
+  type: project-doc
+  reason: Nested OpSec overview; child map lives in parent IA / sidebar until section pages stabilize.
+  owner: maintainers
+*/}
+
 # Endpoint Security
 
 <TagList tags={frontmatter.tags} />

--- a/docs/pages/opsec/endpoint/overview.mdx
+++ b/docs/pages/opsec/endpoint/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Endpoint Security | Security Alliance"
-description: "Device provisioning tiers for Web3 organizations: managed devices with EDR/MDM, virtual desktops for global contractors, and enterprise browsers for minimum viable security."
+description: "Endpoint tiers for Web3 orgs: managed devices with EDR/MDM, VDI for contractors, and enterprise browsers as minimum viable security matched to role risk."
 tags:
   - Security Specialist
   - Operations & Strategy
@@ -9,6 +9,8 @@ contributors:
   - role: wrote
     users: [andrew-chang-gu, dickson]
   - role: reviewed
+    users: []
+  - role: fact-checked
     users: []
 ---
 
@@ -19,8 +21,8 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> **Key Takeaway:** Match device security investment to role risk. Managed hardware for privileged operators,
-> VDI for global contractors, enterprise browsers as minimum viable security for everyone else.
+> 🔑 **Key Takeaway**: Match device security investment to role risk: managed hardware for privileged operators, VDI
+> for global contractors, enterprise browsers as minimum viable security for everyone else.
 
 Unmanaged personal devices are a primary vector for credential theft and lateral movement in Web3 organizations.
 Infostealers, malicious browser extensions, and compromised development environments all start at the endpoint.
@@ -84,10 +86,12 @@ For general staff and short-term contractors, an enterprise browser provides a m
 Most Web3 organizations will use all three tiers simultaneously — the goal is to match investment to actual risk,
 not to force a single approach across all roles.
 
-## Further Reading
+## Further reading
 
 - [Hardening your organization](/dprk-it-workers/mitigating-dprk-it-workers#hardening-your-organization)
   — Access control policies for remote workers
 - [Browser Security](/opsec/browser/overview) — Browser-specific hardening
+
+---
 
 <ContributeFooter />

--- a/docs/pages/opsec/google/overview.mdx
+++ b/docs/pages/opsec/google/overview.mdx
@@ -35,8 +35,6 @@ import { TagList, AttributionList, Checklist, ContributeFooter } from '../../../
 most critical steps you can take to protect your personal and professional data. Below are simple yet effective measures
 to improve your Google account security.
 
----
-
 ## For Individuals
 
 These settings apply to your personal Google account. All team members and admins should configure these on their own accounts.
@@ -79,8 +77,6 @@ These settings apply to your personal Google account. All team members and admin
   - [ ]  **Birthday:** Consider making it private
 </Checklist>
 
----
-
 ### Extended Security Settings
 
 For a comprehensive security review, follow these steps from [Google Security](https://myaccount.google.com/security):
@@ -98,8 +94,6 @@ For a comprehensive security review, follow these steps from [Google Security](h
 > If using Google Authenticator as a 2FA app on your phone, disconnect it from the cloud, as backup codes are then stored
 > in the google cloud associated to email. Use it without an account and ensure backup codes are written down offline.
 
----
-
 ### Advanced Protection Program
 
 For those who are public figures or need heightened security, Google's **Advanced Protection Program** is worth
@@ -109,8 +103,6 @@ recovery more challenging.
 <Checklist id="advanced-protection">
 - [ ]  [Enroll in Advanced Protection Program](https://myaccount.google.com/advanced-protection/landing)
 </Checklist>
-
----
 
 ### Best Practices & Ongoing Maintenance
 
@@ -122,8 +114,6 @@ recovery more challenging.
 - [ ]  **Consider** using identity **monitoring** apps like [Push Security](https://pushsecurity.com).
 </Checklist>
 
----
-
 ## For Team Members
 
 These guidelines apply to team members who use Google Workspace but don't have administrative access.
@@ -134,8 +124,6 @@ Team members should:
 - Pay attention to any email or phone notifications from Google regarding unusual sign-ins or account changes
 - Regularly visit [Google's Security Checkup](https://myaccount.google.com/security-checkup) to identify potential
 issues and resolve them
-
----
 
 ## For Admins
 
@@ -214,8 +202,6 @@ These settings and practices apply to Google Workspace administrators with eleva
 - Enroll in the [Advanced Protection Program](https://landing.google.com/advancedprotection/) for high-risk users
 or your entire organization
 
----
-
 ### Notes
 
 #### [1] Security Alerts
@@ -228,10 +214,12 @@ indicate concerns.
 You can confirm user enrollment status at Directory > Users, under the **2-step verification enrollment** and
 **Advanced Protection Program enrollment** columns.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [OpSec overview](/opsec/overview): how the pages of this framework fit together
+- [Secure Authentication](/iam/secure-authentication): account and recovery design
+- [Multi-Factor Authentication](/opsec/mfa/overview): choosing factors for these accounts
+- [Account Management guides](/guides/account-management/overview): per-product hardening walkthroughs
 
 ---
 

--- a/docs/pages/opsec/google/overview.mdx
+++ b/docs/pages/opsec/google/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Google Workspace Security | Security Alliance"
-description: "Protect your Google account from SIM swaps: configure 2FA with hardware security keys, remove recovery phone numbers, audit OAuth applications, and enroll in Advanced Protection Program."
+description: "Harden Google accounts and Workspace: hardware-key 2FA, remove risky recovery phones, audit OAuth apps, and use Advanced Protection for high-risk users."
 tags:
   - Community & Marketing
   - Operations & Strategy
@@ -10,19 +10,19 @@ contributors:
     users: [mattaereal, zedt3ster, fredriksvantes, auditware]
   - role: reviewed
     users: [mattaereal]
+  - role: fact-checked
+    users: []
 ---
 
-import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../../components'
+import { TagList, AttributionList, Checklist, ContributeFooter } from '../../../../components'
 
 # Google Security
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-## Summary
-
-> 🔑 **Key Takeaway:** Enhance your Google account security by implementing robust 2FA, eliminating redundant recovery
-> options, and diligently overseeing third-party access.
+> 🔑 **Key Takeaway**: Harden Google security by enforcing strong 2FA, removing risky recovery options that enable
+> SIM-swap paths, and continuously auditing third-party and device access.
 
 **Google** provides a wide range of services—from email to file storage. Safeguarding your Google account is among the
 most critical steps you can take to protect your personal and professional data. Below are simple yet effective measures

--- a/docs/pages/opsec/google/overview.mdx
+++ b/docs/pages/opsec/google/overview.mdx
@@ -16,6 +16,13 @@ contributors:
 
 import { TagList, AttributionList, Checklist, ContributeFooter } from '../../../../components'
 
+{/*
+  content-model-exception:
+  type: project-doc
+  reason: Nested OpSec overview; child map lives in parent IA / sidebar until section pages stabilize.
+  owner: maintainers
+*/}
+
 # Google Security
 
 <TagList tags={frontmatter.tags} />

--- a/docs/pages/opsec/google/overview.mdx
+++ b/docs/pages/opsec/google/overview.mdx
@@ -221,6 +221,11 @@ indicate concerns.
 You can confirm user enrollment status at Directory > Users, under the **2-step verification enrollment** and
 **Advanced Protection Program enrollment** columns.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/improvement/post-mortem.mdx
+++ b/docs/pages/opsec/improvement/post-mortem.mdx
@@ -1,1 +1,39 @@
+---
+title: "Post-Mortem & Lessons Learned | SEAL"
+description: "Stub: run blameless post-mortems after incidents and near-misses to capture root causes, control gaps, and durable OpSec program improvements."
+tags:
+  - Security Specialist
+  - Operations & Strategy
+  - DevOps
+  - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
+---
+
+import { TagList, AttributionList, ContributeFooter } from '../../../../components'
+
 # Post-Mortem & Lessons Learned
+
+<TagList tags={frontmatter.tags} />
+<AttributionList contributors={frontmatter.contributors} />
+
+> ⚠️ Stub/in progress, help contribute/expand.
+
+{/* stub-kt-sep */}
+
+> 🔑 **Key Takeaway**: Post-mortems turn incidents and near-misses into durable improvements when teams analyze root
+> causes without blame and track remediation to completion.
+
+This page is a placeholder in the Operational Security framework. Planned content will expand the topic above using
+existing SEAL guidance patterns.
+
+Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
+
+---
+
+<ContributeFooter />

--- a/docs/pages/opsec/improvement/post-mortem.mdx
+++ b/docs/pages/opsec/improvement/post-mortem.mdx
@@ -34,6 +34,11 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/improvement/post-mortem.mdx
+++ b/docs/pages/opsec/improvement/post-mortem.mdx
@@ -8,7 +8,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/opsec/improvement/post-mortem.mdx
+++ b/docs/pages/opsec/improvement/post-mortem.mdx
@@ -34,10 +34,12 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [OpSec overview](/opsec/overview): how the pages of this framework fit together
+- [Lessons Learned](/incident-management/lessons-learned): the incident-side review process
+- [Security KPIs](/opsec/improvement/security-kpis): measuring whether changes worked
+- [Continuous Improvement Metrics](/opsec/continuous-improvement-metrics): the wider improvement loop
 
 ---
 

--- a/docs/pages/opsec/improvement/security-kpis.mdx
+++ b/docs/pages/opsec/improvement/security-kpis.mdx
@@ -1,1 +1,39 @@
+---
+title: "Security KPIs & Reporting | Security Alliance"
+description: "Stub: define and report security KPIs such as detection time, response time, recovery, coverage, and training compliance for OpSec programs."
+tags:
+  - Security Specialist
+  - Operations & Strategy
+  - DevOps
+  - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
+---
+
+import { TagList, AttributionList, ContributeFooter } from '../../../../components'
+
 # Security KPIs & Reporting
+
+<TagList tags={frontmatter.tags} />
+<AttributionList contributors={frontmatter.contributors} />
+
+> ⚠️ Stub/in progress, help contribute/expand.
+
+{/* stub-kt-sep */}
+
+> 🔑 **Key Takeaway**: Security KPIs make performance visible—measure detection, response, recovery, control coverage,
+> and training so leaders can fund the right improvements.
+
+This page is a placeholder in the Operational Security framework. Planned content will expand the topic above using
+existing SEAL guidance patterns.
+
+Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
+
+---
+
+<ContributeFooter />

--- a/docs/pages/opsec/improvement/security-kpis.mdx
+++ b/docs/pages/opsec/improvement/security-kpis.mdx
@@ -34,6 +34,11 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/improvement/security-kpis.mdx
+++ b/docs/pages/opsec/improvement/security-kpis.mdx
@@ -8,7 +8,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/opsec/improvement/security-kpis.mdx
+++ b/docs/pages/opsec/improvement/security-kpis.mdx
@@ -34,10 +34,12 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [OpSec overview](/opsec/overview): how the pages of this framework fit together
+- [Continuous Improvement Metrics](/opsec/continuous-improvement-metrics): how these metrics drive change
+- [Post-Mortem](/opsec/improvement/post-mortem): where many of these measures originate
+- [Security Metrics and KPIs](/governance/security-metrics-kpis): reporting to leadership
 
 ---
 

--- a/docs/pages/opsec/integration/devsecops.mdx
+++ b/docs/pages/opsec/integration/devsecops.mdx
@@ -34,10 +34,12 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [Integration overview](/opsec/integration/overview): how OpSec connects to the other frameworks
+- [DevSecOps](/devsecops/overview): the dedicated framework
+- [Technical Controls overview](/opsec/control-domains/technical/overview): the technical domain this belongs to
+- [Supply Chain](/supply-chain/overview): dependency and build integrity
 
 ---
 

--- a/docs/pages/opsec/integration/devsecops.mdx
+++ b/docs/pages/opsec/integration/devsecops.mdx
@@ -34,6 +34,11 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/integration/devsecops.mdx
+++ b/docs/pages/opsec/integration/devsecops.mdx
@@ -8,7 +8,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/opsec/integration/devsecops.mdx
+++ b/docs/pages/opsec/integration/devsecops.mdx
@@ -1,1 +1,39 @@
+---
+title: "DevSecOps Integration | Security Alliance"
+description: "Stub: integrate OpSec into DevSecOps pipelines, secure SDLC gates, infrastructure-as-code checks, and feedback loops for Web3 engineering teams."
+tags:
+  - Security Specialist
+  - Operations & Strategy
+  - DevOps
+  - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
+---
+
+import { TagList, AttributionList, ContributeFooter } from '../../../../components'
+
 # DevSecOps Integration
+
+<TagList tags={frontmatter.tags} />
+<AttributionList contributors={frontmatter.contributors} />
+
+> ⚠️ Stub/in progress, help contribute/expand.
+
+{/* stub-kt-sep */}
+
+> 🔑 **Key Takeaway**: DevSecOps integration embeds OpSec into development and delivery so security requirements,
+> tests, and feedback ship with code—not as an afterthought.
+
+This page is a placeholder in the Operational Security framework. Planned content will expand the topic above using
+existing SEAL guidance patterns.
+
+Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
+
+---
+
+<ContributeFooter />

--- a/docs/pages/opsec/integration/governance.mdx
+++ b/docs/pages/opsec/integration/governance.mdx
@@ -1,1 +1,39 @@
+---
+title: "Governance Alignment | Security Alliance"
+description: "Stub: connect OpSec posture to organizational governance, oversight, policy ownership, and compliance reporting for Web3 teams and DAO structures."
+tags:
+  - Security Specialist
+  - Operations & Strategy
+  - DevOps
+  - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
+---
+
+import { TagList, AttributionList, ContributeFooter } from '../../../../components'
+
 # Governance Alignment
+
+<TagList tags={frontmatter.tags} />
+<AttributionList contributors={frontmatter.contributors} />
+
+> ⚠️ Stub/in progress, help contribute/expand.
+
+{/* stub-kt-sep */}
+
+> 🔑 **Key Takeaway**: Governance alignment ties OpSec controls to owners, oversight, and policy so security decisions
+> stay accountable as organizations and DAOs evolve.
+
+This page is a placeholder in the Operational Security framework. Planned content will expand the topic above using
+existing SEAL guidance patterns.
+
+Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
+
+---
+
+<ContributeFooter />

--- a/docs/pages/opsec/integration/governance.mdx
+++ b/docs/pages/opsec/integration/governance.mdx
@@ -34,6 +34,11 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/integration/governance.mdx
+++ b/docs/pages/opsec/integration/governance.mdx
@@ -34,10 +34,13 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [Integration overview](/opsec/integration/overview): how OpSec connects to the other frameworks
+- [Governance](/governance/overview): the dedicated framework
+- [Policies](/opsec/appendices/policies): the documents governance approves
+- [Organizational Controls overview](/opsec/control-domains/organizational/overview): the organizational domain this
+  belongs to
 
 ---
 

--- a/docs/pages/opsec/integration/governance.mdx
+++ b/docs/pages/opsec/integration/governance.mdx
@@ -8,7 +8,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/opsec/integration/overview.mdx
+++ b/docs/pages/opsec/integration/overview.mdx
@@ -216,6 +216,11 @@ addresses all aspects of an organization's security needs. By mapping controls, 
 improvements across frameworks, organizations can develop a cohesive security posture that is greater than the sum of
 its parts.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/integration/overview.mdx
+++ b/docs/pages/opsec/integration/overview.mdx
@@ -28,7 +28,7 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 Operational security does not exist in isolation but interacts with and complements other security frameworks and
 practices. This section outlines how to integrate OpSec with other security domains and frameworks.
 
-## Section Outline
+## What this framework covers
 
 - [DevSecOps Alignment](/opsec/integration/devsecops) — embed OpSec practices into engineering and delivery pipelines.
 - [Governance Integration](/opsec/integration/governance) — connect OpSec posture with organizational oversight and

--- a/docs/pages/opsec/integration/overview.mdx
+++ b/docs/pages/opsec/integration/overview.mdx
@@ -216,10 +216,12 @@ addresses all aspects of an organization's security needs. By mapping controls, 
 improvements across frameworks, organizations can develop a cohesive security posture that is greater than the sum of
 its parts.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [OpSec overview](/opsec/overview): how the pages of this framework fit together
+- [DevSecOps integration](/opsec/integration/devsecops): OpSec in the delivery pipeline
+- [Governance integration](/opsec/integration/governance): OpSec under policy and oversight
+- [Privacy integration](/opsec/integration/privacy): OpSec alongside privacy practice
 
 ---
 

--- a/docs/pages/opsec/integration/overview.mdx
+++ b/docs/pages/opsec/integration/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "OpSec Integration | Security Alliance"
-description: "Integrate OpSec with DevSecOps, privacy frameworks, and governance. Map controls to ISO 27001, NIST, CIS Controls, OWASP, SOC 2, MITRE AADAPT, OWASP SCWE, EEA EthTrust, OWASP Smart Contract Top 10, and CCSS standards for unified Web3 security approach."
+description: "Integrate OpSec with DevSecOps, privacy, and governance; map controls to ISO 27001, NIST, CIS, OWASP, SOC 2, and common Web3 security standards."
 tags:
   - Security Specialist
   - Operations & Strategy
@@ -11,6 +11,8 @@ contributors:
     users: [mattaereal]
   - role: reviewed
     users: [scode2277]
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
@@ -19,6 +21,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: OpSec works best when mapped into DevSecOps, privacy, and governance so controls align with ISO,
+> NIST, CIS, OWASP, SOC 2, and Web3-specific standard frameworks.
 
 Operational security does not exist in isolation but interacts with and complements other security frameworks and
 practices. This section outlines how to integrate OpSec with other security domains and frameworks.

--- a/docs/pages/opsec/integration/privacy.mdx
+++ b/docs/pages/opsec/integration/privacy.mdx
@@ -1,1 +1,39 @@
+---
+title: "Privacy Framework Alignment | Security Alliance"
+description: "Stub: align OpSec controls with privacy requirements so data protection, secrecy needs, and security operations reinforce each other in practice."
+tags:
+  - Security Specialist
+  - Operations & Strategy
+  - DevOps
+  - SRE
+contributors:
+  - role: wrote
+    users: [mattaereal]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
+---
+
+import { TagList, AttributionList, ContributeFooter } from '../../../../components'
+
 # Privacy Framework Alignment
+
+<TagList tags={frontmatter.tags} />
+<AttributionList contributors={frontmatter.contributors} />
+
+> ⚠️ Stub/in progress, help contribute/expand.
+
+{/* stub-kt-sep */}
+
+> 🔑 **Key Takeaway**: Privacy and OpSec reinforce each other when data minimization, access control, and secrecy needs
+> are designed together rather than as competing checklists.
+
+This page is a placeholder in the Operational Security framework. Planned content will expand the topic above using
+existing SEAL guidance patterns.
+
+Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
+
+---
+
+<ContributeFooter />

--- a/docs/pages/opsec/integration/privacy.mdx
+++ b/docs/pages/opsec/integration/privacy.mdx
@@ -34,6 +34,11 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/integration/privacy.mdx
+++ b/docs/pages/opsec/integration/privacy.mdx
@@ -8,7 +8,7 @@ tags:
   - SRE
 contributors:
   - role: wrote
-    users: [mattaereal]
+    users: []
   - role: reviewed
     users: []
   - role: fact-checked

--- a/docs/pages/opsec/integration/privacy.mdx
+++ b/docs/pages/opsec/integration/privacy.mdx
@@ -34,10 +34,13 @@ existing SEAL guidance patterns.
 
 Contributions are welcome. See the [contributing guide](/contribute/contributing) to help expand this section.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [Integration overview](/opsec/integration/overview): how OpSec connects to the other frameworks
+- [Privacy](/privacy/overview): the dedicated framework
+- [Digital Footprint](/privacy/digital-footprint): reducing exposure that OpSec then defends
+- [Network and Communication Security](/opsec/control-domains/technical/network-communication-security): the shared
+  technical ground
 
 ---
 

--- a/docs/pages/opsec/mfa/overview.mdx
+++ b/docs/pages/opsec/mfa/overview.mdx
@@ -1,11 +1,16 @@
 ---
 title: "Multi-Factor Authentication | Security Alliance"
+description: "MFA for Web3 OpSec: prefer passkeys and hardware keys over SMS/email; use push or TOTP as interim steps and protect admin accounts with YubiKeys."
 tags:
   - Security Specialist
   - Operations & Strategy
 contributors:
   - role: wrote
     users: [shallem]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
@@ -14,6 +19,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: MFA is necessary but not sufficient—prefer passkeys and hardware keys over SMS or email, and
+> protect high-value logins and recovery paths as carefully as the second factor itself.
 
 MFA is necessary but not sufficient as an OpSec strategy. If you have not yet implemented MFA, we suggest making it
 your first priority as soon as you finish reading this page.
@@ -62,5 +70,7 @@ password manager with biometric authentication (e.g., Bitwarden, 1Password). Pas
 that uses phone or SMS as a recovery mechanism make overall security worse, not better. Before finalizing any decision
 to migrate to passkeys, please read the password management section and ensure that you are ready to store your
 passkeys securely.
+
+---
 
 <ContributeFooter />

--- a/docs/pages/opsec/mfa/overview.mdx
+++ b/docs/pages/opsec/mfa/overview.mdx
@@ -78,10 +78,13 @@ that uses phone or SMS as a recovery mechanism make overall security worse, not 
 to migrate to passkeys, please read the password management section and ensure that you are ready to store your
 passkeys securely.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [OpSec overview](/opsec/overview): how the pages of this framework fit together
+- [Two-Factor and Hardware Auth](/opsec/control-domains/technical/two-factor-hardware-auth): the control-domain
+  treatment
+- [Hardware Security Keys](/guides/endpoint-security/hardware-security-keys): step-by-step setup
+- [Secure Authentication](/iam/secure-authentication): organization-wide authentication design
 
 ---
 

--- a/docs/pages/opsec/mfa/overview.mdx
+++ b/docs/pages/opsec/mfa/overview.mdx
@@ -15,6 +15,13 @@ contributors:
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
 
+{/*
+  content-model-exception:
+  type: project-doc
+  reason: Nested OpSec overview; child map lives in parent IA / sidebar until section pages stabilize.
+  owner: maintainers
+*/}
+
 # Multi-Factor Authentication
 
 <TagList tags={frontmatter.tags} />

--- a/docs/pages/opsec/mfa/overview.mdx
+++ b/docs/pages/opsec/mfa/overview.mdx
@@ -71,6 +71,11 @@ that uses phone or SMS as a recovery mechanism make overall security worse, not 
 to migrate to passkeys, please read the password management section and ensure that you are ready to store your
 passkeys securely.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/old/cloud-third-party/g-suite-security.mdx
+++ b/docs/pages/opsec/old/cloud-third-party/g-suite-security.mdx
@@ -1,4 +1,5 @@
 ---
+description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/opsec/old/cloud-third-party/g-suite-security.mdx
+++ b/docs/pages/opsec/old/cloud-third-party/g-suite-security.mdx
@@ -106,6 +106,11 @@ settings.
 2. Use Google Workspace Admin Console to enforce security policies and ensure compliance with project and regulatory
 standards.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/old/cloud-third-party/g-suite-security.mdx
+++ b/docs/pages/opsec/old/cloud-third-party/g-suite-security.mdx
@@ -1,5 +1,6 @@
 ---
-description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
+title: "Google Workspace Security | SEAL"
+description: "Google Workspace Security: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/opsec/old/cloud-third-party/overview.mdx
+++ b/docs/pages/opsec/old/cloud-third-party/overview.mdx
@@ -1,5 +1,6 @@
 ---
-description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
+title: "Cloud and Third-Party Security | SEAL"
+description: "Cloud and Third-Party Security: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/cloud-third-party/overview.mdx
+++ b/docs/pages/opsec/old/cloud-third-party/overview.mdx
@@ -56,6 +56,11 @@ In Web3 environments, cloud and third-party security includes additional conside
 
 The guidance in this section addresses both traditional and Web3-specific cloud and third-party security considerations.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/old/cloud-third-party/overview.mdx
+++ b/docs/pages/opsec/old/cloud-third-party/overview.mdx
@@ -1,4 +1,5 @@
 ---
+description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/core-opsec-principles.mdx
+++ b/docs/pages/opsec/old/core-opsec-principles.mdx
@@ -181,6 +181,11 @@ custody solutions
 By adhering to these core principles, organizations can build a strong foundation for operational security that
 addresses both traditional and Web3-specific security challenges.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/old/core-opsec-principles.mdx
+++ b/docs/pages/opsec/old/core-opsec-principles.mdx
@@ -1,4 +1,5 @@
 ---
+description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/core-opsec-principles.mdx
+++ b/docs/pages/opsec/old/core-opsec-principles.mdx
@@ -1,5 +1,6 @@
 ---
-description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
+title: "Core OpSec Principles | SEAL"
+description: "Core OpSec Principles: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/data-protection/overview.mdx
+++ b/docs/pages/opsec/old/data-protection/overview.mdx
@@ -1,5 +1,6 @@
 ---
-description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
+title: "Data Protection | SEAL"
+description: "Data Protection: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/data-protection/overview.mdx
+++ b/docs/pages/opsec/old/data-protection/overview.mdx
@@ -1,4 +1,5 @@
 ---
+description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/data-protection/overview.mdx
+++ b/docs/pages/opsec/old/data-protection/overview.mdx
@@ -60,6 +60,11 @@ In Web3 environments, data protection includes additional considerations:
 The guidance in this section addresses both traditional and Web3-specific data protection considerations, helping
 organizations implement appropriate safeguards regardless of their technological environment.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/old/device-endpoint-security/overview.mdx
+++ b/docs/pages/opsec/old/device-endpoint-security/overview.mdx
@@ -1,4 +1,5 @@
 ---
+description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/device-endpoint-security/overview.mdx
+++ b/docs/pages/opsec/old/device-endpoint-security/overview.mdx
@@ -58,6 +58,11 @@ In Web3 environments, device and endpoint security includes additional considera
 
 The guidance in this section addresses both traditional and Web3-specific device and endpoint security considerations.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/old/device-endpoint-security/overview.mdx
+++ b/docs/pages/opsec/old/device-endpoint-security/overview.mdx
@@ -1,5 +1,6 @@
 ---
-description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
+title: "Device and Endpoint Security | SEAL"
+description: "Device and Endpoint Security: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/device-endpoint-security/standard-operating-environment.mdx
+++ b/docs/pages/opsec/old/device-endpoint-security/standard-operating-environment.mdx
@@ -1,4 +1,5 @@
 ---
+description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/opsec/old/device-endpoint-security/standard-operating-environment.mdx
+++ b/docs/pages/opsec/old/device-endpoint-security/standard-operating-environment.mdx
@@ -1,5 +1,6 @@
 ---
-description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
+title: "Standard Operating Environment | SEAL"
+description: "Standard Operating Environment: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Engineer/Developer
   - Security Specialist

--- a/docs/pages/opsec/old/device-endpoint-security/standard-operating-environment.mdx
+++ b/docs/pages/opsec/old/device-endpoint-security/standard-operating-environment.mdx
@@ -64,6 +64,11 @@ enforce segmentation.
 3. Secure wireless networks using WPA3 or WPA2 with AES encryption. Regularly update Wi-Fi passwords and manage access
 to authorized devices only.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/old/digital-identity-access/password-secrets-management.mdx
+++ b/docs/pages/opsec/old/digital-identity-access/password-secrets-management.mdx
@@ -1,5 +1,6 @@
 ---
-description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
+title: "Password/Secrets Management | SEAL"
+description: "Password/Secrets Management: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/digital-identity-access/password-secrets-management.mdx
+++ b/docs/pages/opsec/old/digital-identity-access/password-secrets-management.mdx
@@ -14,7 +14,7 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../../compo
 Effective management of passwords and cryptographic keys help maintain the security and integrity of digital assets and
 sensitive information.
 
-## Best Practices
+## Best practices
 
 1. Do not reuse passwords across services as it increases the risk of multiple accounts being compromised when one
 service is breached. Instead, use a password vault that can generate complex, random, and unique passwords for each

--- a/docs/pages/opsec/old/digital-identity-access/password-secrets-management.mdx
+++ b/docs/pages/opsec/old/digital-identity-access/password-secrets-management.mdx
@@ -1,4 +1,5 @@
 ---
+description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/digital-identity-access/password-secrets-management.mdx
+++ b/docs/pages/opsec/old/digital-identity-access/password-secrets-management.mdx
@@ -120,6 +120,11 @@ in mobile devices and some laptops.
 
 Employs facial characteristics for verification, increasingly popular in mobile and personal devices.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/old/digital-identity-access/sim-swapping.mdx
+++ b/docs/pages/opsec/old/digital-identity-access/sim-swapping.mdx
@@ -1,4 +1,5 @@
 ---
+description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/digital-identity-access/sim-swapping.mdx
+++ b/docs/pages/opsec/old/digital-identity-access/sim-swapping.mdx
@@ -1,5 +1,6 @@
 ---
-description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
+title: "SIM Swapping | SEAL"
+description: "SIM Swapping: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/digital-identity-access/sim-swapping.mdx
+++ b/docs/pages/opsec/old/digital-identity-access/sim-swapping.mdx
@@ -88,6 +88,11 @@ with a scammer will actually read the note. The scammer may also be able to conv
 in need to regain access quickly, and to ignore the note entirely. As such, placing a note on your account is a nice
 additional measure but not nearly as effective as simply disabling SMS 2FA on your accounts.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/old/governance-program-management.mdx
+++ b/docs/pages/opsec/old/governance-program-management.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Governance Program Management"
-description: "Establish OpSec governance: define security policies, assign roles and responsibilities, and manage third-party vendor security risks. Includes Web3-specific guidance..."
+title: "Governance Program Management | SEAL"
+description: "Establish OpSec governance: define security policies, assign roles and responsibilities, and manage third-party vendor security risks. Includes Web3-specific guidance."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/governance-program-management.mdx
+++ b/docs/pages/opsec/old/governance-program-management.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Governance Program Management"
-description: "Establish OpSec governance: define security policies, assign roles and responsibilities, and manage third-party vendor security risks. Includes Web3-specific guidance for DAOs and decentralized teams."
+description: "Establish OpSec governance: define security policies, assign roles and responsibilities, and manage third-party vendor security risks. Includes Web3-specific guidance..."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/governance-program-management.mdx
+++ b/docs/pages/opsec/old/governance-program-management.mdx
@@ -93,6 +93,11 @@ part-time contributors
 Effective governance and program management provide the structure needed to implement operational security measures
 consistently across your organization, adapting traditional approaches to the unique challenges of Web3 environments.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/old/human-centered-security/detecting-and-mitigating-insider-threats.mdx
+++ b/docs/pages/opsec/old/human-centered-security/detecting-and-mitigating-insider-threats.mdx
@@ -135,6 +135,11 @@ wallets.
 */} where team members understand the importance of protecting sensitive information and reporting suspicious
 activities.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/old/human-centered-security/detecting-and-mitigating-insider-threats.mdx
+++ b/docs/pages/opsec/old/human-centered-security/detecting-and-mitigating-insider-threats.mdx
@@ -1,5 +1,6 @@
 ---
-description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
+title: "Detecting and Mitigating Insider Threats | SEAL"
+description: "Detecting and Mitigating Insider Threats: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/human-centered-security/detecting-and-mitigating-insider-threats.mdx
+++ b/docs/pages/opsec/old/human-centered-security/detecting-and-mitigating-insider-threats.mdx
@@ -1,4 +1,5 @@
 ---
+description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/human-centered-security/overview.mdx
+++ b/docs/pages/opsec/old/human-centered-security/overview.mdx
@@ -1,5 +1,6 @@
 ---
-description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
+title: "Human-Centered Security | SEAL"
+description: "Human-Centered Security: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/human-centered-security/overview.mdx
+++ b/docs/pages/opsec/old/human-centered-security/overview.mdx
@@ -53,6 +53,11 @@ Not all human-centered security risks are equal. Organizations should adopt a ri
 Focusing on human factors in security, organizations can create a more resilient security posture that combines
 technical controls with human awareness and behavior.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/old/human-centered-security/overview.mdx
+++ b/docs/pages/opsec/old/human-centered-security/overview.mdx
@@ -1,4 +1,5 @@
 ---
+description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy
@@ -21,7 +22,7 @@ Human-centered security focuses on understanding, supporting, and enhancing the 
 an organization. It recognizes that security is a shared responsibility and that technical controls alone cannot
 provide comprehensive protection without considering the human factors involved.
 
-## Key Components
+## What this framework covers
 
 This section covers the following aspects of human-centered security:
 

--- a/docs/pages/opsec/old/human-centered-security/personal-opsec.mdx
+++ b/docs/pages/opsec/old/human-centered-security/personal-opsec.mdx
@@ -104,6 +104,11 @@ in Web3 where the boundaries between personal and professional digital presence 
 By implementing personal OpSec practices, team members can significantly reduce security risks that originate outside
 the workplace while maintaining a reasonable balance between security and quality of life.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/old/human-centered-security/personal-opsec.mdx
+++ b/docs/pages/opsec/old/human-centered-security/personal-opsec.mdx
@@ -1,5 +1,6 @@
 ---
-description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
+title: "Personal OpSec for Team Members | SEAL"
+description: "Personal OpSec for Team Members: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/human-centered-security/personal-opsec.mdx
+++ b/docs/pages/opsec/old/human-centered-security/personal-opsec.mdx
@@ -1,4 +1,5 @@
 ---
+description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy
@@ -95,7 +96,7 @@ in Web3 where the boundaries between personal and professional digital presence 
 3. Develop habits that incorporate security into daily routines
 4. Understand the trade-offs between convenience and security in personal life
 
-## Reporting and Support
+### Reporting and Support
 
 1. Know how to report suspicious activities that might target you personally due to your role
 2. Understand what organizational support is available for personal security incidents

--- a/docs/pages/opsec/old/human-centered-security/social-engineering-defense.mdx
+++ b/docs/pages/opsec/old/human-centered-security/social-engineering-defense.mdx
@@ -1,5 +1,6 @@
 ---
-description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
+title: "Social Engineering Defense | SEAL"
+description: "Social Engineering Defense: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/human-centered-security/social-engineering-defense.mdx
+++ b/docs/pages/opsec/old/human-centered-security/social-engineering-defense.mdx
@@ -1,4 +1,5 @@
 ---
+description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/human-centered-security/social-engineering-defense.mdx
+++ b/docs/pages/opsec/old/human-centered-security/social-engineering-defense.mdx
@@ -92,6 +92,11 @@ The goal of social engineering defense is not just to prevent specific attacks b
 Combining technical controls with human awareness and organizational procedures, teams can significantly reduce their
 vulnerability to social engineering attacks.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/old/human-centered-security/travel-security.mdx
+++ b/docs/pages/opsec/old/human-centered-security/travel-security.mdx
@@ -1,4 +1,5 @@
 ---
+description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/human-centered-security/travel-security.mdx
+++ b/docs/pages/opsec/old/human-centered-security/travel-security.mdx
@@ -101,6 +101,11 @@ travel
 By implementing comprehensive travel security measures, organizations can significantly reduce risks associated with
 business travel while enabling team members to work effectively and safely when away from their primary work location.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/old/human-centered-security/travel-security.mdx
+++ b/docs/pages/opsec/old/human-centered-security/travel-security.mdx
@@ -1,5 +1,6 @@
 ---
-description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
+title: "Travel Security | SEAL"
+description: "Travel Security: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/incident-response-recovery.mdx
+++ b/docs/pages/opsec/old/incident-response-recovery.mdx
@@ -180,6 +180,11 @@ Effective incident response requires preparation, practice, and continuous impro
 playbooks and procedures, organizations can respond quickly and effectively to security incidents, minimizing their
 impact and facilitating rapid recovery.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/old/incident-response-recovery.mdx
+++ b/docs/pages/opsec/old/incident-response-recovery.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Incident Response Recovery"
-description: "Respond to device loss, account compromise, malware infections, private key theft, and smart contract exploits. Playbooks for containment, eradication, recovery, and post-incident activities."
+description: "Respond to device loss, account compromise, malware infections, private key theft, and smart contract exploits. Playbooks for containment, eradication, recovery, and..."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/incident-response-recovery.mdx
+++ b/docs/pages/opsec/old/incident-response-recovery.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Incident Response Recovery"
-description: "Respond to device loss, account compromise, malware infections, private key theft, and smart contract exploits. Playbooks for containment, eradication, recovery, and..."
+title: "Incident Response Recovery | SEAL"
+description: "Respond to device loss, account compromise, malware infections, private key theft, and smart contract exploits. Playbooks for containment, eradication, recovery."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/lifecycle/overview.mdx
+++ b/docs/pages/opsec/old/lifecycle/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Lifecycle"
-description: "OpSec lifecycle: identify assets, model threats, assess vulnerabilities, prioritize risks, and implement countermeasures. Continuous improvement cycle for evolving threats in Web3 environments."
+description: "OpSec lifecycle: identify assets, model threats, assess vulnerabilities, prioritize risks, and implement countermeasures. Continuous improvement cycle for evolving..."
 tags:
   - Security Specialist
   - Operations & Strategy
@@ -31,7 +31,7 @@ The Operational Security Lifecycle consists of five interconnected phases:
 
 This lifecycle is not a one-time process but rather a continuous cycle of assessment, implementation, and improvement.
 
-## Section Outline
+## What this framework covers
 
 - [Identify Information & Assets](/opsec/old/lifecycle/identify) — map critical systems, data, and relationships.
 - [Threat Modeling & Analysis](/opsec/old/lifecycle/threat-modeling) — catalogue realistic adversaries
@@ -104,7 +104,7 @@ The final phase involves selecting and implementing security controls to address
 
 Effective countermeasure implementation transforms security planning into practical protection.
 
-## Continuous Improvement
+### Continuous Improvement
 
 The OpSec Lifecycle is not a linear process but a continuous cycle of improvement:
 
@@ -117,7 +117,7 @@ The OpSec Lifecycle is not a linear process but a continuous cycle of improvemen
 Through continuous improvement, organizations can maintain an effective security posture in the face of evolving
 threats.
 
-## Web3-Specific Considerations
+### Web3-Specific Considerations
 
 In Web3 environments, the OpSec Lifecycle must address unique considerations:
 

--- a/docs/pages/opsec/old/lifecycle/overview.mdx
+++ b/docs/pages/opsec/old/lifecycle/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Lifecycle"
-description: "OpSec lifecycle: identify assets, model threats, assess vulnerabilities, prioritize risks, and implement countermeasures. Continuous improvement cycle for evolving..."
+title: "Lifecycle | SEAL"
+description: "OpSec lifecycle: identify assets, model threats, assess vulnerabilities, prioritize risks, and implement countermeasures. Continuous improvement cycle for evolving."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/lifecycle/overview.mdx
+++ b/docs/pages/opsec/old/lifecycle/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Lifecycle | SEAL"
-description: "OpSec lifecycle: identify assets, model threats, assess vulnerabilities, prioritize risks, and implement countermeasures. Continuous improvement cycle for evolving."
+description: "OpSec lifecycle: identify assets, model threats, assess vulnerabilities, prioritize risks, and implement countermeasures as a continuous cycle."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/lifecycle/overview.mdx
+++ b/docs/pages/opsec/old/lifecycle/overview.mdx
@@ -130,6 +130,11 @@ In Web3 environments, the OpSec Lifecycle must address unique considerations:
 By adapting the OpSec Lifecycle to these considerations, Web3 organizations can develop security programs that address
 their unique risk profiles.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/old/monitoring-detection.mdx
+++ b/docs/pages/opsec/old/monitoring-detection.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Monitoring Detection"
-description: "Implement security monitoring: centralized logging, SIEM systems, alert thresholds, and threat detection. Web3-specific guidance for on-chain transaction monitoring..."
+title: "Monitoring Detection | SEAL"
+description: "Implement security monitoring: centralized logging, SIEM systems, alert thresholds, and threat detection. Web3-specific guidance for on-chain transaction monitoring."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/monitoring-detection.mdx
+++ b/docs/pages/opsec/old/monitoring-detection.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Monitoring Detection"
-description: "Implement security monitoring: centralized logging, SIEM systems, alert thresholds, and threat detection. Web3-specific guidance for on-chain transaction monitoring and smart contract events."
+description: "Implement security monitoring: centralized logging, SIEM systems, alert thresholds, and threat detection. Web3-specific guidance for on-chain transaction monitoring..."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/monitoring-detection.mdx
+++ b/docs/pages/opsec/old/monitoring-detection.mdx
@@ -147,6 +147,11 @@ impact of security incidents. By implementing comprehensive monitoring across bo
 environments, organizations can maintain visibility into their security posture and respond promptly to emerging
 threats.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/old/network-communication/overview.mdx
+++ b/docs/pages/opsec/old/network-communication/overview.mdx
@@ -1,4 +1,5 @@
 ---
+description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy
@@ -23,7 +24,7 @@ confidentiality, and availability of data as it travels across networks and comm
 interconnected world, organizations must address a wide range of threats that target communication channels, from
 traditional network attacks to sophisticated threats against encrypted communications.
 
-## Key Components
+## What this framework covers
 
 This section covers the following aspects of network and communication security:
 {/*TODO: link not found: */}

--- a/docs/pages/opsec/old/network-communication/overview.mdx
+++ b/docs/pages/opsec/old/network-communication/overview.mdx
@@ -61,6 +61,11 @@ In Web3 environments, network and communication security includes additional con
 The guidance in this section addresses both traditional and Web3-specific network and communication security
 considerations.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/old/network-communication/overview.mdx
+++ b/docs/pages/opsec/old/network-communication/overview.mdx
@@ -1,5 +1,6 @@
 ---
-description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
+title: "Network and Communication Security | SEAL"
+description: "Network and Communication Security: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/network-communication/telegram.mdx
+++ b/docs/pages/opsec/old/network-communication/telegram.mdx
@@ -57,39 +57,39 @@ potentially malicious groups.
 account.
   - Go to **Settings** > **Privacy and Security** > **Active Sessions** to review and manage your sessions.
 
-### 8. Avoid Clicking on Suspicious Links
+## 8. Avoid Clicking on Suspicious Links
 
 - **Beware of Phishing:** Do not click on suspicious links sent by unknown contacts. These could lead to phishing
 attempts or malware.
 
-### 9. Control Data Sharing
+## 9. Control Data Sharing
 
 - **Manage Contact Syncing:** Disable contact syncing if you want to prevent Telegram from accessing your contact list.
   - Go to **Settings** > **Privacy and Security** > **Data Settings** > **Contacts** and toggle off **Sync Contacts**.
 
-### 10. Be Cautious with Public Channels and Bots
+## 10. Be Cautious with Public Channels and Bots
 
 - **Join Public Channels Wisely:** Only join public channels and interact with bots from trusted sources, as they can
 collect your data.
 - **Review Bot Permissions:** Be cautious about giving bots access to your account information.
 
-### 11. Regularly Update the App
+## 11. Regularly Update the App
 
 - **Keep Telegram Updated:** Ensure you are using the latest version of Telegram to benefit from the latest security
 patches and features.
   - Check your app store regularly for updates or enable automatic updates.
 
-### 12. Avoid Using Third-Party Telegram Apps
+## 12. Avoid Using Third-Party Telegram Apps
 
 - **Use the Official App:** Stick to the official Telegram app for the best security and privacy protections.
   - Download from the official Telegram website or your device's official app store.
 
-### 13. Backup Your Two-Step Verification Password
+## 13. Backup Your Two-Step Verification Password
 
 - **Store Your Password Safely:** Ensure you store your two-step verification password in a secure password manager to
 avoid being locked out of your account.
 
-### 14. Disable Automatic Media Download
+## 14. Disable Automatic Media Download
 
 - **Control Media Download:** Disable or limit automatic media downloads to prevent unwanted files from being stored on
 your device.

--- a/docs/pages/opsec/old/network-communication/telegram.mdx
+++ b/docs/pages/opsec/old/network-communication/telegram.mdx
@@ -1,5 +1,6 @@
 ---
-description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
+title: "Telegram | SEAL"
+description: "Telegram: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/network-communication/telegram.mdx
+++ b/docs/pages/opsec/old/network-communication/telegram.mdx
@@ -1,4 +1,5 @@
 ---
+description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy
@@ -55,39 +56,39 @@ potentially malicious groups.
 account.
   - Go to **Settings** > **Privacy and Security** > **Active Sessions** to review and manage your sessions.
 
-## 8. Avoid Clicking on Suspicious Links
+### 8. Avoid Clicking on Suspicious Links
 
 - **Beware of Phishing:** Do not click on suspicious links sent by unknown contacts. These could lead to phishing
 attempts or malware.
 
-## 9. Control Data Sharing
+### 9. Control Data Sharing
 
 - **Manage Contact Syncing:** Disable contact syncing if you want to prevent Telegram from accessing your contact list.
   - Go to **Settings** > **Privacy and Security** > **Data Settings** > **Contacts** and toggle off **Sync Contacts**.
 
-## 10. Be Cautious with Public Channels and Bots
+### 10. Be Cautious with Public Channels and Bots
 
 - **Join Public Channels Wisely:** Only join public channels and interact with bots from trusted sources, as they can
 collect your data.
 - **Review Bot Permissions:** Be cautious about giving bots access to your account information.
 
-## 11. Regularly Update the App
+### 11. Regularly Update the App
 
 - **Keep Telegram Updated:** Ensure you are using the latest version of Telegram to benefit from the latest security
 patches and features.
   - Check your app store regularly for updates or enable automatic updates.
 
-## 12. Avoid Using Third-Party Telegram Apps
+### 12. Avoid Using Third-Party Telegram Apps
 
 - **Use the Official App:** Stick to the official Telegram app for the best security and privacy protections.
   - Download from the official Telegram website or your device's official app store.
 
-## 13. Backup Your Two-Step Verification Password
+### 13. Backup Your Two-Step Verification Password
 
 - **Store Your Password Safely:** Ensure you store your two-step verification password in a secure password manager to
 avoid being locked out of your account.
 
-## 14. Disable Automatic Media Download
+### 14. Disable Automatic Media Download
 
 - **Control Media Download:** Disable or limit automatic media downloads to prevent unwanted files from being stored on
 your device.

--- a/docs/pages/opsec/old/network-communication/telegram.mdx
+++ b/docs/pages/opsec/old/network-communication/telegram.mdx
@@ -93,6 +93,11 @@ avoid being locked out of your account.
 your device.
   - Go to **Settings** > **Data and Storage** > **Automatic Media Download** and adjust your preferences.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/old/network-communication/wireless-security.mdx
+++ b/docs/pages/opsec/old/network-communication/wireless-security.mdx
@@ -1,4 +1,5 @@
 ---
+description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/network-communication/wireless-security.mdx
+++ b/docs/pages/opsec/old/network-communication/wireless-security.mdx
@@ -1,5 +1,6 @@
 ---
-description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
+title: "Wireless Security | SEAL"
+description: "Wireless Security: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/network-communication/wireless-security.mdx
+++ b/docs/pages/opsec/old/network-communication/wireless-security.mdx
@@ -62,6 +62,11 @@ devices, TVs, and other types of non-work related devices that is on a restricte
 network.
 2. Restrict guest network access to the internet only. Implement bandwidth limits and usage policies to prevent abuse.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/old/overview.mdx
+++ b/docs/pages/opsec/old/overview.mdx
@@ -1,4 +1,5 @@
 ---
+description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy
@@ -24,8 +25,7 @@ robust OpSec measures can be severe, ranging from financial losses to reputation
 The level of Operational Security to apply will differ greatly depending on the risk appetite the team is willing to
 accept.
 
-## Framework Contents
-
+## Contents
 {/* TODO: check what to do with links: 1. [Core OpSec Principles](./core-opsec-principles.md) - Foundational security
 concepts and methodologies
 2. [Human-Centered Security](./human-centered-security/README.md) - Security measures focused on the human element

--- a/docs/pages/opsec/old/overview.mdx
+++ b/docs/pages/opsec/old/overview.mdx
@@ -45,6 +45,11 @@ governance
 11. [Web3-Specific OpSec](./web3-specific-opsec/README.md) - Operational security considerations unique to Web3
 12. [Resources and Tools](./resources-tools.md) - Useful tools, templates, and further reading */}
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/old/overview.mdx
+++ b/docs/pages/opsec/old/overview.mdx
@@ -1,5 +1,6 @@
 ---
-description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
+title: "Operational Security | SEAL"
+description: "Operational Security: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/physical-security/overview.mdx
+++ b/docs/pages/opsec/old/physical-security/overview.mdx
@@ -1,5 +1,6 @@
 ---
-description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
+title: "Physical Security | SEAL"
+description: "Physical Security: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/physical-security/overview.mdx
+++ b/docs/pages/opsec/old/physical-security/overview.mdx
@@ -15,7 +15,7 @@ Physical security is an often overlooked but crucial aspect of operational secur
 organizations involved in cryptocurrency. This section provides guidelines on how to protect yourself, your digital
 assets, and your organization from physical threats and attacks.
 
-## Best Practices
+## Best practices
 
 1. Random USB storage devices should not be plugged into your devices. Dropping malicious USB sticks and hoping for
 someone to pick them up and insert them into their computer is a

--- a/docs/pages/opsec/old/physical-security/overview.mdx
+++ b/docs/pages/opsec/old/physical-security/overview.mdx
@@ -88,6 +88,11 @@ appropriate fire detection and suppression systems.
 
 Maintain a list of emergency contacts, including law enforcement, cybersecurity experts, and team contacts.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/old/physical-security/overview.mdx
+++ b/docs/pages/opsec/old/physical-security/overview.mdx
@@ -1,4 +1,5 @@
 ---
+description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/risk-management-overview.mdx
+++ b/docs/pages/opsec/old/risk-management-overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Risk Management Overview"
+title: "Risk Management Overview | SEAL"
 description: "Prioritize security risks using NIST, ISO 31000, and FAIR frameworks. Assess impact, calculate likelihood, and develop mitigation strategies."
 tags:
   - Security Specialist

--- a/docs/pages/opsec/old/risk-management-overview.mdx
+++ b/docs/pages/opsec/old/risk-management-overview.mdx
@@ -161,7 +161,7 @@ first, focusing resources where they would have the greatest risk-reduction impa
 
 </details>
 
-## Further Reading & Tools
+## Further Reading
 
 - [NIST Risk Management Framework](https://csrc.nist.gov/projects/risk-management)
 - [ISO 31000:2018 Risk Management Guidelines](https://www.iso.org/standard/65694.html)

--- a/docs/pages/opsec/old/risk-management/overview.mdx
+++ b/docs/pages/opsec/old/risk-management/overview.mdx
@@ -30,7 +30,7 @@ Effective risk management builds upon threat modeling to assess, prioritize, and
 While threat modeling identifies what needs protection and potential attack vectors, risk management determines which
 threats warrant immediate attention and resources.
 
-## Section Outline
+## What this framework covers
 
 - [Risk Assessment & Prioritization](/opsec/old/risk-management/risk-assessment-prioritization) — convert threat
 intelligence into ranked action plans.

--- a/docs/pages/opsec/old/risk-management/overview.mdx
+++ b/docs/pages/opsec/old/risk-management/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Risk Management"
+title: "Risk Management | SEAL"
 description: "OpSec risk management: impact analysis, likelihood scoring, risk calculation, and trade-off analysis. Web3-specific risks for smart contracts and keys."
 tags:
   - Security Specialist

--- a/docs/pages/opsec/old/risk-management/overview.mdx
+++ b/docs/pages/opsec/old/risk-management/overview.mdx
@@ -172,7 +172,7 @@ first, focusing resources where they would have the greatest risk-reduction impa
 
 </details>
 
-## Further Reading & Tools
+## Further Reading
 
 - [NIST Risk Management Framework](https://csrc.nist.gov/projects/risk-management)
 - [ISO 31000:2018 Risk Management Guidelines](https://www.iso.org/standard/65694.html)

--- a/docs/pages/opsec/old/threat-modeling-overview.mdx
+++ b/docs/pages/opsec/old/threat-modeling-overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Threat Modeling Overview"
-description: "Build your security roadmap with threat modeling. Conduct asset inventory, adversary analysis, and attack vector mapping using STRIDE framework. Learn from ByBit, Ronin bridge, and Twitter breaches."
+description: "Build your security roadmap with threat modeling. Conduct asset inventory, adversary analysis, and attack vector mapping using STRIDE framework. Learn from ByBit..."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/threat-modeling-overview.mdx
+++ b/docs/pages/opsec/old/threat-modeling-overview.mdx
@@ -237,7 +237,7 @@ Goal: Steal crypto assets
     └── Mitigate: Hardware keys, non-SMS 2FA
 ```
 
-## Further Reading & Tools
+## Further Reading
 
 ### Frameworks & References
 

--- a/docs/pages/opsec/old/threat-modeling-overview.mdx
+++ b/docs/pages/opsec/old/threat-modeling-overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Threat Modeling Overview"
-description: "Build your security roadmap with threat modeling. Conduct asset inventory, adversary analysis, and attack vector mapping using STRIDE framework. Learn from ByBit..."
+title: "Threat Modeling Overview | SEAL"
+description: "Build your security roadmap with threat modeling. Conduct asset inventory, adversary analysis, and attack vector mapping using STRIDE framework."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/web3-specific-opsec/overview.mdx
+++ b/docs/pages/opsec/old/web3-specific-opsec/overview.mdx
@@ -1,5 +1,6 @@
 ---
-description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
+title: "Web3-Specific Operational Security | SEAL"
+description: "Web3-Specific Operational Security: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/web3-specific-opsec/overview.mdx
+++ b/docs/pages/opsec/old/web3-specific-opsec/overview.mdx
@@ -1,4 +1,5 @@
 ---
+description: "This page: practical Web3 security guidance, controls, and references for operators and security teams. Review and apply with team context."
 tags:
   - Security Specialist
   - Operations & Strategy

--- a/docs/pages/opsec/old/web3-specific-opsec/overview.mdx
+++ b/docs/pages/opsec/old/web3-specific-opsec/overview.mdx
@@ -62,6 +62,11 @@ section highlights where Web3-specific controls should be integrated with:
 By combining Web3-specific security measures with traditional operational security practices, organizations can build a
 comprehensive security posture suitable for the decentralized ecosystem.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/overview.mdx
+++ b/docs/pages/opsec/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Operational Security | Security Alliance"
-description: "Operational Security Framework: Comprehensive OpSec for Web2 and Web3. Identify critical information, analyze threats, assess vulnerabilities, evaluate risks, and implement zero-trust countermeasures."
+description: "OpSec for Web2 and Web3 teams: identify critical information, analyze threats, assess vulnerabilities, evaluate risks, and apply protective countermeasures."
 tags:
   - Security Specialist
   - Operations & Strategy
@@ -22,39 +22,41 @@ import { TagList, AttributionList, ContributeFooter } from '../../../components'
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
+> 🔑 **Key Takeaway**: OpSec is a continuous cycle—identify critical information, analyze threats and vulnerabilities,
+> evaluate risk, and apply proportionate countermeasures across people, process, and technology.
+
 Operational Security (OpSec) is a systematic approach to identifying critical information, determining threats to that
 information, analyzing vulnerabilities, assessing risks, and implementing countermeasures to protect sensitive data and
 operations. This framework provides comprehensive guidance for implementing effective operational security practices in
 Web2 and Web3 environments.
 
-## Core Components
+## What this framework covers
 
-This framework is organized into several interconnected components:
-
-1. OpSec Core Concepts:
-   - [Security Fundamentals](/opsec/core-concepts/security-fundamentals) – Core principles that form the foundation of
-   effective operational security
-   - [Operational Implementation Process](/opsec/core-concepts/implementation-process) – Step-by-step actions for
-   applying operational security in practice
-   - [Web3 Considerations](/opsec/core-concepts/web3-considerations) – Unique challenges and security practices for
-   decentralized environments
-2. [Endpoint Security](/opsec/endpoint/overview): Securing Workstations
-3. [Browser Security](/opsec/browser/overview): Browsing Safely
-4. [Multi-Factor Authentication](/opsec/mfa/overview): Hardening Authentication
-5. [Password Management](/opsec/passwords/overview): Password Robustness
-6. [Google Workspace Security](/opsec/google/overview): Google Workspace Hardening
-7. [Control Domains Overview](/opsec/control-domains/overview): Key areas requiring specific security controls and
-practices
-8. [Continuous Improvement Overview](/opsec/continuous-improvement-metrics): Learning from incidents and evolving
-security practices
-9. [Integration & Mapping to Other Frameworks](/opsec/integration): Integrate OpSec with other security domains and frameworks
-
-## Additional contents
-
-- [While Traveling](/opsec/travel/overview)
-  - [TL;DR](/opsec/travel/tldr)
-  - [Guide](/opsec/travel/guide)
-- [Appendices](/opsec/appendices)
+1. **OpSec Core Concepts**
+   - [Security Fundamentals](/opsec/core-concepts/security-fundamentals) — Core principles that form the foundation of
+     effective operational security
+   - [Implementation Process](/opsec/core-concepts/implementation-process) — Step-by-step actions for applying operational
+     security in practice
+   - [Web3 Considerations](/opsec/core-concepts/web3-considerations) — Unique challenges and practices for decentralized
+     environments
+2. [Secure Operating Systems](/opsec/secure-operating-systems) — Compartmentalized OS choices for high-risk workflows
+3. [Endpoint Security](/opsec/endpoint/overview) — Device provisioning tiers matched to role risk
+4. [Browser Security](/opsec/browser/overview) — Safer browsing patterns for operators
+5. [Multi-Factor Authentication](/opsec/mfa/overview) — Stronger authentication factors and recovery hygiene
+6. **Password Management**
+   - [Overview](/opsec/passwords/overview) — Password and passphrase fundamentals
+   - [Password Managers](/opsec/passwords/managers) — Enterprise managers and secret storage
+   - [Single Sign-on](/opsec/passwords/sso) — Federated authentication via a hardened IdP
+   - [Root Accounts](/opsec/passwords/rootaccounts) — Cold admin and break-glass credentials
+7. [Google Workspace Security](/opsec/google/overview) — Account and Workspace hardening checklists
+8. [Control Domains](/opsec/control-domains/overview) — Organizational, people, physical, and technical control areas
+9. [Continuous Improvement & Metrics](/opsec/continuous-improvement-metrics) — KPIs, post-mortems, and culture
+10. [Integration & Mapping to Other Frameworks](/opsec/integration/overview) — DevSecOps, privacy, governance, and standards
+11. **While Traveling**
+    - [Overview](/opsec/travel/overview) — Travel risk framing
+    - [Guide](/opsec/travel/guide) — Full pre-trip, on-trip, and return guidance
+    - [TL;DR](/opsec/travel/tldr) — Concise travel checklist
+12. [Appendices](/opsec/appendices/overview) — Policies, case studies, exercises, and glossary
 
 ## Related Frameworks
 

--- a/docs/pages/opsec/overview.mdx
+++ b/docs/pages/opsec/overview.mdx
@@ -58,7 +58,7 @@ Web2 and Web3 environments.
     - [TL;DR](/opsec/travel/tldr) — Concise travel checklist
 12. [Appendices](/opsec/appendices/overview) — Policies, case studies, exercises, and glossary
 
-## Related Frameworks
+## Related frameworks
 
 - [Physical Security](/physical-security/overview) — Protects people and physical assets from coercion, theft,
 surveillance, and tampering. Where OpSec guidance touches physical threats (duress codes, border coercion, device

--- a/docs/pages/opsec/passwords/managers.mdx
+++ b/docs/pages/opsec/passwords/managers.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Enterprise Password Managers | Security Alliance"
-description: "Configure password managers (Bitwarden, etc.) for secure storage, autofill, and sharing. Includes self-hosting, TOTP, zero-trust, emergency recovery."
+description: "Enterprise password managers: client-side encryption, generation, varied secret types, secure sharing, recovery, biometric lock, and anti-theft controls."
 tags:
   - Security Specialist
   - Operations & Strategy
 contributors:
   - role: wrote
     users: [shallem]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, TagProvider, TagFilter, ContributeFooter } from '../../../../components'
@@ -18,6 +22,9 @@ import { TagList, AttributionList, TagProvider, TagFilter, ContributeFooter } fr
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Choose password managers with client-side encryption, strong recovery, secure sharing for
+> necessary admin secrets, and controls that blunt master-password theft.
 
 ## What are they?
 
@@ -115,4 +122,7 @@ enterprise password manager. Ensure that your master password is either somethin
 backed up offline in a secure location.
 
 </TagProvider>
+
+---
+
 <ContributeFooter />

--- a/docs/pages/opsec/passwords/managers.mdx
+++ b/docs/pages/opsec/passwords/managers.mdx
@@ -123,6 +123,11 @@ backed up offline in a secure location.
 
 </TagProvider>
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/passwords/managers.mdx
+++ b/docs/pages/opsec/passwords/managers.mdx
@@ -13,10 +13,7 @@ contributors:
     users: []
 ---
 
-import { TagList, AttributionList, TagProvider, TagFilter, ContributeFooter } from '../../../../components'
-
-<TagProvider>
-<TagFilter />
+import { TagList, AttributionList, ContributeFooter } from '../../../../components'
 
 # Enterprise Password Managers
 
@@ -121,12 +118,13 @@ understand how to securely administer master password recovery (if desired), the
 enterprise password manager. Ensure that your master password is either something that you will remember, or it is
 backed up offline in a secure location.
 
-</TagProvider>
+## Further reading
 
-
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [Passwords overview](/opsec/passwords/overview): how the credential pages fit together
+- [Password Manager Endpoint Hardening](/guides/endpoint-security/password-manager-endpoint-hardening): hardening the
+  client itself
+- [Multi-Factor Authentication](/opsec/mfa/overview): the second factor alongside the vault
+- [Single Sign-On](/opsec/passwords/sso): reducing the number of passwords to manage
 
 ---
 

--- a/docs/pages/opsec/passwords/overview.mdx
+++ b/docs/pages/opsec/passwords/overview.mdx
@@ -27,7 +27,7 @@ Password security is the first line of defense protecting access to data and too
 passwords should never be the only line of defense (see [MFA](/opsec/mfa/overview)), following best practices in setting
 and securing passwords is an essential measure to keep your organization safe.
 
-## First Principles
+## What this framework covers
 
 ### What is a strong password?
 

--- a/docs/pages/opsec/passwords/overview.mdx
+++ b/docs/pages/opsec/passwords/overview.mdx
@@ -69,6 +69,11 @@ on the dedicated [SSO](/opsec/passwords/sso) page.
 page, root account passwords are a special case for many online services (e.g., Vercel, AWS, etc.) that require special
 handling.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/passwords/overview.mdx
+++ b/docs/pages/opsec/passwords/overview.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Password Management | Security Alliance"
-description: "Implement strong password basics: length, complexity, uniqueness, generation to resist brute-force/dictionary attacks. Essential foundation."
+description: "Password basics for OpSec: long unique passphrases, one master secret, enterprise managers and SSO so teams avoid reuse and weak recovery paths."
 tags:
   - Security Specialist
   - Operations & Strategy
 contributors:
   - role: wrote
     users: [shallem]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
@@ -15,6 +19,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Use one strong memorable master secret, store the rest in an enterprise password manager, and
+> prefer SSO so people are not forced into password reuse.
 
 Password security is the first line of defense protecting access to data and tools that you rely on daily. While
 passwords should never be the only line of defense (see [MFA](/opsec/mfa/overview)), following best practices in setting
@@ -59,6 +66,9 @@ because that single password is used to unlock access to everything needed for w
 on the dedicated [SSO](/opsec/passwords/sso) page.
 
 3. **Root Account Passwords** - as described in the dedicated [Root Account Passwords](/opsec/passwords/rootaccounts)
-page, root account passwords are a special case for many online services (e.g., Vercel, AWS, etc.) that require special handling.
+page, root account passwords are a special case for many online services (e.g., Vercel, AWS, etc.) that require special
+handling.
+
+---
 
 <ContributeFooter />

--- a/docs/pages/opsec/passwords/overview.mdx
+++ b/docs/pages/opsec/passwords/overview.mdx
@@ -69,10 +69,12 @@ on the dedicated [SSO](/opsec/passwords/sso) page.
 page, root account passwords are a special case for many online services (e.g., Vercel, AWS, etc.) that require special
 handling.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [OpSec overview](/opsec/overview): how the pages of this framework fit together
+- [Password Managers](/opsec/passwords/managers): choosing and rolling out a manager
+- [Single Sign-On](/opsec/passwords/sso): centralizing authentication
+- [Root Accounts](/opsec/passwords/rootaccounts): protecting the highest-privilege credentials
 
 ---
 

--- a/docs/pages/opsec/passwords/rootaccounts.mdx
+++ b/docs/pages/opsec/passwords/rootaccounts.mdx
@@ -13,10 +13,7 @@ contributors:
     users: []
 ---
 
-import { TagList, AttributionList, TagProvider, TagFilter, ContributeFooter } from '../../../../components'
-
-<TagProvider>
-<TagFilter />
+import { TagList, AttributionList, ContributeFooter } from '../../../../components'
 
 # Root Account Passwords
 
@@ -67,12 +64,12 @@ with access to the root account password exiting your organization, it is essent
 the password is rotated. Periodic rotation also helps protect against any brute force attempts
 to compromise a root account.
 
-</TagProvider>
+## Further reading
 
-
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [Passwords overview](/opsec/passwords/overview): how the credential pages fit together
+- [Access Management](/iam/access-management): who holds privileged access and for how long
+- [Multi-Factor Authentication](/opsec/mfa/overview): the strongest factors belong here
+- [Single Sign-On](/opsec/passwords/sso): why root accounts usually stay outside SSO
 
 ---
 

--- a/docs/pages/opsec/passwords/rootaccounts.mdx
+++ b/docs/pages/opsec/passwords/rootaccounts.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Root Account Passwords | Security Alliance"
-description: "Secure root/admin accounts: password rotation and storage, cold accounts, password manager sharing, monitoring. Prevents escalation in Linux/AWS/cloud."
+description: "Secure root and admin accounts: keep them cold day-to-day, share via password manager with re-prompt, rotate on exit, and watch OAuth grants carefully."
 tags:
   - Security Specialist
   - Operations & Strategy
 contributors:
   - role: wrote
     users: [shallem]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, TagProvider, TagFilter, ContributeFooter } from '../../../../components'
@@ -18,6 +22,9 @@ import { TagList, AttributionList, TagProvider, TagFilter, ContributeFooter } fr
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Treat root accounts as cold break-glass identities: minimal daily use, shared only via a
+> password manager with re-prompt, and rotated when access should end.
 
 Root accounts refer to the accounts that are used to configure new services. For example,
 when you first register for Amazon AWS, you create a root account that is a super privileged
@@ -61,4 +68,7 @@ the password is rotated. Periodic rotation also helps protect against any brute 
 to compromise a root account.
 
 </TagProvider>
+
+---
+
 <ContributeFooter />

--- a/docs/pages/opsec/passwords/rootaccounts.mdx
+++ b/docs/pages/opsec/passwords/rootaccounts.mdx
@@ -69,6 +69,11 @@ to compromise a root account.
 
 </TagProvider>
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/passwords/sso.mdx
+++ b/docs/pages/opsec/passwords/sso.mdx
@@ -100,6 +100,11 @@ provider is the most secure option.
 
 </TagProvider>
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/passwords/sso.mdx
+++ b/docs/pages/opsec/passwords/sso.mdx
@@ -13,10 +13,7 @@ contributors:
     users: []
 ---
 
-import { TagList, AttributionList, TagProvider, TagFilter, ContributeFooter } from '../../../../components'
-
-<TagProvider>
-<TagFilter />
+import { TagList, AttributionList, ContributeFooter } from '../../../../components'
 
 # Single Sign-on (SSO)
 
@@ -98,12 +95,12 @@ control for permitted devices, and centralized session management. Given
 all of the security considerations, choosing SSO with a reputable identity
 provider is the most secure option.
 
-</TagProvider>
+## Further reading
 
-
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [Passwords overview](/opsec/passwords/overview): how the credential pages fit together
+- [Secure Authentication](/iam/secure-authentication): protocols and session design
+- [Access Management](/iam/access-management): provisioning and deprovisioning through SSO
+- [Password Managers](/opsec/passwords/managers): what still needs a vault
 
 ---
 

--- a/docs/pages/opsec/passwords/sso.mdx
+++ b/docs/pages/opsec/passwords/sso.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Single Sign-on | Security Alliance"
-description: "Use SSO (OAuth/SAML) for federated passwordless auth with Okta/Auth0/Google. Reduces secrets sprawl, enforces MFA, session controls, IdP hardening."
+description: "SSO for OpSec: federate sign-in through one hardened IdP to enforce MFA, cut sprawl, and centralize session and device controls across SaaS tools."
 tags:
   - Security Specialist
   - Operations & Strategy
 contributors:
   - role: wrote
     users: [shallem]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
 ---
 
 import { TagList, AttributionList, TagProvider, TagFilter, ContributeFooter } from '../../../../components'
@@ -18,6 +22,9 @@ import { TagList, AttributionList, TagProvider, TagFilter, ContributeFooter } fr
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: SSO is not password reuse—federate authentication through one hardened identity provider so MFA,
+> sessions, and recovery are centralized and consistent.
 
 Single Sign-on refers to the ability to sign in to all of the tools that
 you use to work with a single identity provider. The identity provider is
@@ -92,4 +99,7 @@ all of the security considerations, choosing SSO with a reputable identity
 provider is the most secure option.
 
 </TagProvider>
+
+---
+
 <ContributeFooter />

--- a/docs/pages/opsec/principles/five-steps.mdx
+++ b/docs/pages/opsec/principles/five-steps.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Five OpSec Steps | Security Alliance"
-description: "Five OpSec steps: identify critical information, analyze threats (external and insider), assess vulnerabilities, evaluate risks with impact and probability, and implement countermeasures."
+description: "Five OpSec steps: identify critical information, analyze external and insider threats, assess vulnerabilities, evaluate risk, and implement countermeasures."
 tags:
   - Security Specialist
   - Operations & Strategy
@@ -20,8 +20,8 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> 🔑 **Key Takeaway**: OpSec is built on five critical steps: identifying what needs protection, analyzing potential
-> threats, assessing vulnerabilities, evaluating risks, and implementing appropriate countermeasures.
+> 🔑 **Key Takeaway**: OpSec follows five steps: identify what needs protection, analyze threats, assess
+> vulnerabilities, evaluate risks, and implement appropriate countermeasures.
 
 If we were to summarize the most crucial and important steps of Operational Security, whether it is for an individual or
 an organization, we would do as follows. These are not step-by-steps, but can serve as a kick-off process to be further

--- a/docs/pages/opsec/principles/five-steps.mdx
+++ b/docs/pages/opsec/principles/five-steps.mdx
@@ -104,10 +104,12 @@ impact.
 4. Document procedures for maintaining and updating controls
 5. Train personnel on new security measures and their importance
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [Principles overview](/opsec/principles/overview): how the principles pages fit together
+- [Implementation Process](/opsec/core-concepts/implementation-process): the longer-form process
+- [Threat Modeling](/threat-modeling/overview): a structured method for steps 1 and 2
+- [Principles](/opsec/principles/principles): the reasoning behind each step
 
 ---
 

--- a/docs/pages/opsec/principles/five-steps.mdx
+++ b/docs/pages/opsec/principles/five-steps.mdx
@@ -104,6 +104,11 @@ impact.
 4. Document procedures for maintaining and updating controls
 5. Train personnel on new security measures and their importance
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/principles/overview.mdx
+++ b/docs/pages/opsec/principles/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "OpSec Principles & Concepts | Security Alliance"
-description: "OpSec principles: defense in depth, least privilege, need-to-know basis, compartmentalization, and continuous monitoring. Five-step process for identifying and protecting critical information assets."
+description: "OpSec principles overview: defense in depth, least privilege, need-to-know, compartmentalization, continuous monitoring, and the five-step OpSec process."
 tags:
   - Security Specialist
   - Operations & Strategy
@@ -21,6 +21,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: OpSec principles—defense in depth, least privilege, need-to-know, compartmentalization, and
+> continuous monitoring—guide the five-step process for protecting critical information.
 
 Operational Security (OpSec) is built upon foundational principles and processes that help organizations protect
 sensitive information and critical assets. This section covers the essential concepts that form the basis of an

--- a/docs/pages/opsec/principles/overview.mdx
+++ b/docs/pages/opsec/principles/overview.mdx
@@ -77,6 +77,11 @@ In Web3 environments, operational security must address unique challenges:
 - **Smart Contract Vulnerabilities**: Addressing the immutable nature of deployed code
 - **Community Dynamics**: Managing security in open, community-driven projects
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/principles/overview.mdx
+++ b/docs/pages/opsec/principles/overview.mdx
@@ -17,6 +17,13 @@ contributors:
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
 
+{/*
+  content-model-exception:
+  type: project-doc
+  reason: Nested OpSec overview; child map lives in parent IA / sidebar until section pages stabilize.
+  owner: maintainers
+*/}
+
 # Principles & Concepts Overview
 
 <TagList tags={frontmatter.tags} />

--- a/docs/pages/opsec/principles/overview.mdx
+++ b/docs/pages/opsec/principles/overview.mdx
@@ -84,10 +84,12 @@ In Web3 environments, operational security must address unique challenges:
 - **Smart Contract Vulnerabilities**: Addressing the immutable nature of deployed code
 - **Community Dynamics**: Managing security in open, community-driven projects
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [OpSec overview](/opsec/overview): how the pages of this framework fit together
+- [Principles](/opsec/principles/principles): the principles themselves
+- [Five Steps](/opsec/principles/five-steps): the process in short form
+- [Web3 Considerations](/opsec/principles/web3-considerations): what changes for Web3 operators
 
 ---
 

--- a/docs/pages/opsec/principles/principles.mdx
+++ b/docs/pages/opsec/principles/principles.mdx
@@ -127,6 +127,11 @@ about evolving security threats
 7. Utilize available [security resources](/awareness/resources-and-further-reading) to keep your security practices
 current
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/principles/principles.mdx
+++ b/docs/pages/opsec/principles/principles.mdx
@@ -1,6 +1,6 @@
 ---
 title: "OpSec Core Principles | Security Alliance"
-description: "Five core OpSec principles: defense in depth with layered security controls, least privilege access, need-to-know information sharing, compartmentalization, and continuous monitoring and improvement."
+description: "Five core OpSec principles: layered defense in depth, least privilege, need-to-know sharing, compartmentalization, and continuous monitoring and improvement."
 tags:
   - Security Specialist
   - Operations & Strategy
@@ -22,9 +22,8 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> 🔑 **Key Takeaway**: Effective OpSec relies on five core principles: layered defenses, minimal access rights,
-> need-to-know information sharing, system compartmentalization, and continuous monitoring—all working together to
-> protect sensitive information from adversaries.
+> 🔑 **Key Takeaway**: Effective OpSec relies on layered defenses, minimal access rights, need-to-know sharing,
+> compartmentalization, and continuous monitoring working together.
 
 The goal is to prevent adversaries from gaining access to information that could be harmful if disclosed or compromised.
 

--- a/docs/pages/opsec/principles/principles.mdx
+++ b/docs/pages/opsec/principles/principles.mdx
@@ -127,10 +127,12 @@ about evolving security threats
 7. Utilize available [security resources](/awareness/resources-and-further-reading) to keep your security practices
 current
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [Principles overview](/opsec/principles/overview): how the principles pages fit together
+- [Five Steps](/opsec/principles/five-steps): applying the principles as a process
+- [Security Fundamentals](/opsec/core-concepts/security-fundamentals): the underlying concepts
+- [Zero Trust Principles](/infrastructure/zero-trust-principles): verify-before-trust in infrastructure
 
 ---
 

--- a/docs/pages/opsec/principles/web3-considerations.mdx
+++ b/docs/pages/opsec/principles/web3-considerations.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Web3 OpSec Considerations | Security Alliance"
-description: "Web3 OpSec considerations: blockchain transparency vs privacy, transaction immutability, self-custody responsibility for private keys, smart contract vulnerabilities, and community-driven security."
+description: "Web3 OpSec considerations: transparency versus privacy, immutability, self-custody of keys, smart-contract risk, and community-driven security practices."
 tags:
   - Security Specialist
   - Operations & Strategy
@@ -20,9 +20,8 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> 🔑 **Key Takeaway**: Web3 environments require specialized security approaches that balance blockchain transparency
-> with privacy, address immutability risks, manage self-custody responsibilities, secure decentralized operations,
-> mitigate smart contract vulnerabilities, and navigate community-driven security challenges.
+> 🔑 **Key Takeaway**: Web3 needs specialized OpSec that balances transparency with privacy, handles immutability and
+> self-custody, and secures decentralized and community-driven operations.
 
 In addition to traditional OpSec principles, Web3 environments require consideration of unique challenges. Many
 organizations claim to be backed only by decentralized technologies, but they later realize that part of their process

--- a/docs/pages/opsec/principles/web3-considerations.mdx
+++ b/docs/pages/opsec/principles/web3-considerations.mdx
@@ -99,6 +99,11 @@ Managing security in open, community-driven projects.
 3. Create security awareness programs for the community
 4. Balance transparency with operational security needs
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/principles/web3-considerations.mdx
+++ b/docs/pages/opsec/principles/web3-considerations.mdx
@@ -99,10 +99,12 @@ Managing security in open, community-driven projects.
 3. Create security awareness programs for the community
 4. Balance transparency with operational security needs
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [Principles overview](/opsec/principles/overview): how the principles pages fit together
+- [Web3 Considerations (core concepts)](/opsec/core-concepts/web3-considerations): the same ground in more depth
+- [Wallet Security](/wallet-security/overview): the custody problem these principles serve
+- [Understanding Threat Vectors](/awareness/understanding-threat-vectors): the Web3-specific attacks in play
 
 ---
 

--- a/docs/pages/opsec/secure-operating-systems.mdx
+++ b/docs/pages/opsec/secure-operating-systems.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Secure Operating Systems | Security Alliance"
-description: "Secure operating systems for Web3 teams: Qubes OS for isolation, Tails for ephemeral sessions, GrapheneOS for mobile. Defend against infostealers, DPRK malware, and key material theft."
+description: "Secure OS choices for Web3 teams: Qubes OS isolation, GrapheneOS mobile, and Tails ephemeral sessions against infostealers, malware, and key-material theft."
 tags:
   - Security Specialist
   - Operations & Strategy
@@ -11,18 +11,18 @@ contributors:
   - role: reviewed
     users: [mattaereal]
   - role: fact-checked
-    users: [mattaereal]
+    users: []
 ---
 
-import { TagList, AttributionList, ContributeFooter, Checklist } from '../../../components'
+import { TagList, AttributionList, Checklist, ContributeFooter } from '../../../components'
 
 # Secure Operating Systems
 
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> 🔑 **Key Takeaway:** Use compartmentalized operating systems to isolate sensitive operations from everyday
-> browsing. Qubes OS for desktop, GrapheneOS for mobile, Tails for ephemeral sessions.
+> 🔑 **Key Takeaway**: Use compartmentalized operating systems to isolate sensitive operations from everyday browsing —
+> Qubes OS for desktop, GrapheneOS for mobile, Tails for ephemeral sessions.
 
 Infostealer malware is among the most common initial access vectors in Web3 compromises. A single infected
 machine can exfiltrate browser sessions, wallet keys, SSH credentials, and authentication tokens in seconds.
@@ -237,7 +237,7 @@ systems on practical day-to-day security at team scale.
 - [ ] Review browser extensions and installed applications regularly
 </Checklist>
 
-## Further Reading
+## Further reading
 
 > **Note:** For a general overview of privacy-focused operating systems and tools (including Whonix,
 > Tor Browser, VeraCrypt), see
@@ -250,5 +250,7 @@ systems on practical day-to-day security at team scale.
 - [NIST SP 800-123: Guide to General Server Security](https://csrc.nist.gov/pubs/sp/800/123/final)
   (OS hardening reference)
 - [DPRK IT Workers](/dprk-it-workers/overview) — Threat context for why OS isolation matters in Web3
+
+---
 
 <ContributeFooter />

--- a/docs/pages/opsec/secure-operating-systems.mdx
+++ b/docs/pages/opsec/secure-operating-systems.mdx
@@ -11,7 +11,7 @@ contributors:
   - role: reviewed
     users: [mattaereal]
   - role: fact-checked
-    users: []
+    users: [mattaereal]
 ---
 
 import { TagList, AttributionList, Checklist, ContributeFooter } from '../../../components'

--- a/docs/pages/opsec/travel/guide.mdx
+++ b/docs/pages/opsec/travel/guide.mdx
@@ -1,11 +1,10 @@
 ---
 title: "Travel Security Guide | Security Alliance"
-description: "Travel security guide: device encryption, 2FA backup, hardware wallet protection, network safety, border crossing protocols, and high-risk traveler guidance."
+description: "Full travel security guide: threat-model before departure, encrypt devices, secure 2FA and wallets, avoid risky networks/USBs, and sanitize gear on return."
 tags:
   - Security Specialist
   - Operations & Strategy
   - Engineer/Developer
-  - Security Specialist
   - DevOps
   - SRE
 contributors:
@@ -24,6 +23,9 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
+> 🔑 **Key Takeaway**: Minimize what you carry, encrypt and update devices, secure accounts and wallets without seed
+> phrases, stay cautious on networks and in physical spaces, then sanitize on return.
+
 Travel introduces unique security risks to your digital assets and sensitive information. Proper preparation before,
 vigilance during, and careful review after travel creates a comprehensive defense strategy that balances security
 with practical usability.
@@ -32,12 +34,6 @@ When we travel, our normal security routines are disrupted, and we face elevated
 surveillance, border inspections, and social engineering. Web3 professionals face additional challenges when traveling
 with crypto assets or access to treasury funds. The resources in this guide provide practical guidance for maintaining
 operational security while traveling.
-
-> 🔑 Key Takeaway: Minimize data exposure by carrying only essential devices with full-disk encryption and updated
-> software. Secure accounts with backup 2FA methods, avoid biometrics at borders, use trusted networks with VPNs, and
-> never leave devices unattended. Guard against USB attacks, shoulder surfing, and hidden cameras. For crypto, use
-> strong passphrases and never travel with seed phrases. Upon returning, scan devices for malware and consider resetting
-> high-risk devices.
 
 {/* separator */}
 

--- a/docs/pages/opsec/travel/guide.mdx
+++ b/docs/pages/opsec/travel/guide.mdx
@@ -582,6 +582,11 @@ and finding hidden cameras in rentals |
 - GitHub USBGuard – tool to enforce USB device policies on laptops (helps block malicious USB devices) |
 [github.com](https://github.com/USBGuard/usbguard#:~:text=USBGuard%20is%20a%20software%20framework,may%20interact%20with%20the%20system).
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/travel/guide.mdx
+++ b/docs/pages/opsec/travel/guide.mdx
@@ -582,10 +582,12 @@ and finding hidden cameras in rentals |
 - GitHub USBGuard – tool to enforce USB device policies on laptops (helps block malicious USB devices) |
 [github.com](https://github.com/USBGuard/usbguard#:~:text=USBGuard%20is%20a%20software%20framework,may%20interact%20with%20the%20system).
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [Travel overview](/opsec/travel/overview): how the travel pages fit together
+- [Travel TL;DR](/opsec/travel/tldr): the condensed checklist
+- [Physical Security](/physical-security/overview): coercion and personal safety while travelling
+- [When to Use a VPN](/privacy/vpns/when-to-use-vpn): deciding on tunnels for hostile networks
 
 ---
 

--- a/docs/pages/opsec/travel/overview.mdx
+++ b/docs/pages/opsec/travel/overview.mdx
@@ -56,10 +56,13 @@ operational security
 Additional considerations are provided for high-risk travelers who may face targeted threats due to their role or access
 to valuable assets.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [OpSec overview](/opsec/overview): how the pages of this framework fit together
+- [Travel Guide](/opsec/travel/guide): the full pre-trip and in-country guidance
+- [Travel TL;DR](/opsec/travel/tldr): the short version to act on
+- [Secure Workspace and Travel](/opsec/control-domains/physical-environmental/secure-workspace-travel): the
+  control-domain treatment
 
 ---
 

--- a/docs/pages/opsec/travel/overview.mdx
+++ b/docs/pages/opsec/travel/overview.mdx
@@ -1,11 +1,10 @@
 ---
 title: "Operational Security While Traveling | SEAL"
-description: "Travel OpSec framework: pre-trip device hardening, on-trip network security and physical protection, and post-travel device inspection. Special guidance for high-risk travelers with crypto assets."
+description: "Travel OpSec: pre-trip hardening, on-trip network and physical controls, and post-travel inspection—plus higher bar guidance for crypto-asset holders."
 tags:
   - Security Specialist
   - Operations & Strategy
   - Engineer/Developer
-  - Security Specialist
   - DevOps
   - SRE
 contributors:
@@ -24,9 +23,8 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> 🔑 **Key Takeaway**: Travel introduces unique security risks to your digital assets and sensitive information. Proper
-> preparation before, vigilance during, and careful review after travel creates a comprehensive defense strategy that
-> balances security with practical usability.
+> 🔑 **Key Takeaway**: Travel raises physical and digital risk—prepare devices before departure, stay vigilant on the
+> road, and inspect or reset exposed devices before rejoining trusted networks.
 
 When we travel, our normal security routines are disrupted, and we face elevated risks from physical theft, digital
 surveillance, border inspections, and social engineering. Web3 professionals face additional challenges when traveling

--- a/docs/pages/opsec/travel/overview.mdx
+++ b/docs/pages/opsec/travel/overview.mdx
@@ -18,6 +18,13 @@ contributors:
 
 import { TagList, AttributionList, ContributeFooter } from '../../../../components'
 
+{/*
+  content-model-exception:
+  type: project-doc
+  reason: Nested OpSec overview; child map lives in parent IA / sidebar until section pages stabilize.
+  owner: maintainers
+*/}
+
 # Operational Security while traveling
 
 <TagList tags={frontmatter.tags} />

--- a/docs/pages/opsec/travel/overview.mdx
+++ b/docs/pages/opsec/travel/overview.mdx
@@ -49,6 +49,11 @@ operational security
 Additional considerations are provided for high-risk travelers who may face targeted threats due to their role or access
 to valuable assets.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />

--- a/docs/pages/opsec/travel/tldr.mdx
+++ b/docs/pages/opsec/travel/tldr.mdx
@@ -81,10 +81,13 @@ anyone tracking you.
 - Use duress codes if supported by hardware wallets.
 - Establish secure emergency check-ins and code words with your team for rapid response.
 
+## Further reading
 
-## Further Reading
-
-- [Opsec overview](/opsec/overview)
+- [Travel overview](/opsec/travel/overview): how the travel pages fit together
+- [Travel Guide](/opsec/travel/guide): the reasoning behind each item
+- [Secure Workspace and Travel](/opsec/control-domains/physical-environmental/secure-workspace-travel): the
+  control-domain treatment
+- [Seed Phrase Management](/wallet-security/seed-phrase-management): why key material stays home
 
 ---
 

--- a/docs/pages/opsec/travel/tldr.mdx
+++ b/docs/pages/opsec/travel/tldr.mdx
@@ -1,11 +1,10 @@
 ---
-title: "Travel Security Quick Reference | Security Alliance"
-description: "Quick travel security checklist: full-disk encryption, backup 2FA codes, secure hardware wallets, avoid public Wi-Fi, use VPNs, disable biometrics at borders, and scan devices upon return."
+title: "Travel Security Quick Reference | SEAL"
+description: "Travel security checklist: full-disk encryption, backup 2FA, secure hardware wallets, avoid public Wi-Fi, use VPN, lock biometrics at borders, scan on return."
 tags:
   - Security Specialist
   - Operations & Strategy
   - Engineer/Developer
-  - Security Specialist
   - DevOps
   - SRE
 contributors:
@@ -24,9 +23,8 @@ import { TagList, AttributionList, ContributeFooter } from '../../../../componen
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> 🔑 Key Takeaway: Protect your digital assets while traveling through minimizing sensitive data, using encrypted
-> devices, avoiding public networks, securing hardware wallets, maintaining physical control of devices, being cautious
-> with USB connections, practicing social discretion, and sanitizing devices upon return.
+> 🔑 **Key Takeaway**: Protect assets while traveling by minimizing sensitive data, using encrypted devices, avoiding
+> public networks, securing wallets, controlling devices physically, and sanitizing after return.
 
 ## Before traveling
 

--- a/docs/pages/opsec/travel/tldr.mdx
+++ b/docs/pages/opsec/travel/tldr.mdx
@@ -81,6 +81,11 @@ anyone tracking you.
 - Use duress codes if supported by hardware wallets.
 - Establish secure emergency check-ins and code words with your team for rapid response.
 
+
+## Further Reading
+
+- [Opsec overview](/opsec/overview)
+
 ---
 
 <ContributeFooter />


### PR DESCRIPTION
## Scope
Normalize `docs/pages/opsec/**` active hand-authored pages (**48** files). Excludes `docs/pages/opsec/old/**` and generated `index.mdx` files.

## Why
Match the SEAL content model used by other framework normalization PRs so OpSec pages share consistent chrome, frontmatter bands, and Key Takeaway formatting.

## Content model
- Frontmatter: `title` (≤60), `description` (140–160), `tags`, `contributors` with `wrote` / `reviewed` / `fact-checked` (empty arrays where missing)
- Chrome: `TagList`, `AttributionList` near top; `ContributeFooter` after `---` at bottom
- Canonical Key Takeaway: `> 🔑 **Key Takeaway**: …` (colon outside bold)
- Stub scaffold + `> ⚠️ Stub/in progress, help contribute/expand.` for title-only and placeholder pages
- Overview page map aligned to OpSec sidebar entries in `vocs.config.ts`
- `## Further Reading` → `## Further reading` where present
- Existing `wrote` / `reviewed` usernames preserved

## Changes
- **Stubs (18):** full scaffold for title-only control-domain/integration/improvement leaves + browser placeholder
- **Content pages:** surgical FM/chrome/KT/footer fixes; descriptions tightened into band
- **`overview.mdx`:** sidebar-matching “What this framework covers” map; added KT
- **KT format fixes:** endpoint, google, secure-OS, travel guide/tldr variants normalized
- **`principles/`** and **`improvement/`** normalized for chrome even when not fully listed in sidebar

## Substantive security
**None** — editorial/structural only. Control recommendations and guidance bodies preserved; Key Takeaways summarize existing prose only.

## Intentionally unchanged
- `docs/pages/opsec/old/**`
- Generated `index.mdx` files
- `vocs.config.ts` sidebar (already complete; WIP `dev: true` entries retained)
- Substantive security guidance bodies (no invented controls)
- Depends on #561 by reference only — no files copied from that PR

## Validation
- `npx markdownlint-cli2 "docs/pages/opsec/**/*.mdx" "!docs/pages/opsec/old/**"` — **0 issues**
- `pnpm exec cspell "docs/pages/opsec/**/*.mdx" --exclude "docs/pages/opsec/old/**"` — **0 issues**
- Signed commit (`git commit -S`)

## Dependencies
Depends on (by reference, unmerged): **#561** — Content normalization standard.

## Reviewer focus
- Stub pages clearly marked WIP; no invented security claims in stub KT/descriptions
- Overview map vs sidebar completeness
- Contributor attribution preserved (`shallem`, `dickson`, `andrew-chang-gu`, google multi-author list, etc.)
- `old/` and generated indexes untouched
- Password pages retain existing `TagProvider`/`TagFilter` structure