### PR TITLE
fix: add placeholder for pages with no contributors

### DIFF
--- a/components/attribution/AttributionList.css
+++ b/components/attribution/AttributionList.css
@@ -115,6 +115,36 @@
   color: #2563eb;
 }
 
+/* Empty state placeholder */
+.attribution-empty {
+  text-align: center;
+}
+
+.attribution-placeholder {
+  margin: 0;
+  padding: 8px 0;
+  font-size: 14px;
+  color: #9ca3af;
+}
+
+:root:not([data-vocs-theme='dark']) .attribution-placeholder {
+  color: #202020;
+}
+
+.attribution-placeholder-link {
+  color: #60a5fa;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.attribution-placeholder-link:hover {
+  text-decoration: underline;
+}
+
+:root:not([data-vocs-theme='dark']) .attribution-placeholder-link {
+  color: #2563eb;
+}
+
 /* Responsive design */
 @media (max-width: 768px) {
   .attribution-container {

--- a/components/attribution/AttributionList.tsx
+++ b/components/attribution/AttributionList.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'vocs'
 import contributorsData from '../../docs/pages/config/contributors.json'
 import './AttributionList.css'
 
@@ -79,26 +80,25 @@ function RoleSection({ role, userSlugs }: { role: string; userSlugs: string[] })
 
 function hasAnyContributor(contributors: ContributorRole[]): boolean {
   return contributors.some(group =>
+    Array.isArray(group?.users) &&
     group.users.some(slug => getContributor(slug) !== null)
   )
 }
 
 export function AttributionList({ contributors = [] }: AttributionListProps) {
-  if (!contributors || contributors.length === 0) return null
+  const roleGroups = Array.isArray(contributors) ? contributors : []
 
-  const hasContributors = hasAnyContributor(contributors)
-
-  if (!hasContributors) {
+  if (!hasAnyContributor(roleGroups)) {
     return (
       <div className="attribution-container attribution-empty">
         <p className="attribution-placeholder">
           No contributors yet.{' '}
-          <a
-            href="/contribute/contributing"
+          <Link
+            to="/contribute/contributing"
             className="attribution-placeholder-link"
           >
             Be the first to contribute
-          </a>
+          </Link>
           !
         </p>
       </div>
@@ -107,7 +107,7 @@ export function AttributionList({ contributors = [] }: AttributionListProps) {
 
   return (
     <div className="attribution-container">
-      {contributors.map((roleGroup, index) => (
+      {roleGroups.map((roleGroup, index) => (
         <RoleSection 
           key={index}
           role={roleGroup.role} 

--- a/components/attribution/AttributionList.tsx
+++ b/components/attribution/AttributionList.tsx
@@ -77,8 +77,33 @@ function RoleSection({ role, userSlugs }: { role: string; userSlugs: string[] })
   )
 }
 
+function hasAnyContributor(contributors: ContributorRole[]): boolean {
+  return contributors.some(group =>
+    group.users.some(slug => getContributor(slug) !== null)
+  )
+}
+
 export function AttributionList({ contributors = [] }: AttributionListProps) {
   if (!contributors || contributors.length === 0) return null
+
+  const hasContributors = hasAnyContributor(contributors)
+
+  if (!hasContributors) {
+    return (
+      <div className="attribution-container attribution-empty">
+        <p className="attribution-placeholder">
+          No contributors yet.{' '}
+          <a
+            href="/contribute/contributing"
+            className="attribution-placeholder-link"
+          >
+            Be the first to contribute
+          </a>
+          !
+        </p>
+      </div>
+    )
+  }
 
   return (
     <div className="attribution-container">


### PR DESCRIPTION
## Summary

- When a page has contributor roles defined in frontmatter but all user lists are empty (`users: []`), the `AttributionList` component rendered an empty styled container with no visible content.
- Added a placeholder message ("No contributors yet. Be the first to contribute!") with a link to the contributing guide, shown when no contributors resolve from any role group.
- Added `hasAnyContributor()` helper to detect the all-empty state before rendering role sections.
- Added CSS for the placeholder styling, consistent with existing dark/light theme patterns.

## Changes

- `components/attribution/AttributionList.tsx` — new `hasAnyContributor()` check + placeholder JSX
- `components/attribution/AttributionList.css` — `.attribution-empty`, `.attribution-placeholder`, `.attribution-placeholder-link` styles

Closes #593
