### PR TITLE
docs(supply-chain): add developer workstation security guidance

### DIFF
--- a/docs/pages/ai-security/overview.mdx
+++ b/docs/pages/ai-security/overview.mdx
@@ -135,6 +135,8 @@ verify currency before using them in decisions.
 - [DevSecOps](/devsecops/overview): isolation, pipeline, and sandbox depth
 - [Secure Software Development](/secure-software-development/overview): when AI code lands in production paths
 - [Supply Chain](/supply-chain/overview): model, plugin, and MCP-style tool trust
+- [Developer Workstation Security](/supply-chain/developer-workstation-security): owns pre-execution screening and
+  allowlisting for plugins, MCP servers, agent rules, and model artifacts
 - [OpSec](/opsec/overview): operator and key-handling next to agent tools
 - [Awareness](/awareness/overview): human misuse and social engineering with AI assistants
 - [Incident Management](/incident-management/overview): response when agentic systems cause loss

--- a/docs/pages/config/contributors.json
+++ b/docs/pages/config/contributors.json
@@ -1,4 +1,17 @@
 {
+  "s1ns3nz0": {
+    "slug": "s1ns3nz0",
+    "name": "s1ns3nz0",
+    "avatar": "https://avatars.githubusercontent.com/s1ns3nz0",
+    "github": "https://github.com/s1ns3nz0",
+    "twitter": null,
+    "website": "https://miata.cloud",
+    "company": null,
+    "job_title": null,
+    "role": "contributor",
+    "description": null,
+    "badges": []
+  },
   "mattaereal": {
     "slug": "mattaereal",
     "name": "matta",

--- a/docs/pages/devsecops/developer-targeted-intrusions/handling-untrusted-code.mdx
+++ b/docs/pages/devsecops/developer-targeted-intrusions/handling-untrusted-code.mdx
@@ -161,6 +161,8 @@ proof that every other recipient avoided execution.
   repository-controlled input into code execution
 - [Developer machine confinement](/devsecops/isolation/developer-machine-sandboxing): practical confinement patterns
   for developer tools and AI coding agents
+- [Developer workstation security](/supply-chain/developer-workstation-security): the governance side of this
+  procedure, covering allowlists, MCP and package approval, and exception evidence
 - [Incident Management](/incident-management/overview): preparation, escalation, investigation, containment, and
   recovery guidance
 - [SEAL 911 War Room Guidelines](/incident-management/playbooks/seal-911-war-room-guidelines): emergency coordination

--- a/docs/pages/devsecops/developer-targeted-intrusions/overview.mdx
+++ b/docs/pages/devsecops/developer-targeted-intrusions/overview.mdx
@@ -128,6 +128,8 @@ before allowing the new revision onto a privileged workstation or into a trusted
 
 ## Further reading
 
+- [Developer workstation security](/supply-chain/developer-workstation-security): governing which tools, MCP servers,
+  dependencies, and model artifacts are approved before any of this reaches a workstation
 - [SEAL: VS Code Tasks Abuse](https://radar.securityalliance.org/vs-code-tasks-abuse-by-contagious-interview-dprk/):
   a developer-targeted campaign using workspace tasks
 - [Elastic Security Labs: Bit ByBit](https://www.elastic.co/security-labs/bit-bybit): analysis of malicious source,

--- a/docs/pages/devsecops/integrated-development-environments.mdx
+++ b/docs/pages/devsecops/integrated-development-environments.mdx
@@ -102,6 +102,8 @@ controls in place.
   external repositories
 - [Developer machine confinement](/devsecops/isolation/developer-machine-sandboxing): confining agent and IDE
   workloads on the laptop
+- [Developer workstation security](/supply-chain/developer-workstation-security): governing which extensions, MCP
+  servers, and dependencies are approved in the first place
 - [Repository hardening](/devsecops/repository-hardening): controls for the code the IDE pushes
 - [Security testing](/devsecops/security-testing): pipeline counterparts to IDE analysis
 - [Visual Studio Code Workspace Trust](https://code.visualstudio.com/docs/editing/workspaces/workspace-trust):

--- a/docs/pages/dprk-it-workers/techniques-tactics-and-procedures.mdx
+++ b/docs/pages/dprk-it-workers/techniques-tactics-and-procedures.mdx
@@ -322,6 +322,8 @@ are used as cover. Incorporate unpredictable, interactive requests that a pre-re
     recruiters](https://unit42.paloaltonetworks.com/north-korean-threat-actors-lure-tech-job-seekers-as-fake-recruiters/)
     and [Two Campaigns by North Korea Bad Actors target job
     hunters](https://unit42.paloaltonetworks.com/two-campaigns-by-north-korea-bad-actors-target-job-hunters/).
+    [Developer Workstation Security](/supply-chain/developer-workstation-security) owns the pre-execution intake and
+    confinement controls for coding exercises and unfamiliar repositories used in campaigns like this.
     Your North Korean employee **may leverage the credibility granted by being employed at your company to conduct
     malware-related campaigns in the present and future.** This could significantly affect your brand.
 5. **A DPRK IT Worker will try to escalate their access if possible**, whether by adding new members (who will also

--- a/docs/pages/opsec/endpoint/overview.mdx
+++ b/docs/pages/opsec/endpoint/overview.mdx
@@ -49,6 +49,9 @@ Issue organization-managed hardware to your highest-risk roles. This provides fu
 
 **Target roles:** Developers with production access, leadership, treasury custodians, key signers, security leads.
 
+For developer roles, [Developer Workstation Security](/supply-chain/developer-workstation-security) owns the
+pre-execution screening boundary for repositories, IDE configuration, dependencies, and AI tooling on managed endpoints.
+
 ### Tier 2: Virtual Desktop Infrastructure (Privacy-First Scale)
 
 For global contractors where issuing hardware is impractical, VDI provides a secure cloud-hosted environment

--- a/docs/pages/supply-chain/developer-workstation-security.mdx
+++ b/docs/pages/supply-chain/developer-workstation-security.mdx
@@ -178,18 +178,19 @@ Coordinate the investigation through [Supply Chain Incident Response](/supply-ch
 If malware may have executed, follow the immediate containment and recovery steps in the
 [Malware Infection playbook](/incident-management/playbooks/malware).
 
-The examples below connect a documented failure to a governance lesson. The PolinRider execution path is
+The examples below connect a documented failure to a governance lesson. Dates are source publication and update dates,
+not when activity began or ended. The PolinRider execution path is
 **repository-controlled workspace automation, not a malicious extension installation**: the repository supplies the
 task, while the IDE's built-in task runner interprets it after trust is granted. Extension publishing incidents involve
 a separate artifact, approval path, and detection signal.
 
 | Example | Control failure | Governance lesson |
 | --- | --- | --- |
-| [Contagious Interview / PolinRider](https://github.com/OpenSourceMalware/PolinRider) | Repository-controlled workspace tasks executed locally | Quarantine repositories and require explicit workspace trust |
-| [Amazon Q extension incident](https://aws.amazon.com/security/security-bulletins/AWS-2025-015/) | An extension publishing path and release control were compromised | Approve publishers and versions, control updates, and monitor release drift |
-| [`postmark-mcp`](https://snyk.io/blog/malicious-mcp-server-on-npm-postmark-mcp-harvests-emails/) | A later MCP package version added covert data exfiltration | Treat MCP servers as executable vendors; pin, review, monitor, and revoke |
-| [Nx `s1ngularity`](https://github.com/nrwl/nx/security/advisories/GHSA-cxm3-wv7p-598c) | A compromised dependency used local AI tooling and credentials | Separate credentials, constrain agent capabilities, and monitor package behavior |
-| [Slopsquatting research](https://www.usenix.org/system/files/usenixsecurity25-spracklen.pdf) | AI generated plausible package names that did not exist | Verify package identity against canonical documentation before approval |
+| [Contagious Interview / PolinRider](https://github.com/OpenSourceMalware/PolinRider)<br />Dossier: March 7, 2026; updated April 11, 2026 | Repository-controlled workspace tasks executed locally | Quarantine repositories and require explicit workspace trust |
+| [Amazon Q extension incident](https://aws.amazon.com/security/security-bulletins/AWS-2025-015/)<br />AWS bulletin: July 23, 2025; updated July 25, 2025 | An extension publishing path and release control were compromised | Approve publishers and versions, control updates, and monitor release drift |
+| [`postmark-mcp`](https://snyk.io/blog/malicious-mcp-server-on-npm-postmark-mcp-harvests-emails/)<br />Snyk analysis: September 25, 2025 | A later MCP package version added covert data exfiltration | Treat MCP servers as executable vendors; pin, review, monitor, and revoke |
+| [Nx `s1ngularity`](https://github.com/nrwl/nx/security/advisories/GHSA-cxm3-wv7p-598c)<br />GitHub advisory: August 27, 2025; updated August 30, 2025 | A compromised dependency used local AI tooling and credentials | Separate credentials, constrain agent capabilities, and monitor package behavior |
+| [Slopsquatting research](https://www.usenix.org/system/files/usenixsecurity25-spracklen.pdf)<br />USENIX Security 2025 paper | AI generated plausible package names that did not exist | Verify package identity against canonical documentation before approval |
 
 ## Further reading
 

--- a/docs/pages/supply-chain/developer-workstation-security.mdx
+++ b/docs/pages/supply-chain/developer-workstation-security.mdx
@@ -40,12 +40,8 @@ into internal systems. It can therefore compromise downstream builds even when t
 Execution may begin when an IDE opens a repository, a package manager runs a lifecycle script, an extension or Model
 Context Protocol (MCP) server starts, an AI agent reads project instructions, or a framework deserializes a model
 artifact. Treat opening, installing, importing, building, testing, and asking an agent to work as distinct execution
-decisions.
-
-## Treat development inputs as untrusted
-
-Trust applies to a specific artifact and version, not to a familiar filename, repository name, or author profile.
-Review these inputs before allowing them to interact with a normal workstation:
+decisions. For that reason, trust applies to a specific artifact and version, not to a familiar filename, repository
+name, or author profile. Treat these development inputs as untrusted until they have been reviewed:
 
 | Input | Possible execution path | Review focus |
 | --- | --- | --- |

--- a/docs/pages/supply-chain/developer-workstation-security.mdx
+++ b/docs/pages/supply-chain/developer-workstation-security.mdx
@@ -16,6 +16,8 @@ contributors:
 
 import { TagList, AttributionList, Checklist, ContributeFooter } from '../../../components'
 
+{/* cspell:ignore ngularity */}
+
 # Developer Workstation Security
 
 <TagList tags={frontmatter.tags} />
@@ -38,25 +40,52 @@ Source code reaches production through developers, their tools, and their creden
 alter source or lockfiles, steal package-publishing and cloud credentials, tamper with commits, or provide a foothold
 into internal systems. It can therefore compromise downstream builds even when the production pipeline is isolated.
 
-Execution may begin when an IDE opens a repository, a package manager runs a lifecycle script, an extension or Model
-Context Protocol (MCP) server starts, an AI agent reads project instructions, or a framework deserializes a model
-artifact. Treat opening, installing, importing, building, testing, and asking an agent to work as distinct execution
-decisions. For that reason, trust applies to a specific artifact and version, not to a familiar filename, repository
-name, or author profile. Treat these development inputs as untrusted until they have been reviewed:
+Execution may begin when a tool interprets repository configuration, installs packages or extensions, starts Model
+Context Protocol (MCP) servers, follows agent rules or skills, accepts AI-suggested packages, or loads executable model
+artifacts. Treat opening, installing, importing, building, testing, and asking an agent to work as distinct execution
+decisions. Trust applies to a specific artifact and version, not to a familiar name, repository, or author profile.
 
-| Input | Possible execution path | Review focus |
-| --- | --- | --- |
-| Repository configuration | IDE tasks, workspace settings, debug launchers, dev-container hooks, shell hooks, or build configuration | Commands, referenced executables, environment access, and automatic triggers |
-| Dependencies | Package-manager lifecycle scripts, native builds, compiler plugins, or imported modules | Canonical publisher, resolved version, lockfile entry, integrity metadata, and install scripts |
-| IDE and coding-agent extensions | Extension activation with the editor user's permissions | Publisher, source, requested capabilities, release provenance, and organizational approval |
-| MCP servers | A local server binary or startup command launched by an AI client | Distribution source, command, filesystem and network scope, credentials, and exposed tools |
-| Agent rules and skills | Instructions interpreted by an agent that can call tools or run commands | Hidden instructions, external downloads, destructive actions, credential requests, and permission changes |
-| AI-suggested packages | A plausible but nonexistent name that an attacker can register | Existence, ownership, release history, canonical documentation, and internal approval |
-| Model artifacts | Deserialization or custom model code during loading | File format, expected hash, provenance, loader behavior, and whether executable deserialization is required |
+Review each input's canonical source, execution triggers, requested permissions, data and credential access, network
+destinations, update behavior, and integrity evidence. Local MCP servers can run with the client's privileges, and
+some model formats execute code during deserialization, so their configuration and artifacts are executable software
+rather than passive data.
 
-Local MCP servers can run with the client's privileges, so treat their configuration as executable software rather
-than passive metadata. Likewise, do not deserialize untrusted pickle-based model files; prefer a non-executable weight
-format when the ecosystem supports one.
+## Govern external development tools
+
+Organizations should govern extensions, MCP servers, coding agents, package-manager plugins, model loaders, and other
+external development tools throughout their lifecycle:
+
+1. **Establish business need.** Record the approved use and why an existing capability does not meet it.
+2. **Classify risk.** Assess execution, data, update, and communication risk in the intended environment.
+3. **Review the tool.** Examine provenance, permissions, data flows, credentials, egress, and behavior.
+4. **Make the risk decision.** Approve, reject, or grant a time-limited exception with compensating controls.
+5. **Deploy the decision.** Distribute and enforce the approved version and configuration.
+6. **Monitor drift.** Detect changes in version, permission, publisher, and behavior.
+7. **Reassess the decision.** Review on a defined cadence and after material changes or incidents.
+8. **Revoke and remove.** Withdraw access, remove the tool, and preserve the decision record.
+
+Organizations may combine these functions in one role or distribute them across security, engineering, procurement,
+legal, and operations. The control objective is documented separation between the request, the risk decision, and
+ongoing ownership, not a prescribed department or organization chart.
+
+Maintain a managed allowlist as the authoritative inventory of approved external development tools. Each record must
+include:
+
+| Record field | Required evidence |
+| --- | --- |
+| Identity and use | Tool or category and approved use |
+| Provenance | Canonical publisher and distribution source |
+| Release constraint | Approved version, digest, or update channel |
+| Access | Permissions, accessible data, network destinations, and credential access |
+| Ownership | Review date, designated approver, tool owner, and next review date |
+| Safeguards | Required technical and operational safeguards |
+| Exception | Recorded exception reference and expiration |
+| Exit plan | Removal and incident-response instructions |
+
+Inspection evidence should show inventory completeness, approval records, expired exceptions, periodic review
+completion, configuration enforcement, version or permission drift, removal evidence, and linked incident records.
+This evidence lets owners demonstrate that decisions remain current without asserting compliance with a particular
+regulation or standard.
 
 ## Screen before execution
 
@@ -82,11 +111,11 @@ Apply the following gates in order. A failed or inconclusive gate keeps the mate
    artifact is identical.
 
 4. **Approve dependencies and tools.** Resolve every package name against the expected registry and publisher,
-   including names proposed by AI tools. Pin approved dependencies, extensions, MCP servers, actions, and model
-   revisions to immutable versions or digests and verify integrity metadata. **Install scripts** execute during common
-   package-manager operations, so block them by default and approve exceptions only after review. **Mutable versions**
-   such as branches, floating tags, and ranges can resolve to different code after approval; do not treat them as a
-   stable security decision.
+   including names proposed by AI tools. Confirm the item and intended use appear in the managed allowlist. Pin
+   approved dependencies, extensions, MCP servers, actions, and model revisions to immutable versions or digests and
+   verify integrity metadata. **Install scripts** execute during common package-manager operations, so block them by
+   default and approve exceptions only after review. **Mutable versions** such as branches, floating tags, and ranges
+   can resolve to different code after approval; do not treat them as a stable security decision.
 
 5. **Execute only in a confined, disposable environment.** Use a fresh VM or hardened development container with no
    production, publishing, wallet, source-control, cloud, or personal credentials. Grant only required filesystem and
@@ -94,14 +123,20 @@ Apply the following gates in order. A failed or inconclusive gate keeps the mate
    execution path into a simple channel for payload retrieval or data exfiltration. Destroy the environment after the
    evaluation and promote only reviewed source and locked metadata.
 
-## Apply baseline controls
+## Apply and verify baseline controls
 
 Standardize controls so a developer does not have to reconstruct the intake boundary for each project. Workspace Trust
 reduces repository-driven execution, while extension and MCP allowlists address separately installed executable tools.
-Use endpoint detection and response (EDR) and mobile device management (MDM) to enforce and observe the baseline.
+Use endpoint detection and response (EDR) and mobile device management (MDM) to enforce and observe the baseline. Test
+the deployed configuration and retain its results; a documented setting is not evidence that endpoints enforce it.
 
 <Checklist id="developer-workstation-supply-chain-baseline">
 
+- [ ] Define approved and prohibited external-tool categories and document approval criteria
+- [ ] Maintain an allowlist with tool owners, approved uses, versions, permissions, safeguards, and review dates
+- [ ] Record exceptions with scope, compensating controls, an owner, and an expiration date
+- [ ] Reassess tools after material publisher, ownership, permission, update, behavior, or incident changes
+- [ ] Remove unapproved or expired tools and retain evidence of the decision and removal
 - [ ] Keep Workspace Trust enabled, leave unfamiliar folders untrusted, and require explicit approval before trusting them
 - [ ] Disable automatic workspace tasks and review task configuration before enabling it
 - [ ] Allowlist IDE extensions, coding-agent extensions, and MCP servers
@@ -120,7 +155,7 @@ This checklist defines the intake baseline. Apply the implementation patterns in
 [Sandboxing & Isolation](/devsecops/isolation/sandboxing-and-isolation) rather than copying product-specific container,
 filesystem, or network configuration into this page.
 
-## Detect and respond
+## Detect, respond, and learn from incidents
 
 Collect endpoint, process, filesystem, network, IDE, agent, source-control, and package-registry telemetry. Alert on:
 
@@ -143,24 +178,25 @@ Coordinate the investigation through [Supply Chain Incident Response](/supply-ch
 If malware may have executed, follow the immediate containment and recovery steps in the
 [Malware Infection playbook](/incident-management/playbooks/malware).
 
-## Case study and related guidance
+The examples below connect a documented failure to a governance lesson. The PolinRider execution path is
+**repository-controlled workspace automation, not a malicious extension installation**: the repository supplies the
+task, while the IDE's built-in task runner interprets it after trust is granted. Extension publishing incidents involve
+a separate artifact, approval path, and detection signal.
 
-Activity linked to the Democratic People's Republic of Korea (DPRK), tracked as **Contagious Interview**, used
-convincing coding exercises and repositories to push developers toward installation or execution. OpenSourceMalware
-dated its related **PolinRider** dossier March 7, 2026, and last updated it April 11, 2026; a separate Contagious
-Interview repository analysis was published June 30, 2026. These are report publication and update dates, not claims
-about when the activity began or ended. The reports document malicious project files, including
-`.vscode/tasks.json` entries with `runOn: "folderOpen"`, that retrieved and executed a payload after the workspace
-allowed automatic tasks.
-
-This execution path is **repository-controlled workspace automation, not a malicious VS Code extension**. The task
-definition arrives as a project file and the IDE's built-in task runner interprets it. A malicious extension is a
-separate executable supply-chain risk that requires publisher verification and extension allowlisting. Both risks are
-reduced by keeping an unfamiliar repository in Restricted Mode, but they have different artifacts, approval paths, and
-detection signals.
+| Example | Control failure | Governance lesson |
+| --- | --- | --- |
+| [Contagious Interview / PolinRider](https://github.com/OpenSourceMalware/PolinRider) | Repository-controlled workspace tasks executed locally | Quarantine repositories and require explicit workspace trust |
+| [Amazon Q extension incident](https://aws.amazon.com/security/security-bulletins/AWS-2025-015/) | An extension publishing path and release control were compromised | Approve publishers and versions, control updates, and monitor release drift |
+| [`postmark-mcp`](https://snyk.io/blog/malicious-mcp-server-on-npm-postmark-mcp-harvests-emails/) | A later MCP package version added covert data exfiltration | Treat MCP servers as executable vendors; pin, review, monitor, and revoke |
+| [Nx `s1ngularity`](https://github.com/nrwl/nx/security/advisories/GHSA-cxm3-wv7p-598c) | A compromised dependency used local AI tooling and credentials | Separate credentials, constrain agent capabilities, and monitor package behavior |
+| [Slopsquatting research](https://www.usenix.org/system/files/usenixsecurity25-spracklen.pdf) | AI generated plausible package names that did not exist | Verify package identity against canonical documentation before approval |
 
 ## Further reading
 
+- [Risk Management](/governance/risk-management): ownership patterns for risk acceptance, exception decisions, and
+  recurring review
+- [Compliance & Regulatory Requirements](/governance/compliance-regulatory-requirements): adaptable compliance-
+  governance context for assigning evidence, review, and oversight responsibilities
 - [DPRK IT Workers](/dprk-it-workers/overview): organizational controls for DPRK-linked hiring and insider risk
 - [AI Security](/ai-security/overview): runtime controls for AI systems, coding agents, tool calls, and model use
 - [Endpoint Security](/opsec/endpoint/overview): managed endpoint provisioning, EDR, MDM, and credential-separation
@@ -172,10 +208,6 @@ detection signals.
   for Restricted Mode, tasks, settings, extensions, and AI agents
 - [VS Code automatic task controls](https://code.visualstudio.com/docs/debugtest/tasks#_run-behavior): official
   documentation for `runOn: "folderOpen"` and `task.allowAutomaticTasks`
-- [OpenSourceMalware PolinRider technical dossier](https://github.com/OpenSourceMalware/PolinRider): campaign analysis,
-  project-file execution paths, and detection artifacts
-- [Contagious Interview technical analysis](https://kudelskisecurity.com/research/how-dprks-contagious-interview-campaign-targets-developers):
-  technical analysis of the fake-interview repository and its VS Code task trigger
 - [Model Context Protocol security best practices](https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices):
   risks and confinement guidance for local MCP servers
 - [SLSA artifact verification](https://slsa.dev/spec/v1.2/verifying-artifacts): verifying artifact digests, signatures,
@@ -185,8 +217,6 @@ detection signals.
   from untrusted sources
 - [Trojan Source paper](https://www.usenix.org/system/files/usenixsecurity23-boucher.pdf): analysis of bidirectional
   Unicode control characters that can alter how source code is displayed
-- [USENIX package hallucination study](https://www.usenix.org/system/files/usenixsecurity25-spracklen.pdf): research on
-  nonexistent package names generated by coding models and the resulting package-confusion risk
 
 ---
 

--- a/docs/pages/supply-chain/developer-workstation-security.mdx
+++ b/docs/pages/supply-chain/developer-workstation-security.mdx
@@ -101,16 +101,16 @@ Use endpoint detection and response (EDR) and mobile device management (MDM) to 
 
 <Checklist id="developer-workstation-supply-chain-baseline">
 
-- Require Workspace Trust or the IDE's equivalent before project features activate
-- Disable automatic workspace tasks and review task configuration before enabling it
-- Allowlist IDE extensions, coding-agent extensions, and MCP servers
-- Pin approved tool and dependency versions and verify integrity metadata
-- Block install-time scripts by default and document approved exceptions
-- Detect invisible Unicode and suspicious obfuscation in code and agent instruction files
-- Keep production, publishing, and treasury credentials outside untrusted development environments
-- Apply EDR and MDM controls to managed developer endpoints
-- Restrict outbound traffic from evaluation environments
-- Open untrusted projects only in disposable VMs or hardened development containers
+- [ ] Require Workspace Trust or the IDE's equivalent before project features activate
+- [ ] Disable automatic workspace tasks and review task configuration before enabling it
+- [ ] Allowlist IDE extensions, coding-agent extensions, and MCP servers
+- [ ] Pin approved tool and dependency versions and verify integrity metadata
+- [ ] Block install-time scripts by default and document approved exceptions
+- [ ] Detect invisible Unicode and suspicious obfuscation in code and agent instruction files
+- [ ] Keep production, publishing, and treasury credentials outside untrusted development environments
+- [ ] Apply EDR and MDM controls to managed developer endpoints
+- [ ] Restrict outbound traffic from evaluation environments
+- [ ] Open untrusted projects only in disposable VMs or hardened development containers
 
 </Checklist>
 

--- a/docs/pages/supply-chain/developer-workstation-security.mdx
+++ b/docs/pages/supply-chain/developer-workstation-security.mdx
@@ -137,6 +137,7 @@ the deployed configuration and retain its results; a documented setting is not e
 - [ ] Maintain an allowlist with tool owners, approved uses, versions, permissions, safeguards, and review dates
 - [ ] Record exceptions with scope, compensating controls, an owner, and an expiration date
 - [ ] Periodically review inventory and enforcement evidence for version, permission, publisher, and behavior drift
+- [ ] Reassess tools after material publisher, ownership, permission, update, behavior, or incident changes
 - [ ] Remove unapproved or expired tools and retain evidence of the decision and removal
 - [ ] Keep Workspace Trust enabled, leave unfamiliar folders untrusted, and require explicit approval before trusting them
 - [ ] Disable automatic workspace tasks and review task configuration before enabling it

--- a/docs/pages/supply-chain/developer-workstation-security.mdx
+++ b/docs/pages/supply-chain/developer-workstation-security.mdx
@@ -1,0 +1,190 @@
+---
+title: "Developer Workstation Security | SEAL"
+description: "Screen repositories, IDE configuration, AI tools, and dependencies before execution to stop supply chain attacks at the developer workstation boundary."
+tags:
+  - Engineer/Developer
+  - Security Specialist
+  - DevOps
+contributors:
+  - role: wrote
+    users: [s1ns3nz0]
+  - role: reviewed
+    users: []
+  - role: fact-checked
+    users: []
+---
+
+import { TagList, AttributionList, Checklist, ContributeFooter } from '../../../components'
+
+# Developer Workstation Security
+
+<TagList tags={frontmatter.tags} />
+<AttributionList contributors={frontmatter.contributors} />
+
+> 🔑 **Key Takeaway**: Screen untrusted development material before an IDE, package manager, model loader, or AI
+> agent interprets it. Confinement limits the damage when screening misses a malicious input.
+
+A developer workstation is an execution boundary, not just a place to edit code. Routine actions can activate content
+from another party before a developer reaches the application entry point.
+
+This guidance applies when evaluating a new repository, contributor branch, coding exercise, dependency, development
+tool, agent integration, or model artifact. Perform intake on a credential-free system, then move only approved
+material into normal development environments.
+
+## Why the workstation is part of the supply chain
+
+Source code reaches production through developers, their tools, and their credentials. A compromised workstation can
+alter source or lockfiles, steal package-publishing and cloud credentials, tamper with commits, or provide a foothold
+into internal systems. It can therefore compromise downstream builds even when the production pipeline is isolated.
+
+Execution may begin when an IDE opens a repository, a package manager runs a lifecycle script, an extension or Model
+Context Protocol (MCP) server starts, an AI agent reads project instructions, or a framework deserializes a model
+artifact. Treat opening, installing, importing, building, testing, and asking an agent to work as distinct execution
+decisions.
+
+## Treat development inputs as untrusted
+
+Trust applies to a specific artifact and version, not to a familiar filename, repository name, or author profile.
+Review these inputs before allowing them to interact with a normal workstation:
+
+| Input | Possible execution path | Review focus |
+| --- | --- | --- |
+| Repository configuration | IDE tasks, workspace settings, debug launchers, dev-container hooks, shell hooks, or build configuration | Commands, referenced executables, environment access, and automatic triggers |
+| Dependencies | Package-manager lifecycle scripts, native builds, compiler plugins, or imported modules | Canonical publisher, resolved version, lockfile entry, integrity metadata, and install scripts |
+| IDE and coding-agent extensions | Extension activation with the editor user's permissions | Publisher, source, requested capabilities, release provenance, and organizational approval |
+| MCP servers | A local server binary or startup command launched by an AI client | Distribution source, command, filesystem and network scope, credentials, and exposed tools |
+| Agent rules and skills | Instructions interpreted by an agent that can call tools or run commands | Hidden instructions, external downloads, destructive actions, credential requests, and permission changes |
+| AI-suggested packages | A plausible but nonexistent name that an attacker can register | Existence, ownership, release history, canonical documentation, and internal approval |
+| Model artifacts | Deserialization or custom model code during loading | File format, expected hash, provenance, loader behavior, and whether executable deserialization is required |
+
+Local MCP servers can run with the client's privileges, so treat their configuration as executable software rather
+than passive metadata. Likewise, do not deserialize untrusted pickle-based model files; prefer a non-executable weight
+format when the ecosystem supports one.
+
+## Screen before execution
+
+Apply the following gates in order. A failed or inconclusive gate keeps the material in quarantine.
+
+1. **Acquire without execution.** Fetch the material into a quarantine directory or disposable virtual machine (VM)
+   with IDE integration, file previews, shell directory hooks, agents, and package installation disabled. Do not start
+   a referenced MCP server or load a model merely to inspect it.
+
+2. **Inspect provenance and execution triggers.** Confirm the canonical source through an independent channel, then
+   inspect signatures, release metadata, contributors, and the exact revision. Search workspace tasks and settings,
+   launch and container files, Git hooks, package scripts, build plugins, MCP startup commands, agent rules and skills,
+   and model-loading code. A plausible commit author or old timestamp does not defeat **forged history**; corroborate
+   important revisions with signed releases, immutable object identifiers, repository audit data, or a known upstream.
+   A trusted workspace may permit **workspace auto-run**, so keep Workspace Trust disabled and automatic tasks off
+   until these files pass review.
+
+3. **Scan and compare artifacts with reviewed source.** Run static malware, dependency, secret, and policy scans without
+   importing the project. Inspect unusually large whitespace, encoded strings, binary files in source paths, and
+   bidirectional or invisible Unicode. **Invisible Unicode** can make displayed control flow differ from the compiled
+   source, so use a scanner or editor view that exposes code points. Compare packaged files and model artifacts with
+   reviewed source, checksums, signatures, and provenance; a clean source tree does not prove a separately built
+   artifact is identical.
+
+4. **Approve dependencies and tools.** Resolve every package name against the expected registry and publisher,
+   including names proposed by AI tools. Pin approved dependencies, extensions, MCP servers, actions, and model
+   revisions to immutable versions or digests and verify integrity metadata. **Install scripts** execute during common
+   package-manager operations, so block them by default and approve exceptions only after review. **Mutable versions**
+   such as branches, floating tags, and ranges can resolve to different code after approval; do not treat them as a
+   stable security decision.
+
+5. **Execute only in a confined, disposable environment.** Use a fresh VM or hardened development container with no
+   production, publishing, wallet, source-control, cloud, or personal credentials. Grant only required filesystem and
+   process access, record activity, and allowlist required destinations. **Unrestricted egress** turns any missed
+   execution path into a simple channel for payload retrieval or data exfiltration. Destroy the environment after the
+   evaluation and promote only reviewed source and locked metadata.
+
+## Apply baseline controls
+
+Standardize controls so a developer does not have to reconstruct the intake boundary for each project. Workspace Trust
+reduces repository-driven execution, while extension and MCP allowlists address separately installed executable tools.
+Use endpoint detection and response (EDR) and mobile device management (MDM) to enforce and observe the baseline.
+
+<Checklist id="developer-workstation-supply-chain-baseline">
+
+- Require Workspace Trust or the IDE's equivalent before project features activate
+- Disable automatic workspace tasks and review task configuration before enabling it
+- Allowlist IDE extensions, coding-agent extensions, and MCP servers
+- Pin approved tool and dependency versions and verify integrity metadata
+- Block install-time scripts by default and document approved exceptions
+- Detect invisible Unicode and suspicious obfuscation in code and agent instruction files
+- Keep production, publishing, and treasury credentials outside untrusted development environments
+- Apply EDR and MDM controls to managed developer endpoints
+- Restrict outbound traffic from evaluation environments
+- Open untrusted projects only in disposable VMs or hardened development containers
+
+</Checklist>
+
+This checklist defines the intake baseline. Apply the implementation patterns in
+[Developer Machine Confinement](/devsecops/isolation/developer-machine-sandboxing) and
+[Sandboxing & Isolation](/devsecops/isolation/sandboxing-and-isolation) rather than copying product-specific container,
+filesystem, or network configuration into this page.
+
+## Detect and respond
+
+Collect endpoint, process, filesystem, network, IDE, agent, source-control, and package-registry telemetry. Alert on:
+
+- **Unexpected child processes:** editors, agents, package managers, model loaders, or MCP clients spawning shells,
+  downloaders, interpreters, persistence tools, or unsigned binaries outside an approved workflow
+- **Credential-path access:** reads of wallet stores, browser profiles, SSH keys, cloud configuration, password-manager
+  data, package tokens, or source-control credentials by development processes
+- **Unapproved egress:** new domains, direct IP connections, tunneling, paste sites, or blockchain endpoints from an
+  evaluation environment
+- **Tool drift:** unapproved extension or MCP-server installation, changed hashes, disabled Workspace Trust, enabled
+  automatic tasks, or divergence from the managed tool inventory
+- **Registry anomalies:** a new publisher, unexpected ownership change, release outside the normal cadence, republished
+  version, provenance failure, or package contents that differ from the reviewed source
+
+When a signal indicates execution, isolate the endpoint without destroying volatile evidence, preserve relevant
+repository and tool artifacts, and identify every credential or signing capability the process could access. Revoke
+sessions and rotate exposed credentials from a clean device. Quarantine affected commits, packages, and build outputs;
+then hunt for the same indicators across developer systems, repositories, continuous integration, and registry logs.
+Coordinate the investigation through [Supply Chain Incident Response](/supply-chain/incident-response-supply-chain).
+If malware may have executed, follow the immediate containment and recovery steps in the
+[Malware Infection playbook](/incident-management/playbooks/malware).
+
+## Case study and related guidance
+
+The DPRK-linked **Contagious Interview** activity used convincing coding exercises and repositories to push developers
+toward installation or execution. Technical reporting on the related **PolinRider** cluster documents malicious
+project files, including `.vscode/tasks.json` entries with `runOn: "folderOpen"`, that retrieved and executed a payload
+after the workspace allowed automatic tasks.
+
+This execution path is **repository-controlled workspace automation, not a malicious VS Code extension**. The task
+definition arrives as a project file and the IDE's built-in task runner interprets it. A malicious extension is a
+separate executable supply-chain risk that requires publisher verification and extension allowlisting. Both risks are
+reduced by keeping an unfamiliar repository in Restricted Mode, but they have different artifacts, approval paths, and
+detection signals.
+
+## Further reading
+
+- [DPRK IT Workers](/dprk-it-workers/overview): organizational controls for DPRK-linked hiring and insider risk
+- [Integrated Development Environments](/devsecops/integrated-development-environments): extension review and general
+  IDE hardening
+- [Dependency Awareness](/supply-chain/dependency-awareness): package pinning, lockfiles, and dependency review
+- [VS Code Workspace Trust](https://code.visualstudio.com/docs/editing/workspaces/workspace-trust): official behavior
+  for Restricted Mode, tasks, settings, extensions, and AI agents
+- [VS Code automatic task controls](https://code.visualstudio.com/docs/debugtest/tasks#_run-behavior): official
+  documentation for `runOn: "folderOpen"` and `task.allowAutomaticTasks`
+- [OpenSourceMalware PolinRider technical dossier](https://github.com/OpenSourceMalware/PolinRider): campaign analysis,
+  project-file execution paths, and detection artifacts
+- [Contagious Interview technical analysis](https://kudelskisecurity.com/research/how-dprks-contagious-interview-campaign-targets-developers):
+  technical analysis of the fake-interview repository and its VS Code task trigger
+- [Model Context Protocol security best practices](https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices):
+  risks and confinement guidance for local MCP servers
+- [SLSA artifact verification](https://slsa.dev/spec/v1.2/verifying-artifacts): verifying artifact digests, signatures,
+  canonical source, builders, and provenance
+- [npm lifecycle scripts](https://docs.npmjs.com/cli/using-npm/scripts/): install-time execution behavior
+- [PyTorch model loading](https://docs.pytorch.org/docs/stable/generated/torch.load.html): warning against loading data
+  from untrusted sources
+- [Trojan Source paper](https://www.usenix.org/system/files/usenixsecurity23-boucher.pdf): analysis of bidirectional
+  Unicode control characters that can alter how source code is displayed
+- [USENIX package hallucination study](https://www.usenix.org/system/files/usenixsecurity25-spracklen.pdf): research on
+  nonexistent package names generated by coding models and the resulting package-confusion risk
+
+---
+
+<ContributeFooter />

--- a/docs/pages/supply-chain/developer-workstation-security.mdx
+++ b/docs/pages/supply-chain/developer-workstation-security.mdx
@@ -52,8 +52,9 @@ rather than passive data.
 
 ## Govern external development tools
 
-Organizations should govern extensions, MCP servers, coding agents, package-manager plugins, model loaders, and other
-external development tools throughout their lifecycle:
+Organizations should govern anything brought into the development environment from an external source throughout its
+lifecycle. This includes extensions, MCP servers, coding agents, package-manager plugins and packages, model loaders
+and model artifacts, repository-supplied configuration, and other external development inputs and tools:
 
 1. **Establish business need.** Record the approved use and why an existing capability does not meet it.
 2. **Classify risk.** Assess execution, data, update, and communication risk in the intended environment.
@@ -79,7 +80,7 @@ include:
 | Access | Permissions, accessible data, network destinations, and credential access |
 | Ownership | Review date, designated approver, tool owner, and next review date |
 | Safeguards | Required technical and operational safeguards |
-| Exception | Recorded exception reference and expiration |
+| Exception | Exception reference and expiration when applicable; otherwise, an explicit not-applicable state |
 | Exit plan | Removal and incident-response instructions |
 
 Inspection evidence should show inventory completeness, approval records, expired exceptions, periodic review
@@ -135,7 +136,7 @@ the deployed configuration and retain its results; a documented setting is not e
 - [ ] Define approved and prohibited external-tool categories and document approval criteria
 - [ ] Maintain an allowlist with tool owners, approved uses, versions, permissions, safeguards, and review dates
 - [ ] Record exceptions with scope, compensating controls, an owner, and an expiration date
-- [ ] Reassess tools after material publisher, ownership, permission, update, behavior, or incident changes
+- [ ] Periodically review inventory and enforcement evidence for version, permission, publisher, and behavior drift
 - [ ] Remove unapproved or expired tools and retain evidence of the decision and removal
 - [ ] Keep Workspace Trust enabled, leave unfamiliar folders untrusted, and require explicit approval before trusting them
 - [ ] Disable automatic workspace tasks and review task configuration before enabling it

--- a/docs/pages/supply-chain/developer-workstation-security.mdx
+++ b/docs/pages/supply-chain/developer-workstation-security.mdx
@@ -133,22 +133,23 @@ the deployed configuration and retain its results; a documented setting is not e
 
 <Checklist id="developer-workstation-supply-chain-baseline">
 
-- [ ] Define approved and prohibited external-tool categories and document approval criteria
-- [ ] Maintain an allowlist with tool owners, approved uses, versions, permissions, safeguards, and review dates
-- [ ] Record exceptions with scope, compensating controls, an owner, and an expiration date
-- [ ] Periodically review inventory and enforcement evidence for version, permission, publisher, and behavior drift
-- [ ] Reassess tools after material publisher, ownership, permission, update, behavior, or incident changes
-- [ ] Remove unapproved or expired tools and retain evidence of the decision and removal
-- [ ] Keep Workspace Trust enabled, leave unfamiliar folders untrusted, and require explicit approval before trusting them
-- [ ] Disable automatic workspace tasks and review task configuration before enabling it
-- [ ] Allowlist IDE extensions, coding-agent extensions, and MCP servers
-- [ ] Pin approved tool and dependency versions and verify integrity metadata
-- [ ] Block install-time scripts by default and document approved exceptions
-- [ ] Detect invisible Unicode and suspicious obfuscation in code and agent instruction files
-- [ ] Keep production, publishing, and treasury credentials outside untrusted development environments
-- [ ] Apply EDR and MDM controls to managed developer endpoints
-- [ ] Restrict outbound traffic from evaluation environments
-- [ ] Open untrusted projects only in disposable VMs or hardened development containers
+- [ ] Approved and prohibited external-tool categories **must** be defined, and the approval criteria documented
+- [ ] The allowlist **must** record tool owners, approved uses, versions, permissions, safeguards, and review dates
+- [ ] Exceptions **must** carry a scope, compensating controls, an owner, and an expiration date
+- [ ] Inventory and enforcement evidence **should** be reviewed for version, permission, publisher, and behavior drift
+- [ ] Tools **must** be reassessed after material publisher, ownership, permission, update, behavior, or incident changes
+- [ ] Unapproved or expired tools **must** be removed, and evidence of the decision and removal retained
+- [ ] Workspace Trust **must** stay enabled, unfamiliar folders **must** remain untrusted, and trusting one **must**
+  require explicit approval
+- [ ] Automatic workspace tasks **must** be disabled, and task configuration reviewed before enabling it
+- [ ] IDE extensions, coding-agent extensions, and MCP servers **must** be allowlisted
+- [ ] Approved tool and dependency versions **must** be pinned, and their integrity metadata verified
+- [ ] Install-time scripts **should** be blocked by default, with approved exceptions documented
+- [ ] Invisible Unicode and suspicious obfuscation **should** be detected in code and agent instruction files
+- [ ] Production, publishing, and treasury credentials **must** stay outside untrusted development environments
+- [ ] EDR and MDM controls **should** be applied to managed developer endpoints
+- [ ] Outbound traffic from evaluation environments **must** be restricted
+- [ ] Untrusted projects **must** be opened only in disposable VMs or hardened development containers
 
 </Checklist>
 

--- a/docs/pages/supply-chain/developer-workstation-security.mdx
+++ b/docs/pages/supply-chain/developer-workstation-security.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Developer Workstation Security | SEAL"
-description: "Screen repositories, IDE configuration, AI tools, and dependencies before execution to stop supply chain attacks at the developer workstation boundary."
+description: "Screen repositories, IDE configuration, AI tools, and dependencies before execution to stop supply-chain attacks at the developer workstation boundary."
 tags:
   - Engineer/Developer
   - Security Specialist
@@ -21,8 +21,9 @@ import { TagList, AttributionList, Checklist, ContributeFooter } from '../../../
 <TagList tags={frontmatter.tags} />
 <AttributionList contributors={frontmatter.contributors} />
 
-> 🔑 **Key Takeaway**: Screen untrusted development material before an IDE, package manager, model loader, or AI
-> agent interprets it. Confinement limits the damage when screening misses a malicious input.
+> 🔑 **Key Takeaway**: Screen untrusted development material before an integrated development environment (IDE),
+> package manager, model loader, or artificial intelligence (AI) agent interprets it. Confinement limits the damage
+> when screening misses a malicious input.
 
 A developer workstation is an execution boundary, not just a place to edit code. Routine actions can activate content
 from another party before a developer reaches the application entry point.
@@ -70,8 +71,8 @@ Apply the following gates in order. A failed or inconclusive gate keeps the mate
    launch and container files, Git hooks, package scripts, build plugins, MCP startup commands, agent rules and skills,
    and model-loading code. A plausible commit author or old timestamp does not defeat **forged history**; corroborate
    important revisions with signed releases, immutable object identifiers, repository audit data, or a known upstream.
-   A trusted workspace may permit **workspace auto-run**, so keep Workspace Trust disabled and automatic tasks off
-   until these files pass review.
+   A trusted workspace may permit **workspace auto-run**, so keep Workspace Trust enabled, leave the folder untrusted
+   in Restricted Mode, and require explicit approval before trusting it or enabling automatic tasks.
 
 3. **Scan and compare artifacts with reviewed source.** Run static malware, dependency, secret, and policy scans without
    importing the project. Inspect unusually large whitespace, encoded strings, binary files in source paths, and
@@ -101,7 +102,7 @@ Use endpoint detection and response (EDR) and mobile device management (MDM) to 
 
 <Checklist id="developer-workstation-supply-chain-baseline">
 
-- [ ] Require Workspace Trust or the IDE's equivalent before project features activate
+- [ ] Keep Workspace Trust enabled, leave unfamiliar folders untrusted, and require explicit approval before trusting them
 - [ ] Disable automatic workspace tasks and review task configuration before enabling it
 - [ ] Allowlist IDE extensions, coding-agent extensions, and MCP servers
 - [ ] Pin approved tool and dependency versions and verify integrity metadata
@@ -144,10 +145,13 @@ If malware may have executed, follow the immediate containment and recovery step
 
 ## Case study and related guidance
 
-The DPRK-linked **Contagious Interview** activity used convincing coding exercises and repositories to push developers
-toward installation or execution. Technical reporting on the related **PolinRider** cluster documents malicious
-project files, including `.vscode/tasks.json` entries with `runOn: "folderOpen"`, that retrieved and executed a payload
-after the workspace allowed automatic tasks.
+Activity linked to the Democratic People's Republic of Korea (DPRK), tracked as **Contagious Interview**, used
+convincing coding exercises and repositories to push developers toward installation or execution. OpenSourceMalware
+dated its related **PolinRider** dossier March 7, 2026, and last updated it April 11, 2026; a separate Contagious
+Interview repository analysis was published June 30, 2026. These are report publication and update dates, not claims
+about when the activity began or ended. The reports document malicious project files, including
+`.vscode/tasks.json` entries with `runOn: "folderOpen"`, that retrieved and executed a payload after the workspace
+allowed automatic tasks.
 
 This execution path is **repository-controlled workspace automation, not a malicious VS Code extension**. The task
 definition arrives as a project file and the IDE's built-in task runner interprets it. A malicious extension is a
@@ -158,6 +162,9 @@ detection signals.
 ## Further reading
 
 - [DPRK IT Workers](/dprk-it-workers/overview): organizational controls for DPRK-linked hiring and insider risk
+- [AI Security](/ai-security/overview): runtime controls for AI systems, coding agents, tool calls, and model use
+- [Endpoint Security](/opsec/endpoint/overview): managed endpoint provisioning, EDR, MDM, and credential-separation
+  ownership
 - [Integrated Development Environments](/devsecops/integrated-development-environments): extension review and general
   IDE hardening
 - [Dependency Awareness](/supply-chain/dependency-awareness): package pinning, lockfiles, and dependency review

--- a/docs/pages/supply-chain/developer-workstation-security.mdx
+++ b/docs/pages/supply-chain/developer-workstation-security.mdx
@@ -90,39 +90,26 @@ regulation or standard.
 
 ## Screen before execution
 
-Apply the following gates in order. A failed or inconclusive gate keeps the material in quarantine.
+[Handling Untrusted Code](/devsecops/developer-targeted-intrusions/handling-untrusted-code) owns the operator
+procedure: verify before retrieval, retrieve in isolation, inspect before tool execution, execute with bounded
+capabilities, and revalidate every update. Follow that procedure rather than a second version of it here, and see
+[Developer Machine Confinement](/devsecops/isolation/developer-machine-sandboxing) for the environment it runs in. A
+failed or inconclusive step keeps the material in quarantine.
 
-1. **Acquire without execution.** Fetch the material into a quarantine directory or disposable virtual machine (VM)
-   with IDE integration, file previews, shell directory hooks, agents, and package installation disabled. Do not start
-   a referenced MCP server or load a model merely to inspect it.
+Two governance decisions sit inside that procedure and belong to this page, because they are approvals rather than
+handling steps.
 
-2. **Inspect provenance and execution triggers.** Confirm the canonical source through an independent channel, then
-   inspect signatures, release metadata, contributors, and the exact revision. Search workspace tasks and settings,
-   launch and container files, Git hooks, package scripts, build plugins, MCP startup commands, agent rules and skills,
-   and model-loading code. A plausible commit author or old timestamp does not defeat **forged history**; corroborate
-   important revisions with signed releases, immutable object identifiers, repository audit data, or a known upstream.
-   A trusted workspace may permit **workspace auto-run**, so keep Workspace Trust enabled, leave the folder untrusted
-   in Restricted Mode, and require explicit approval before trusting it or enabling automatic tasks.
+**Approve dependencies and tools before they enter the allowlist.** Resolve every package name against the expected
+registry and publisher, including names proposed by AI tools. Confirm the item and its intended use appear in the
+managed allowlist. Pin approved dependencies, extensions, MCP servers, actions, and model revisions to immutable
+versions or digests, and verify integrity metadata. Install scripts execute during common package-manager operations,
+so block them by default and approve exceptions only after review. Mutable versions such as branches, floating tags,
+and ranges can resolve to different code after approval, so they are not a stable security decision.
 
-3. **Scan and compare artifacts with reviewed source.** Run static malware, dependency, secret, and policy scans without
-   importing the project. Inspect unusually large whitespace, encoded strings, binary files in source paths, and
-   bidirectional or invisible Unicode. **Invisible Unicode** can make displayed control flow differ from the compiled
-   source, so use a scanner or editor view that exposes code points. Compare packaged files and model artifacts with
-   reviewed source, checksums, signatures, and provenance; a clean source tree does not prove a separately built
-   artifact is identical.
-
-4. **Approve dependencies and tools.** Resolve every package name against the expected registry and publisher,
-   including names proposed by AI tools. Confirm the item and intended use appear in the managed allowlist. Pin
-   approved dependencies, extensions, MCP servers, actions, and model revisions to immutable versions or digests and
-   verify integrity metadata. **Install scripts** execute during common package-manager operations, so block them by
-   default and approve exceptions only after review. **Mutable versions** such as branches, floating tags, and ranges
-   can resolve to different code after approval; do not treat them as a stable security decision.
-
-5. **Execute only in a confined, disposable environment.** Use a fresh VM or hardened development container with no
-   production, publishing, wallet, source-control, cloud, or personal credentials. Grant only required filesystem and
-   process access, record activity, and allowlist required destinations. **Unrestricted egress** turns any missed
-   execution path into a simple channel for payload retrieval or data exfiltration. Destroy the environment after the
-   evaluation and promote only reviewed source and locked metadata.
+**Compare model artifacts against reviewed source.** A packaged model is a separately built artifact, and a clean
+source tree does not prove the two match. Compare packaged files and model artifacts with reviewed source, checksums,
+signatures, and provenance before an approval decision records the artifact as reviewed. Do not start a referenced MCP
+server or load a model merely to inspect it.
 
 ## Apply and verify baseline controls
 
@@ -197,6 +184,14 @@ a separate artifact, approval path, and detection signal.
 
 ## Further reading
 
+- [Developer-Targeted Intrusions](/devsecops/developer-targeted-intrusions/overview): threat model for the lures and
+  execution boundaries this page governs approval for
+- [Handling Untrusted Code](/devsecops/developer-targeted-intrusions/handling-untrusted-code): the operator procedure
+  for intake, isolation, inspection, first execution, and compromise response
+- [Execution Paths in Untrusted Code](/devsecops/developer-targeted-intrusions/execution-paths): the conditions that
+  turn source, Git, IDE, container, and agent inputs into execution
+- [Developer Machine Confinement](/devsecops/isolation/developer-machine-sandboxing): confining agent and IDE
+  workloads on the laptop
 - [Risk Management](/governance/risk-management): ownership patterns for risk acceptance, exception decisions, and
   recurring review
 - [Compliance & Regulatory Requirements](/governance/compliance-regulatory-requirements): adaptable compliance-

--- a/docs/pages/supply-chain/index.mdx
+++ b/docs/pages/supply-chain/index.mdx
@@ -12,6 +12,7 @@ title: "Supply Chain"
 ## Pages
 
 - [Supply Chain Security](/supply-chain/overview)
+- [Developer Workstation Security](/supply-chain/developer-workstation-security)
 - [Supply Chain Levels for Software Artifacts](/supply-chain/supply-chain-levels-software-artifacts)
 - [Dependency Awareness](/supply-chain/dependency-awareness)
 - [Web3 Supply Chain Threats](/supply-chain/web3-supply-chain-threats)

--- a/docs/pages/supply-chain/overview.mdx
+++ b/docs/pages/supply-chain/overview.mdx
@@ -56,11 +56,13 @@ This framework provides practical guidance for securing each layer of your suppl
    components by risk level and apply proportional controls.
 2. [Dependency Awareness](/supply-chain/dependency-awareness): Manage external packages securely, including version
    pinning, lockfile integrity, vulnerability scanning, and protection against typosquatting.
-3. [Web3 Supply Chain Threats](/supply-chain/web3-supply-chain-threats): The specific threat vectors that affect Web3
+3. [Developer Workstation Security](/supply-chain/developer-workstation-security): Establish the pre-execution intake
+   and screening boundary for repositories, IDE configuration, AI tools, dependencies, and model artifacts.
+4. [Web3 Supply Chain Threats](/supply-chain/web3-supply-chain-threats): The specific threat vectors that affect Web3
    projects, from front-end library hijacking to infrastructure compromise and hardware tampering.
-4. [Vendor Risk Management](/supply-chain/vendor-risk-management): Evaluate and monitor third-party providers including
+5. [Vendor Risk Management](/supply-chain/vendor-risk-management): Evaluate and monitor third-party providers including
    RPC services, oracle networks, security auditors, and contractors.
-5. [Supply Chain Incident Response](/supply-chain/incident-response-supply-chain): What to do when a dependency or
+6. [Supply Chain Incident Response](/supply-chain/incident-response-supply-chain): What to do when a dependency or
    provider is compromised, including Web3-specific response scenarios.
 
 ## Related frameworks

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -572,6 +572,11 @@ const config = {
           collapsed: true,
           items: [
             { text: 'Overview', link: '/supply-chain/overview' },
+            {
+              text: 'Developer Workstation Security',
+              link: '/supply-chain/developer-workstation-security',
+              dev: true,
+            },
             { text: 'Supply Chain Levels for Software Artifacts', link: '/supply-chain/supply-chain-levels-software-artifacts' },
             { text: 'Dependency Awareness', link: '/supply-chain/dependency-awareness' },
             { text: 'Web3 Supply Chain Threats', link: '/supply-chain/web3-supply-chain-threats' },


### PR DESCRIPTION
### What does this PR change?

Adds a developer-workstation security guide that treats repositories, IDE configuration, AI tools, MCP servers, dependencies, and model artifacts as software supply-chain inputs before execution.

The guide covers:

- governance of external development tools through request, risk review, approval, managed deployment, monitoring, reassessment, and removal
- managed allowlists, time-limited exceptions, and inspectable compliance evidence
- pre-execution screening and confined evaluation environments
- endpoint baselines, detection, incident response, and an interactive checklist
- dated, directly sourced examples covering repository automation, extension publishing, MCP packages, dependency compromise, and AI package hallucination

It also links the guidance from Supply Chain, AI Security, DevSecOps IDE, Endpoint Security, and DPRK IT Worker pages, and registers the author and navigation entry.

### Type of change
- [x] New content
- [x] Edit to existing content
- [x] Outline / structure change
- [ ] Typo or formatting fix
- [x] Tooling / config

### If applicable
- [ ] Editing existing content: tagged the current contributors from the attribution list
- [ ] Framework has a steward: asked them to review
- [x] Outline change: updated `vocs.config.ts` with the `dev: true` parameter
- [ ] Want community feedback: shared this PR in our Discord

### Verification

- `pnpm exec just lint`
- `pnpm run docs:build`
- CSpell and targeted supply-chain validation
- Interactive checklist and rendered links verified locally
- All contribution commits are signed