### PR TITLE
Fix: Make "developer-targeted intrusions" section visible on .org

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -120,23 +120,10 @@ const config = {
             {
               text: 'Developer-Targeted Intrusions',
               collapsed: false,
-              dev: true,
               items: [
-                {
-                  text: 'Overview',
-                  link: '/devsecops/developer-targeted-intrusions/overview',
-                  dev: true,
-                },
-                {
-                  text: 'Execution Paths in Untrusted Code',
-                  link: '/devsecops/developer-targeted-intrusions/execution-paths',
-                  dev: true,
-                },
-                {
-                  text: 'Handling Untrusted Code',
-                  link: '/devsecops/developer-targeted-intrusions/handling-untrusted-code',
-                  dev: true,
-                },
+                { text: 'Overview', link: '/devsecops/developer-targeted-intrusions/overview' },
+                { text: 'Execution Paths in Untrusted Code', link: '/devsecops/developer-targeted-intrusions/execution-paths' },
+                { text: 'Handling Untrusted Code', link: '/devsecops/developer-targeted-intrusions/handling-untrusted-code' },
               ],
             },
             { text: 'Code Signing', link: '/devsecops/code-signing' },


### PR DESCRIPTION
<!--
Thanks for contributing! New here? Skim the contributor guide first:
https://frameworks.securityalliance.dev/contribute/contributing
-->

### What does this PR change?
<!-- A short summary: what you changed and why. -->
<!-- Opened an issue first, or completing one? Add "Closes #123" here so the issue auto-closes when this PR merges. -->
Make "developer-targeted intrusions" section visible on .org

### Type of change
- [ ] New content
- [ ] Edit to existing content
- [ ] Outline / structure change
- [ ] Typo or formatting fix
- [ ] Tooling / config

### If applicable
- [ ] Editing existing content: tagged the current contributors from the attribution list
- [ ] Framework has a steward: asked them to review
- [ ] Outline change: updated `vocs.config.ts` with the `dev: true` parameter
- [ ] Want community feedback: shared this PR in our Discord

Stuck on anything? Just write it here and we're happy to help.
