### PR TITLE
Chore: spotlight zone upgrade

### DIFF
--- a/components/contributors/BadgeDisplay.css
+++ b/components/contributors/BadgeDisplay.css
@@ -6,15 +6,7 @@
 /* Badge Display Container */
 .badge-display {
   position: relative;
-  opacity: 1;
-  transform: translateY(0);
-  transition: all 0.6s var(--badge-easing);
   overflow: visible !important;
-}
-
-.badge-display.visible {
-  opacity: 1;
-  transform: translateY(0);
 }
 
 /* Badge Summary */
@@ -66,9 +58,9 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 48px;
-  height: 48px;
-  border-radius: 12px;
+  width: 36px;
+  height: 36px;
+  border-radius: 9px;
   border: 2px dashed var(--theme-popup-border);
   background: var(--quote-bg, rgba(0, 0, 0, 0.05));
   font-size: 0.6875rem;
@@ -97,7 +89,7 @@
 
 .badge-overflow-tooltip {
   position: absolute;
-  bottom: calc(100% + 14px);
+  top: calc(100% + 14px);
   left: 50%;
   transform: translateX(-50%);
   background: linear-gradient(135deg, #1f2937 0%, #111827 100%);
@@ -109,16 +101,27 @@
   visibility: hidden;
 }
 
-.badge-overflow-tooltip { width: max-content; }
+.badge-overflow-tooltip {
+  width: max-content;
+}
+
+.badge-overflow-tooltip::after {
+  content: '';
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  right: 0;
+  height: 16px;
+}
 
 .badge-overflow-tooltip::before {
   content: '';
   position: absolute;
-  top: 100%;
+  bottom: 100%;
   left: 50%;
   transform: translateX(-50%);
   border: 7px solid transparent;
-  border-top-color: #111827;
+  border-bottom-color: #111827;
 }
 
 .badge-overflow-chip:hover .badge-overflow-tooltip,
@@ -133,10 +136,21 @@
   justify-items: center;
 }
 
-.badge-overflow-tooltip-grid[data-cols="1"] { grid-template-columns: repeat(1, 48px); }
-.badge-overflow-tooltip-grid[data-cols="2"] { grid-template-columns: repeat(2, 48px); }
-.badge-overflow-tooltip-grid[data-cols="3"] { grid-template-columns: repeat(3, 48px); }
-.badge-overflow-tooltip-grid[data-cols="4"] { grid-template-columns: repeat(4, 48px); }
+.badge-overflow-tooltip-grid[data-cols="1"] {
+  grid-template-columns: repeat(1, 36px);
+}
+
+.badge-overflow-tooltip-grid[data-cols="2"] {
+  grid-template-columns: repeat(2, 36px);
+}
+
+.badge-overflow-tooltip-grid[data-cols="3"] {
+  grid-template-columns: repeat(3, 36px);
+}
+
+.badge-overflow-tooltip-grid[data-cols="4"] {
+  grid-template-columns: repeat(4, 36px);
+}
 
 .badge-overflow-tooltip .badge-wrapper {
   z-index: 1;
@@ -185,14 +199,22 @@
 
 /* Compact Mode */
 .badge-display.compact .badge-card {
-  width: 48px;
-  height: 48px;
-  border-radius: 12px;
+  width: 36px;
+  height: 36px;
+  border-radius: 9px;
   border-width: 2px;
 }
 
-.badge-display.compact .badge-tier-indicator {
-  display: none;
+/* Without this the 45px default icon overflows the compact card's inner box. */
+.badge-display.compact .badge-icon-container {
+  width: 26px;
+  height: 26px;
+}
+
+/* Row gap exceeds the hover lift (6px) plus the scale growth (~1.5px), so a
+   raised badge never reaches the row above it. */
+.badge-display.compact .badges-container {
+  gap: 0.625rem 0.375rem;
 }
 
 /* Category-Based Border Styling */
@@ -291,6 +313,22 @@
   animation: pulseGlow 1.5s infinite;
 }
 
+/* The indicator has to shrink with the badge, otherwise its border and ring
+   overhang the 6px gap and sit on top of the neighbouring badge. */
+.badge-display.compact .new-indicator {
+  top: -3px;
+  right: -3px;
+  width: 10px;
+  height: 10px;
+  border-width: 2px;
+  box-shadow: 0 0 0 1.5px #fbbf24, 0 1px 4px rgba(251, 191, 36, 0.5);
+}
+
+.badge-display.compact .pulse-dot {
+  width: 4px;
+  height: 4px;
+}
+
 @keyframes pulseGlow {
 
   0%,
@@ -306,32 +344,10 @@
 }
 
 /* Tier Indicator */
-.badge-tier-indicator {
-  position: absolute;
-  bottom: -4px;
-  right: -4px;
-  font-size: 0.875rem;
-  background: var(--sidebar-bg);
-  border: 2px solid var(--badge-color);
-  border-radius: 50%;
-  width: 24px;
-  height: 24px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
-  z-index: 5;
-  transition: transform 0.3s var(--badge-easing);
-}
-
-.badge-wrapper:hover .badge-tier-indicator {
-  transform: scale(1.15) rotate(12deg);
-}
-
 /* Badge Icon Container */
 .badge-icon-container {
   width: 45px;
-  height: 45x;
+  height: 45px;
   position: relative;
   transition: transform 0.4s var(--badge-easing);
   filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.1));
@@ -350,18 +366,17 @@
 /* Tooltip */
 .badge-tooltip {
   position: absolute;
-  bottom: calc(100% + 12px);
+  top: calc(100% + 12px);
   left: 50%;
   transform: translateX(-50%);
   background: linear-gradient(135deg, #1f2937 0%, #111827 100%);
   color: white;
   padding: 0.875rem;
   border-radius: 10px;
-  width: 220px;
-  max-width: 220px;
+  width: 250px;
+  max-width: 250px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(255, 255, 255, 0.1);
   z-index: 999999;
-  pointer-events: none;
   opacity: 0;
   visibility: hidden;
 }
@@ -376,7 +391,7 @@
 }
 
 :root:not([data-vocs-theme='dark']) .badge-tooltip::before {
-  border-top-color: #ffffff;
+  border-bottom-color: #ffffff;
 }
 
 :root:not([data-vocs-theme='dark']) .tooltip-description {
@@ -391,34 +406,66 @@
   color: #6b7280;
 }
 
-.badge-wrapper:hover .badge-tooltip {
+.badge-wrapper:hover .badge-tooltip,
+.badge-tooltip:hover {
   opacity: 1;
   visibility: visible;
+}
+
+.badge-tooltip::after {
+  content: '';
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  right: 0;
+  height: 14px;
 }
 
 .badge-tooltip::before {
   content: '';
   position: absolute;
-  top: 100%;
+  bottom: 100%;
   left: 50%;
   transform: translateX(-50%);
   border: 8px solid transparent;
-  border-top-color: #111827;
+  border-bottom-color: #111827;
 }
 
 .tooltip-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   margin-bottom: 0.5rem;
-  gap: 0.5rem;
+  gap: 0.625rem;
+}
+
+/* The badge, drawn large enough to actually look at. */
+.tooltip-art {
+  flex: 0 0 auto;
+  width: 52px;
+  height: 52px;
+  display: block;
+}
+
+.tooltip-art svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.25));
+}
+
+.tooltip-heading {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.3rem;
+  min-width: 0;
+  flex: 1;
 }
 
 .tooltip-header strong {
   font-weight: 700;
   font-size: 0.875rem;
   line-height: 1.3;
-  flex: 1;
   word-wrap: break-word;
 }
 
@@ -427,8 +474,7 @@
   font-weight: 800;
   padding: 0.2rem 0.4rem;
   border-radius: 4px;
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
+  letter-spacing: 0.01em;
   white-space: nowrap;
   flex-shrink: 0;
 }
@@ -453,6 +499,11 @@
   color: white;
 }
 
+.tier-badge.tier-status {
+  background: linear-gradient(135deg, #22d3ee 0%, #0891b2 100%);
+  color: #06333d;
+}
+
 .tooltip-description {
   font-size: 0.75rem;
   color: #d1d5db;
@@ -473,19 +524,6 @@
   align-items: center;
   gap: 0.375rem;
   flex-wrap: wrap;
-}
-
-/* Alternative: Position tooltip below if there's not enough space above */
-.badges-container.tooltip-below .badge-tooltip {
-  bottom: auto;
-  top: calc(100% + 12px);
-}
-
-.badges-container.tooltip-below .badge-tooltip::before {
-  top: auto;
-  bottom: 100%;
-  border-top-color: transparent;
-  border-bottom-color: #1f2937;
 }
 
 .new-badge-text {
@@ -584,7 +622,9 @@
 
 /* Dark mode adjustments for badges */
 :root[data-vocs-theme='dark'] .badge-card {
-  background: linear-gradient(135deg, var(--sidebar-bg, #1f2937) 0%, var(--quote-bg, rgba(255, 255, 255, 0.05)) 100%);
+  background:
+    linear-gradient(135deg, var(--sidebar-bg, #1f2937) 0%, var(--quote-bg, rgba(255, 255, 255, 0.05)) 100%),
+    var(--sidebar-bg, #1f2937);
   border-color: var(--theme-popup-border, #374151);
 }
 
@@ -603,20 +643,31 @@
   box-shadow: 0 0 0 2px rgb(252 211 77 / 70%), 2px 2px 3px rgba(252, 211, 77, 0.35);
 }
 
+/* The tier tints are translucent, so they need an opaque layer underneath.
+   Without it a raised badge on hover shows whatever it overlaps straight
+   through its own background. */
 :root[data-vocs-theme='dark'] .badge-wrapper.tier-legendary .badge-card {
-  background: linear-gradient(135deg, rgba(251, 191, 36, 0.2) 0%, rgba(245, 158, 11, 0.15) 100%);
+  background:
+    linear-gradient(135deg, rgba(251, 191, 36, 0.2) 0%, rgba(245, 158, 11, 0.15) 100%),
+    var(--sidebar-bg, #1f2937);
 }
 
 :root[data-vocs-theme='dark'] .badge-wrapper.tier-epic .badge-card {
-  background: linear-gradient(135deg, rgba(168, 85, 247, 0.2) 0%, rgba(147, 51, 234, 0.15) 100%);
+  background:
+    linear-gradient(135deg, rgba(168, 85, 247, 0.2) 0%, rgba(147, 51, 234, 0.15) 100%),
+    var(--sidebar-bg, #1f2937);
 }
 
 :root[data-vocs-theme='dark'] .badge-wrapper.tier-rare .badge-card {
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.2) 0%, rgba(37, 99, 235, 0.15) 100%);
+  background:
+    linear-gradient(135deg, rgba(59, 130, 246, 0.2) 0%, rgba(37, 99, 235, 0.15) 100%),
+    var(--sidebar-bg, #1f2937);
 }
 
 :root[data-vocs-theme='dark'] .badge-wrapper.tier-common .badge-card {
-  background: linear-gradient(135deg, rgba(16, 185, 129, 0.2) 0%, rgba(5, 150, 105, 0.15) 100%);
+  background:
+    linear-gradient(135deg, rgba(16, 185, 129, 0.2) 0%, rgba(5, 150, 105, 0.15) 100%),
+    var(--sidebar-bg, #1f2937);
 }
 
 :root[data-vocs-theme='dark'] .badge-wrapper.role:hover .badge-card {
@@ -638,10 +689,6 @@
   border-color: var(--sidebar-bg, #1f2937);
 }
 
-:root[data-vocs-theme='dark'] .badge-tier-indicator {
-  background: var(--sidebar-bg, #1f2937);
-}
-
 /* Responsive Design */
 @media (max-width: 768px) {
   .badge-card {
@@ -654,14 +701,22 @@
     height: 40px;
   }
 
+  /* 3 x 30px + 2 x 6px = 102px, inside ~109px of content on a 130px card. */
   .badge-display.compact .badge-card {
-    width: 40px;
-    height: 40px;
+    width: 30px;
+    height: 30px;
+    border-radius: 8px;
   }
 
   .badge-display.compact .badge-icon-container {
-    width: 28px;
-    height: 28px;
+    width: 22px;
+    height: 22px;
+  }
+
+  .badge-overflow-chip {
+    width: 30px;
+    height: 30px;
+    border-radius: 8px;
   }
 
   .badge-tooltip {
@@ -673,4 +728,28 @@
   .badges-container {
     gap: 0.5rem;
   }
+}
+
+.badge-tooltip {
+  left: 0;
+  transform: none;
+}
+
+.badge-tooltip::before {
+  left: 18px;
+  transform: none;
+}
+
+/* The overflow chip is the last thing in the row, so its tooltip is the one
+   case that opens leftward, otherwise it would hang off the right of the card. */
+.badge-overflow-tooltip {
+  left: auto;
+  right: 0;
+  transform: none;
+}
+
+.badge-overflow-tooltip::before {
+  left: auto;
+  right: 18px;
+  transform: none;
 }

--- a/components/contributors/BadgeDisplay.tsx
+++ b/components/contributors/BadgeDisplay.tsx
@@ -1,9 +1,15 @@
 "use client";
 
-import { useEffect, useRef, useState } from 'react';
 import './BadgeDisplay.css';
 import contributorsData from '../../docs/pages/config/contributors.json';
-import { getBadgeConfig, BadgeIcon } from '../shared/badgeConfig';
+import {
+  getBadgeConfig,
+  badgeIconUid,
+  BadgeIcon,
+  getTierChip,
+  isDisplayableBadge,
+  renderBadgeIcon
+} from '../shared/badgeConfig';
 
 interface Badge {
   name: string;
@@ -27,25 +33,6 @@ interface Contributor {
   badges: Badge[];
 }
 
-function useIntersectionObserver(options = {}) {
-  const [isVisible, setIsVisible] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const observer = new IntersectionObserver(([entry]) => {
-      if (entry.isIntersecting) {
-        setIsVisible(true);
-        observer.unobserve(entry.target);
-      }
-    }, options);
-
-    if (ref.current) observer.observe(ref.current);
-    return () => observer.disconnect();
-  }, []);
-
-  return [ref, isVisible] as const;
-}
-
 function isNewlyEarned(assignedDate: string): boolean {
   if (!assignedDate) return false;
   try {
@@ -63,7 +50,12 @@ function formatDate(dateString: string): string {
   if (!dateString) return '';
   try {
     const date = new Date(dateString);
-    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+    return date.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      timeZone: 'UTC'
+    });
   } catch {
     return dateString;
   }
@@ -83,8 +75,9 @@ interface BadgeDisplayProps {
   layout?: 'grid' | 'stack';
 }
 
-function BadgeCard({ badge, index, compact }: { badge: Badge; index: number; compact: boolean }) {
+function BadgeCard({ badge, index, uid }: { badge: Badge; index: number; uid: string }) {
   const config = getBadgeConfig(badge.name);
+  const tierChip = getTierChip(config);
   const effectiveDate = getBadgeDate(badge);
   const dateLabel = getBadgeDateLabel(badge);
   const isNew = isNewlyEarned(effectiveDate);
@@ -104,29 +97,26 @@ function BadgeCard({ badge, index, compact }: { badge: Badge; index: number; com
         '--badge-color': config.color,
         '--tier-glow': `${config.color}33`
       } as React.CSSProperties}
-      title={`${badgeLabel} - ${badgeDescription}`}
+      role="img"
+      aria-label={`${badgeLabel}: ${badgeDescription}`}
     >
       <div className="badge-card">
-        <BadgeIcon name={badge.name} isNew={isNew} />
+        <BadgeIcon name={badge.name} isNew={isNew} uid={uid} />
         {isNew && (
           <div className="new-indicator">
             <span className="pulse-dot"></span>
-          </div>
-        )}
-        {!compact && (
-          <div className="badge-tier-indicator">
-            {config.tier === 'legendary' && '👑'}
-            {config.tier === 'epic' && '💎'}
-            {config.tier === 'rare' && '⭐'}
           </div>
         )}
       </div>
 
       <div className="badge-tooltip">
         <div className="tooltip-header">
-          <strong>{badgeLabel}</strong>
-          <span className={`tier-badge tier-${config.tier}`}>
-            {config.tier?.toUpperCase()}
+          <span className="tooltip-art" aria-hidden="true">
+            {renderBadgeIcon(badge.name, `${uid}-tip`)}
+          </span>
+          <span className="tooltip-heading">
+            <strong>{badgeLabel}</strong>
+            <span className={`tier-badge ${tierChip.className}`}>{tierChip.text}</span>
           </span>
         </div>
         <p className="tooltip-description">{badgeDescription}</p>
@@ -150,17 +140,15 @@ export function BadgeDisplay({
   showCount = false,
   layout = 'grid'
 }: BadgeDisplayProps) {
-  const [containerRef, isVisible] = useIntersectionObserver({ threshold: 0.1 });
-
   let displayBadges: Badge[] = [];
 
   if (badges) {
-    displayBadges = badges.filter(b => b.name && b.name.trim() !== '');
+    displayBadges = badges.filter(b => isDisplayableBadge(b.name));
   } else if (contributorSlug) {
     const contributors = contributorsData as unknown as Record<string, Contributor>;
     const contributor = contributors[contributorSlug];
     if (contributor?.badges) {
-      displayBadges = contributor.badges.filter(b => b.name && b.name.trim() !== '');
+      displayBadges = contributor.badges.filter(b => isDisplayableBadge(b.name));
     }
   }
 
@@ -184,10 +172,7 @@ export function BadgeDisplay({
   }
 
   return (
-    <div
-      ref={containerRef}
-      className={`badge-display ${compact ? 'compact' : ''} ${layout} ${isVisible ? 'visible' : ''}`}
-    >
+    <div className={`badge-display ${compact ? 'compact' : ''} ${layout}`}>
       {showCount && !compact && (
         <div className="badge-summary">
           <span className="badge-count">{displayBadges.length}</span>
@@ -197,7 +182,12 @@ export function BadgeDisplay({
 
       <div className={`badges-container ${layout}`}>
         {visibleBadges.map((badge, index) => (
-          <BadgeCard key={`${badge.name}-${badge.framework || ''}-${index}`} badge={badge} index={index} compact={compact} />
+          <BadgeCard
+            key={`${badge.name}-${badge.framework || ''}-${index}`}
+            badge={badge}
+            index={index}
+            uid={badgeIconUid('b', contributorSlug, index)}
+          />
         ))}
         {hiddenBadges.length > 0 && (() => {
           const count = hiddenBadges.length;
@@ -208,7 +198,12 @@ export function BadgeDisplay({
               <div className="badge-overflow-tooltip" data-cols={cols}>
                 <div className="badge-overflow-tooltip-grid" data-cols={cols}>
                   {hiddenBadges.map((badge, index) => (
-                    <BadgeCard key={`overflow-${badge.name}-${badge.framework || ''}-${index}`} badge={badge} index={index} compact={true} />
+                    <BadgeCard
+                      key={`overflow-${badge.name}-${badge.framework || ''}-${index}`}
+                      badge={badge}
+                      index={index}
+                      uid={badgeIconUid('o', contributorSlug, index)}
+                    />
                   ))}
                 </div>
               </div>

--- a/components/contributors/BadgeLegend.css
+++ b/components/contributors/BadgeLegend.css
@@ -1,14 +1,150 @@
 /* Badge Legend Styles */
 .badge-legend {
-  margin-top: 3rem;
-  padding: 2rem;
+  margin: 2rem 0;
+  padding: 0;
   background: var(--sidebar-bg, #f9fafb);
-  border-radius: 16px;
+  border-radius: 12px;
   border: 1px solid var(--theme-popup-border, #e5e7eb);
+  border-left: 3px solid #a855f7;
+  overflow: hidden;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.badge-legend-title.vocs_H2 {
-  margin-bottom: 0.75rem;
+.badge-legend[open] {
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+/* Disclosure header: always visible, collapsed by default */
+.badge-legend-summary {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  cursor: pointer;
+  list-style: none;
+  padding: 0.875rem 1.25rem;
+  transition: background 0.2s ease;
+}
+
+.badge-legend-summary:hover {
+  background: rgba(0, 0, 0, 0.03);
+}
+
+/* Replace the default triangle with our own so it can sit at the end */
+.badge-legend-summary::-webkit-details-marker {
+  display: none;
+}
+
+.badge-legend-summary:focus-visible {
+  outline: 2px solid #a855f7;
+  outline-offset: -2px;
+}
+
+.badge-legend-heading {
+  display: flex;
+  align-items: baseline;
+  gap: 0.625rem;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.badge-legend .badge-legend-title {
+  margin: 0;
+  padding: 0;
+  border: none;
+  font-size: 1.0625rem;
+  font-weight: 650;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  color: var(--fg, #111827);
+}
+
+.badge-legend-hint {
+  font-size: 0.8125rem;
+  color: var(--fg, #6b7280);
+  opacity: 0.6;
+}
+
+/* Preview of a few real badges, so the closed row shows what it holds */
+.badge-legend-preview {
+  display: flex;
+  align-items: center;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.badge-legend-preview-icon {
+  width: 26px;
+  height: 26px;
+  display: block;
+  margin-left: -7px;
+  opacity: 0.9;
+  transition: transform 0.2s ease, margin 0.2s ease;
+}
+
+.badge-legend-preview-icon:first-child {
+  margin-left: 0;
+}
+
+.badge-legend-preview-icon svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+/* Fan the stack out slightly on hover */
+.badge-legend-summary:hover .badge-legend-preview-icon {
+  margin-left: -3px;
+  opacity: 1;
+}
+
+.badge-legend-summary:hover .badge-legend-preview-icon:first-child {
+  margin-left: 0;
+}
+
+.badge-legend[open] .badge-legend-preview {
+  display: none;
+}
+
+.badge-legend-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  flex-shrink: 0;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--fg, #6b7280);
+  opacity: 0.55;
+  transition: opacity 0.2s ease;
+}
+
+.badge-legend[open] .badge-legend-toggle {
+  margin-left: auto;
+}
+
+.badge-legend-summary:hover .badge-legend-toggle {
+  opacity: 0.85;
+}
+
+.badge-legend[open] .badge-legend-toggle-label {
+  visibility: hidden;
+}
+
+.badge-legend-chevron {
+  width: 0.45rem;
+  height: 0.45rem;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: translateY(-2px) rotate(45deg);
+  transition: transform 0.2s ease;
+}
+
+.badge-legend[open] .badge-legend-chevron {
+  transform: translateY(1px) rotate(-135deg);
+}
+
+.badge-legend-body {
+  padding: 0.25rem 1.25rem 1.5rem;
 }
 
 .badge-legend-intro {
@@ -102,10 +238,31 @@
 
 .badge-item {
   display: flex;
-  flex-direction: column;
-  gap: 0.125rem;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.75rem;
   padding: 0.5rem 0;
   border-bottom: 1px solid var(--theme-popup-border, rgba(0, 0, 0, 0.08));
+}
+
+.badge-item-icon {
+  width: 34px;
+  height: 34px;
+  flex-shrink: 0;
+  display: block;
+}
+
+.badge-item-icon svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.badge-item-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  min-width: 0;
 }
 
 .badge-item:last-child {
@@ -152,8 +309,15 @@
 }
 
 @keyframes arrow-bounce {
-  0%, 100% { transform: translateX(0); }
-  50% { transform: translateX(3px); }
+
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+
+  50% {
+    transform: translateX(3px);
+  }
 }
 
 /* Visual indicator in legend note */
@@ -178,14 +342,34 @@
 }
 
 @keyframes legend-pulse {
-  0%, 100% { opacity: 1; transform: scale(1); }
-  50% { opacity: 0.6; transform: scale(0.8); }
+
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  50% {
+    opacity: 0.6;
+    transform: scale(0.8);
+  }
 }
 
 /* Dark mode adjustments */
 :root[data-vocs-theme='dark'] .badge-legend {
   background: #1b1b1b;
-  border-color: var(--theme-popup-border, #374151);
+  /* Per side: the shorthand would repaint the left accent stripe too */
+  border-top-color: var(--theme-popup-border, #374151);
+  border-right-color: var(--theme-popup-border, #374151);
+  border-bottom-color: var(--theme-popup-border, #374151);
+}
+
+:root[data-vocs-theme='dark'] .badge-legend-summary:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+:root[data-vocs-theme='dark'] .badge-legend .badge-legend-title {
+  color: var(--fg, #f9fafb);
 }
 
 :root[data-vocs-theme='dark'] .badge-legend-intro {
@@ -231,6 +415,17 @@
   color: var(--fg, #9ca3af);
 }
 
+:root[data-vocs-theme='dark'] .legend-block-title,
+:root[data-vocs-theme='dark'] .legend-tier-meaning,
+:root[data-vocs-theme='dark'] .legend-rule-list li {
+  color: var(--fg, #f9fafb);
+}
+
+:root[data-vocs-theme='dark'] .legend-block-intro,
+:root[data-vocs-theme='dark'] .legend-tier-members {
+  color: var(--fg, #9ca3af);
+}
+
 :root[data-vocs-theme='dark'] .badge-legend-note {
   background: rgba(251, 191, 36, 0.15);
   color: #fcd34d;
@@ -242,7 +437,131 @@
     grid-template-columns: 1fr;
   }
 
+  .badge-legend-summary {
+    gap: 0.625rem;
+  }
+
+  /* Not enough room for the preview stack next to the title */
+  .badge-legend-preview {
+    display: none;
+  }
+
+  .badge-legend-toggle {
+    margin-left: auto;
+  }
+
   .badge-legend-category.milestone {
     height: auto;
+  }
+}
+
+/* ---- Tiers and rules ---- */
+
+.badge-legend-tiers,
+.badge-legend-rules {
+  margin-top: 1.5rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--theme-popup-border, rgba(0, 0, 0, 0.08));
+}
+
+.legend-block-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--fg, #111827);
+  margin: 0 0 0.375rem;
+}
+
+.legend-block-intro {
+  font-size: 0.9375rem;
+  line-height: 1.55;
+  color: var(--fg, #6b7280);
+  opacity: 0.8;
+  margin: 0 0 0.875rem;
+}
+
+.legend-tier-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.625rem;
+}
+
+.legend-tier-row {
+  display: grid;
+  grid-template-columns: 5.5rem minmax(0, 1fr);
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.legend-tier-row .tier-badge {
+  justify-self: start;
+  align-self: center;
+}
+
+.legend-tier-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.legend-tier-meaning {
+  font-size: 0.875rem;
+  line-height: 1.45;
+  color: var(--fg, #111827);
+}
+
+.legend-tier-members {
+  font-size: 0.75rem;
+  line-height: 1.5;
+  color: var(--fg, #6b7280);
+  opacity: 0.7;
+}
+
+.legend-rule-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.legend-rule-list li {
+  font-size: 0.875rem;
+  line-height: 1.55;
+  padding-left: 0.875rem;
+  position: relative;
+  color: var(--fg, #111827);
+}
+
+.legend-rule-list li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.55em;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.35;
+}
+
+.legend-rule-list strong {
+  font-weight: 650;
+}
+
+.legend-inline-chip {
+  display: inline-block;
+  padding: 0.05rem 0.3rem;
+  border-radius: 4px;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  background: rgba(148, 163, 184, 0.22);
+}
+
+@media (max-width: 600px) {
+  .legend-tier-row {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.25rem;
   }
 }

--- a/components/contributors/BadgeLegend.tsx
+++ b/components/contributors/BadgeLegend.tsx
@@ -1,13 +1,24 @@
 import './BadgeLegend.css';
-import { BADGE_CONFIG, BadgeCategory } from '../shared/badgeConfig';
+import './BadgeDisplay.css';
+import {
+  BADGE_CONFIG,
+  badgeIconUid,
+  renderBadgeIcon,
+  isDisplayableBadge,
+  BadgeCategory,
+  BadgeTier
+} from '../shared/badgeConfig';
 
-// Convert BADGE_CONFIG to array format for the legend
-const BADGE_LEGEND = Object.entries(BADGE_CONFIG).map(([name, config]) => ({
-  name,
-  label: config.label,
-  description: config.description,
-  category: config.category
-}));
+// Convert BADGE_CONFIG to array format for the legend. Badges that never draw
+// on a card have nothing to explain here; their effect is covered in the rules.
+const BADGE_LEGEND = Object.entries(BADGE_CONFIG)
+  .filter(([name]) => isDisplayableBadge(name))
+  .map(([name, config]) => ({
+    name,
+    label: config.label,
+    description: config.description,
+    category: config.category
+  }));
 
 const CATEGORY_INFO: Record<BadgeCategory, { label: string; color: string; description: string }> = {
   role: {
@@ -27,6 +38,35 @@ const CATEGORY_INFO: Record<BadgeCategory, { label: string; color: string; descr
   }
 };
 
+const PREVIEW_BADGES = ['Lead', 'Contributor-25', 'Reviewer-10', 'Active-Last-7d']
+  .filter(isDisplayableBadge);
+
+const TIER_ORDER: BadgeTier[] = ['legendary', 'epic', 'rare', 'common'];
+
+const TIER_INFO: Record<BadgeTier, string> = {
+  legendary: 'The rarest thing on this page. Handed to the few people who carry a framework, or the project itself, on their back.',
+  epic: 'Twenty-five deep. Years of showing up, and a very short list of holders.',
+  rare: 'Ten and counting. The rung where someone stops being a visitor and starts being a regular.',
+  common: 'Where everyone starts, including everyone above. The only badge nobody can take back is the first one.'
+};
+
+const STATUS_ROW = {
+  key: 'status',
+  label: 'Status',
+  meaning: 'Says who is around right now, and it changes as people come and go.'
+};
+
+function tierMembers(tier: BadgeTier): string {
+  const labels = Object.values(BADGE_CONFIG)
+    .filter(c => c.tier === tier && c.category !== 'activity')
+    .map(c => c.label);
+  return Array.from(new Set(labels)).join(', ');
+}
+
+function statusMembers(): string {
+  return BADGE_LEGEND.filter(b => b.category === 'activity').map(b => b.label).join(', ');
+}
+
 function CategoryCard({ category }: { category: BadgeCategory }) {
   const info = CATEGORY_INFO[category];
   const badges = BADGE_LEGEND.filter(b => b.category === category);
@@ -45,8 +85,13 @@ function CategoryCard({ category }: { category: BadgeCategory }) {
       <div className="badge-list">
         {badges.map((badge) => (
           <div key={badge.name} className="badge-item">
-            <span className="badge-label">{badge.label}</span>
-            <span className="badge-description">{badge.description}</span>
+            <span className="badge-item-icon" aria-hidden="true">
+              {renderBadgeIcon(badge.name, badgeIconUid('legend', badge.name))}
+            </span>
+            <span className="badge-item-text">
+              <span className="badge-label">{badge.label}</span>
+              <span className="badge-description">{badge.description}</span>
+            </span>
           </div>
         ))}
       </div>
@@ -56,55 +101,90 @@ function CategoryCard({ category }: { category: BadgeCategory }) {
 
 export function BadgeLegend() {
   return (
-    <div className="badge-legend">
-      <h2 id="badge-legend" data-v="" className="badge-legend-title">
-        Badge Legend
-        <a className="heading-anchor" href="#badge-legend" aria-label="Link to this section">
-          <svg
-            className="heading-anchor-icon"
-            xmlns="http://www.w3.org/2000/svg"
-            width="0.75em"
-            height="0.75em"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
-            <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
-          </svg>
-        </a>
-      </h2>
-      <p className="badge-legend-intro">
-        Contributors earn badges based on their participation and achievements.
-        Badges are color-coded by category and sorted chronologically on each contributor's card.
-      </p>
+    <details className="badge-legend">
+      <summary className="badge-legend-summary">
+        <span className="badge-legend-heading">
+          <h2 id="badge-legend" data-v="" className="badge-legend-title">
+            Badge Legend
+          </h2>
+          <span className="badge-legend-hint">What each badge means</span>
+        </span>
 
-      <div className="badge-legend-categories">
-        {/* Left column: Role + Activity*/}
-        <div className="badge-legend-column">
-          <CategoryCard category="role" />
-          <CategoryCard category="activity" />
+        <span className="badge-legend-preview" aria-hidden="true">
+          {PREVIEW_BADGES.map((name) => (
+            <span key={name} className="badge-legend-preview-icon">
+              {renderBadgeIcon(name, badgeIconUid('legend-preview', name))}
+            </span>
+          ))}
+        </span>
+
+        <span className="badge-legend-toggle" aria-hidden="true">
+          <span className="badge-legend-toggle-label">Open</span>
+          <span className="badge-legend-chevron" />
+        </span>
+      </summary>
+
+      <div className="badge-legend-body">
+        <p className="badge-legend-intro">
+          Contributors earn badges based on their participation and achievements.
+          Badges are color-coded by category and sorted chronologically on each contributor's card.
+        </p>
+
+        <div className="badge-legend-categories">
+          {/* Left column: Role + Activity*/}
+          <div className="badge-legend-column">
+            <CategoryCard category="role" />
+            <CategoryCard category="activity" />
+          </div>
+
+          {/* Right column: Milestone */}
+          <div className="badge-legend-column">
+            <CategoryCard category="milestone" />
+          </div>
         </div>
 
-        {/* Right column: Milestone */}
-        <div className="badge-legend-column">
-          <CategoryCard category="milestone" />
+        <div className="badge-legend-tiers">
+          <h3 className="legend-block-title">Tiers</h3>
+          <p className="legend-block-intro">
+            Every badge carries one, shown on its tooltip. They are ranked by how much of the project
+            the badge stands for, and the ladder is the same for everyone: today&rsquo;s Legendary
+            holders all started at the bottom of it.
+          </p>
+          <ul className="legend-tier-list">
+            {TIER_ORDER.map((tier) => (
+              <li key={tier} className="legend-tier-row">
+                <span className={`tier-badge tier-${tier}`}>
+                  {tier.charAt(0).toUpperCase()}{tier.slice(1)}
+                </span>
+                <span className="legend-tier-text">
+                  <span className="legend-tier-meaning">{TIER_INFO[tier]}</span>
+                  <span className="legend-tier-members">{tierMembers(tier)}</span>
+                </span>
+              </li>
+            ))}
+            {/* Activity badges are not ranked, so Status closes the list rather
+                than sitting inside it. */}
+            <li className="legend-tier-row">
+              <span className="tier-badge tier-status">{STATUS_ROW.label}</span>
+              <span className="legend-tier-text">
+                <span className="legend-tier-meaning">{STATUS_ROW.meaning}</span>
+                <span className="legend-tier-members">{statusMembers()}</span>
+              </span>
+            </li>
+          </ul>
+        </div>
+
+        <div className="badge-legend-note">
+          <span className="legend-note-text">
+            <strong>Badges earned within the last 30 days display a golden pulsing indicator</strong>
+          </span>
+          <span className="legend-note-arrow">→</span>
+          <span className="legend-new-indicator">
+            <span className="legend-pulse-dot"></span>
+          </span>
         </div>
       </div>
-
-      <div className="badge-legend-note">
-        <span className="legend-note-text">
-          <strong>Badges earned within the last 30 days display a golden pulsing indicator</strong>
-        </span>
-        <span className="legend-note-arrow">→</span>
-        <span className="legend-new-indicator">
-          <span className="legend-pulse-dot"></span>
-        </span>
-      </div>
-    </div>
+    </details>
   );
 }
 

--- a/components/contributors/Contributors.css
+++ b/components/contributors/Contributors.css
@@ -104,26 +104,14 @@
 
 .contributors-group h2 {
   margin-bottom: 2rem;
-  padding-bottom: 0.75rem;
-  border-bottom: 3px solid var(--theme-popup-border);
   position: relative;
-}
-
-.contributors-group h2::after {
-  content: '';
-  position: absolute;
-  bottom: -3px;
-  left: 0;
-  width: 60px;
-  height: 3px;
-  background: linear-gradient(90deg, rgba(128, 128, 128, 0.25), transparent);
 }
 
 /* Grid Layout */
 .contributors-page-list {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 0.75rem;
   padding: 0 0.5rem;
   max-width: 1400px;
 }
@@ -133,9 +121,10 @@
   background: var(--sidebar-bg);
   border: 1px solid var(--theme-popup-border);
   border-radius: 6px;
-  padding: 0.75rem 0.625rem;
+  padding: 0.5rem;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
   transition: all 0.2s ease, z-index 0s 0.2s;
+  z-index: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -144,11 +133,13 @@
   position: relative;
   min-height: 0;
   min-width: 0;
-  isolation: isolate;
 }
 
 .contributors-page-card:hover {
   transform: translateY(-3px);
+  /* Above neighbouring cards only. See the stacking note below. */
+  z-index: 3;
+  transition: all 0.2s ease, z-index 0s;
 }
 
 /* Content wrapper */
@@ -170,8 +161,8 @@
 }
 
 .contributors-page-avatar {
-  width: 60px;
-  height: 60px;
+  width: 52px;
+  height: 52px;
   border-radius: 50%;
   object-fit: cover;
   border: 2px solid var(--theme-popup-border);
@@ -203,13 +194,14 @@
   box-shadow: 0 4px 12px rgba(168, 85, 247, 0.4);
 }
 
-/* Role badge overlay on avatar corner */
+/* Role badge overlay on avatar corner.
+   Offset tracks the avatar: half its width (26px) plus a 6px overhang. */
 .role-badge-overlay {
   position: absolute;
   bottom: -4px;
-  right: calc(50% - 38px);
-  width: 26px;
-  height: 26px;
+  right: calc(50% - 32px);
+  width: 22px;
+  height: 22px;
   z-index: 3;
   cursor: pointer;
 }
@@ -370,10 +362,10 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.25rem;
-  font-size: 0.75rem;
+  gap: 0.125rem;
+  font-size: 0.7rem;
   color: var(--fg);
-  padding: 0.5rem 0.75rem;
+  padding: 0.375rem 0.5rem;
   border: 1px solid var(--theme-popup-border);
   border-radius: 6px;
   width: 100%;
@@ -381,7 +373,7 @@
 }
 
 .steward-label {
-  font-size: 0.7rem;
+  font-size: 0.65rem;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -437,24 +429,10 @@
 
 /* Badge Display Section */
 .contributors-page-badges {
-  padding-top: 0.75rem;
+  padding-top: 0.5rem;
   border-top: 1px solid var(--theme-popup-border);
   width: 100%;
   margin-top: auto;
-}
-
-.contributors-page-badges::before {
-  content: '';
-  position: absolute;
-  top: -2px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 60px;
-  height: 2px;
-  background: linear-gradient(90deg,
-      transparent,
-      rgba(128, 128, 128, 0.25),
-      transparent);
 }
 
 .contributors-page-card:hover .contributors-page-badges {
@@ -478,7 +456,7 @@
 .contributors-page-card:has(.role-badge-overlay:hover),
 .contributors-page-card:has(.avatar-wrapper:hover),
 .contributors-page-card:has(.contributor-hover-card:hover) {
-  z-index: 99999;
+  z-index: 3;
   transition-delay: 0s;
   isolation: auto;
 }
@@ -535,15 +513,13 @@
 
 .contributors-group .contributors-page-card {
   border-left: 4px solid #a855f7;
-  border-right: 1px solid #ffffff17;
-  border-bottom: 1px solid #ffffff17;
 }
 
 /* Contributor hover card (shown when hovering avatar) */
 .contributor-hover-card {
   position: absolute;
-  /* sit right next to the avatar: 50% of avatar-wrapper (card center) + half-avatar (30px) */
-  left: calc(50% + 50px);
+  /* sit right next to the avatar: 50% of avatar-wrapper (card center) + half-avatar (26px) */
+  left: calc(50% + 46px);
   top: 50%;
   transform: translateY(-50%);
   width: 230px;
@@ -598,14 +574,13 @@
   line-height: 1.2;
 }
 
+/* Job titles wrap onto as many lines as they need. Truncating them to a single
+   line hid most of the text, which is the only place it appears. */
 .hover-card-job-title {
   font-size: 0.7rem;
   color: #9ca3af;
   font-style: italic;
-  line-height: 1.2;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  line-height: 1.35;
 }
 
 .hover-card-company {
@@ -642,16 +617,32 @@
   box-shadow: 0 8px 24px rgba(15, 23, 42, 0.12), 0 0 0 1px rgba(15, 23, 42, 0.06);
 }
 
-:root:not([data-vocs-theme='dark']) .hover-card-name    { color: #111827; }
-:root:not([data-vocs-theme='dark']) .hover-card-job-title { color: #6b7280; }
+:root:not([data-vocs-theme='dark']) .hover-card-name {
+  color: #111827;
+}
+
+:root:not([data-vocs-theme='dark']) .hover-card-job-title {
+  color: #6b7280;
+}
+
 :root:not([data-vocs-theme='dark']) .hover-card-company {
   color: #374151;
   background: rgba(15, 23, 42, 0.05);
   border-color: rgba(15, 23, 42, 0.1);
 }
-:root:not([data-vocs-theme='dark']) .hover-card-steward  { color: #2563eb; }
-:root:not([data-vocs-theme='dark']) .hover-card-description { color: #4b5563; border-top-color: rgba(15, 23, 42, 0.08); }
-:root:not([data-vocs-theme='dark']) .hover-card-avatar   { border-color: rgba(15, 23, 42, 0.15); }
+
+:root:not([data-vocs-theme='dark']) .hover-card-steward {
+  color: #2563eb;
+}
+
+:root:not([data-vocs-theme='dark']) .hover-card-description {
+  color: #4b5563;
+  border-top-color: rgba(15, 23, 42, 0.08);
+}
+
+:root:not([data-vocs-theme='dark']) .hover-card-avatar {
+  border-color: rgba(15, 23, 42, 0.15);
+}
 
 /* Corner Accent for elite contributors */
 .corner-accent {
@@ -706,40 +697,32 @@
   }
 
   .contributors-page-list {
-    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-    gap: 0.75rem;
+    grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+    gap: 0.625rem;
     padding: 0;
   }
 
   .contributors-page-card {
-    padding: 0.625rem 0.5rem;
+    padding: 0.5rem 0.375rem;
   }
 
   .contributors-page-avatar {
-    width: 52px;
-    height: 52px;
+    width: 44px;
+    height: 44px;
   }
 
-  .avatar-badge {
-    right: calc(50% - 30px - 6px);
-    width: 22px;
-    height: 22px;
-    font-size: 0.75rem;
+  .role-badge-overlay {
+    right: calc(50% - 28px);
+    width: 20px;
+    height: 20px;
+  }
+
+  .contributor-hover-card {
+    left: calc(50% + 42px);
   }
 
   .contributors-page-badges {
-    margin: 1rem 0 0.5rem;
-    padding-top: 1rem;
-  }
-}
-
-@media (min-width: 769px) and (max-width: 1024px) {
-  .contributors-page-list {
-    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-    gap: 0.875rem;
-  }
-
-  .stat-number {
-    font-size: 2.5rem;
+    margin-top: auto;
+    padding-top: 0.5rem;
   }
 }

--- a/components/contributors/Contributors.tsx
+++ b/components/contributors/Contributors.tsx
@@ -1,7 +1,7 @@
 import contributorsData from '../../docs/pages/config/contributors.json';
 import './Contributors.css';
 import BadgeDisplay from './BadgeDisplay';
-import { getBadgeConfig, BADGE_ICONS } from '../shared/badgeConfig';
+import { getBadgeConfig, badgeIconUid, renderBadgeIcon, isDisplayableBadge } from '../shared/badgeConfig';
 
 interface Badge {
   name: string;
@@ -43,7 +43,7 @@ function formatFrameworks(frameworks: string[]): string {
 function getRoleBadgeInfo(role: string, badges: Badge[]): { label: string; badgeName: string; color: string; description: string; tier: string } | null {
   if (role === 'lead') {
     const config = getBadgeConfig('Lead');
-    return { label: 'Lead', badgeName: 'Lead', color: config.color, description: config.description, tier: config.tier || 'epic' };
+    return { label: 'Lead', badgeName: 'Lead', color: config.color, description: config.description, tier: config.tier || 'legendary' };
   }
   if (role === 'core') {
     const config = getBadgeConfig('Core-Contributor');
@@ -66,7 +66,7 @@ function getRoleBadgeInfo(role: string, badges: Badge[]): { label: string; badge
 }
 
 // Helper component for role badge overlay
-function RoleBadgeOverlay({ role, badges }: { role: string; badges: Badge[] }) {
+function RoleBadgeOverlay({ role, badges, slug }: { role: string; badges: Badge[]; slug: string }) {
   const roleInfo = getRoleBadgeInfo(role, badges);
   if (!roleInfo) return null;
   return (
@@ -75,7 +75,7 @@ function RoleBadgeOverlay({ role, badges }: { role: string; badges: Badge[] }) {
       style={{ '--role-color': roleInfo.color } as React.CSSProperties}
     >
       <div className="role-badge-icon-svg">
-        {BADGE_ICONS[roleInfo.badgeName] || BADGE_ICONS['default']}
+        {renderBadgeIcon(roleInfo.badgeName, badgeIconUid('role', slug))}
       </div>
       <span className="role-badge-simple-tooltip">{roleInfo.label}</span>
     </div>
@@ -127,40 +127,68 @@ function StewardInfo({ badges }: { badges: Badge[] }) {
   );
 }
 
-// Get activity status from badges: 'active' | 'dormant' | 'none'
-function getActivityStatus(badges: Badge[]): 'active' | 'dormant' | 'none' {
-  const hasActive = badges.some(b =>
+type ActivityStatus = 'active' | 'neutral' | 'dormant' | 'unbadged';
+
+// Display order: contributors who are actually active, then those who simply
+// carry no activity badge, then dormant ones, then those with no badges at all.
+const ACTIVITY_PRIORITY: Record<ActivityStatus, number> = {
+  active: 0,
+  neutral: 1,
+  dormant: 2,
+  unbadged: 3
+};
+
+// Nearly everyone holds these two, so they say nothing about a contributor
+// relative to their peers. They still render on the card; they just don't earn
+// a better position in the list.
+const BASELINE_BADGES = new Set(['First-Contribution', 'Dormant-90d+']);
+
+function hasEarnedBadges(badges: Badge[]): boolean {
+  return badges.some(b => b.name && b.name.trim() !== '' && !BASELINE_BADGES.has(b.name));
+}
+
+function getActivityStatus(badges: Badge[]): ActivityStatus {
+  // Match the filter BadgeDisplay renders with, so "no badges" here means the
+  // card genuinely shows none.
+  const named = badges.filter(b => b.name && b.name.trim() !== '');
+  if (named.length === 0) return 'unbadged';
+
+  const hasActive = named.some(b =>
     b.name === 'Active-Last-7d' || b.name === 'Active-Last-30d'
   );
   if (hasActive) return 'active';
 
-  const hasDormant = badges.some(b => b.name === 'Dormant-90d+');
+  const hasDormant = named.some(b => b.name === 'Dormant-90d+');
   if (hasDormant) return 'dormant';
 
-  return 'none';
+  return 'neutral';
 }
 
 // Get the most recent activity date from badges
 function getLastActivityDate(badges: Badge[]): Date | null {
-  const activityBadge = badges.find(b =>
-    b.name === 'Active-Last-7d' || b.name === 'Active-Last-30d' || b.name === 'Dormant-90d+'
-  );
-  if (activityBadge?.lastActive) {
-    return new Date(activityBadge.lastActive);
-  }
-  return null;
+  const timestamps = badges
+    .filter(b =>
+      b.name === 'Active-Last-7d' || b.name === 'Active-Last-30d' || b.name === 'Dormant-90d+'
+    )
+    .map(b => (b.lastActive ? new Date(b.lastActive).getTime() : NaN))
+    .filter(t => !Number.isNaN(t));
+
+  return timestamps.length > 0 ? new Date(Math.max(...timestamps)) : null;
 }
 
-// Sort contributors by activity within their group
+// Sort contributors within their group: those who earned something beyond the
+// baseline badges lead, then by activity, then by recency.
 function sortByActivity(contributors: Contributor[]): Contributor[] {
   return [...contributors].sort((a, b) => {
+    const earnedA = hasEarnedBadges(a.badges || []);
+    const earnedB = hasEarnedBadges(b.badges || []);
+    if (earnedA !== earnedB) return earnedA ? -1 : 1;
+
     const statusA = getActivityStatus(a.badges || []);
     const statusB = getActivityStatus(b.badges || []);
 
-    // Priority: active > none > dormant
-    const priority = { active: 0, none: 1, dormant: 2 };
-    if (priority[statusA] !== priority[statusB]) {
-      return priority[statusA] - priority[statusB];
+    if (ACTIVITY_PRIORITY[statusA] !== ACTIVITY_PRIORITY[statusB]) {
+      return ACTIVITY_PRIORITY[statusA] - ACTIVITY_PRIORITY[statusB];
     }
 
     // Within same status, sort by most recent activity date (newest first)
@@ -261,7 +289,7 @@ export function Contributors() {
                       loading="lazy"
                     />
                     {(contributor.role === 'lead' || contributor.role === 'core' || contributor.role === 'steward') && (
-                      <RoleBadgeOverlay role={contributor.role} badges={contributor.badges || []} />
+                      <RoleBadgeOverlay role={contributor.role} badges={contributor.badges || []} slug={contributor.slug} />
                     )}
                     <ContributorHoverCard contributor={contributor} />
                   </div>
@@ -278,10 +306,15 @@ export function Contributors() {
                     <StewardInfo badges={contributor.badges || []} />
                   )}
 
-                  {/* Badges display */}
-                  {contributor.badges && contributor.badges.length > 0 && (
+                  {/* Badges display. Dormant is recorded but never drawn, so a
+                      contributor carrying only that must not get an empty row. */}
+                  {(contributor.badges || []).some(b => isDisplayableBadge(b.name)) && (
                     <div className="contributors-page-badges">
-                      <BadgeDisplay badges={contributor.badges} compact={true} />
+                      <BadgeDisplay
+                        badges={contributor.badges}
+                        contributorSlug={contributor.slug}
+                        compact={true}
+                      />
                     </div>
                   )}
 

--- a/components/shared/badgeConfig.tsx
+++ b/components/shared/badgeConfig.tsx
@@ -21,7 +21,7 @@ export const BADGE_CONFIG: Record<string, BadgeConfigItem> = {
     category: 'role',
     label: 'Lead',
     description: 'Initiative lead and project maintainer',
-    tier: 'epic'
+    tier: 'legendary'
   },
   'Framework-Steward': {
     color: '#3b82f6',
@@ -38,21 +38,21 @@ export const BADGE_CONFIG: Record<string, BadgeConfigItem> = {
     tier: 'legendary'
   },
   'Contributor-25': {
-    color: '#ec4899',
+    color: '#f59e0b',
     category: 'milestone',
-    label: 'Diamond Contributor',
+    label: 'Gold Contributor',
     description: '25+ merged contributions',
     tier: 'epic'
   },
   'Contributor-10': {
-    color: '#f59e0b',
+    color: '#9ca3af',
     category: 'milestone',
-    label: 'Gold Contributor',
+    label: 'Silver Contributor',
     description: '10+ merged contributions',
     tier: 'rare'
   },
   'Contributor-5': {
-    color: '#fb923c',
+    color: '#b45309',
     category: 'milestone',
     label: 'Bronze Contributor',
     description: '5+ merged contributions',
@@ -61,35 +61,37 @@ export const BADGE_CONFIG: Record<string, BadgeConfigItem> = {
   'Reviewer-10': {
     color: '#8b5cf6',
     category: 'milestone',
-    label: 'Skilled Reviewer',
+    label: 'Trusted Reviewer',
     description: '10+ code reviews completed',
     tier: 'rare'
   },
   'Reviewer-25': {
     color: '#a855f7',
     category: 'milestone',
-    label: 'Review Master',
+    label: 'Senior Reviewer',
     description: '25+ code reviews completed',
     tier: 'epic'
   },
+  // Reporter -> Observer -> Investigator -> Analyst. Each rung is a bare noun;
+  // the description under it says which activity it counts.
   'Issue-Opener-5': {
     color: '#06b6d4',
     category: 'milestone',
-    label: 'Issue Reporter',
+    label: 'Reporter',
     description: '5+ issues opened',
     tier: 'common'
   },
   'Issue-Opener-10': {
     color: '#0ea5e9',
     category: 'milestone',
-    label: 'Active Reporter',
+    label: 'Observer',
     description: '10+ issues opened',
     tier: 'rare'
   },
   'Issue-Opener-25': {
     color: '#3b82f6',
     category: 'milestone',
-    label: 'Master Reporter',
+    label: 'Investigator',
     description: '25+ issues opened',
     tier: 'epic'
   },
@@ -164,537 +166,332 @@ export function getBadgeConfig(badgeName: string): BadgeConfigItem {
   };
 }
 
-export const BADGE_ICONS: Record<string, JSX.Element> = {
-  // FRAMEWORK STEWARD - Shield with gear/cog representing maintenance & protection
-  'Framework-Steward': (
-    <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <defs>
-        <linearGradient id="steward-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="#3b82f6" />
-          <stop offset="100%" stopColor="#1e40af" />
-        </linearGradient>
-        <linearGradient id="steward-inner" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="#60a5fa" />
-          <stop offset="100%" stopColor="#3b82f6" />
-        </linearGradient>
-      </defs>
-      {/* Shield shape */}
-      <path d="M32 4L8 14V30C8 44 18 54 32 60C46 54 56 44 56 30V14L32 4Z"
-        fill="url(#steward-grad)" className="badge-main" />
-      <path d="M32 8L12 16V30C12 42 20 50 32 56C44 50 52 42 52 30V16L32 8Z"
-        fill="url(#steward-inner)" opacity="0.3" />
-      {/* Gear/cog icon - represents maintenance */}
-      <circle cx="32" cy="32" r="8" fill="white" opacity="0.95" />
-      <circle cx="32" cy="32" r="5" fill="#1e40af" />
-      {/* Gear teeth */}
-      {[0, 45, 90, 135, 180, 225, 270, 315].map((angle, i) => {
-        const rad = (angle * Math.PI) / 180;
-        const x = 32 + Math.cos(rad) * 12;
-        const y = 32 + Math.sin(rad) * 12;
-        return <circle key={i} cx={x} cy={y} r="3" fill="white" opacity="0.9" />;
-      })}
-      {/* Crown on top - leadership */}
-      <path d="M24 18L28 14L32 18L36 14L40 18L38 22H26L24 18Z" fill="#fbbf24" />
-    </svg>
-  ),
+/**
+ * Badges that are recorded and used, but never drawn on a card. Empty for now;
+ * add a badge name here to keep it working in the sort and the data while
+ * keeping it off the page.
+ */
+export const HIDDEN_BADGES = new Set<string>();
 
-  // CORE CONTRIBUTOR - Star with connected nodes (network/core team)
-  'Core-Contributor': (
-    <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <defs>
-        <linearGradient id="core-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="#fbbf24" />
-          <stop offset="100%" stopColor="#d97706" />
-        </linearGradient>
-        <filter id="core-glow">
-          <feGaussianBlur stdDeviation="2" result="blur" />
-          <feMerge><feMergeNode in="blur" /><feMergeNode in="SourceGraphic" /></feMerge>
-        </filter>
-      </defs>
-      {/* Outer star burst */}
-      <path d="M32 2L38 22L58 22L42 36L48 56L32 44L16 56L22 36L6 22L26 22L32 2Z"
-        fill="url(#core-grad)" className="badge-main" />
-      {/* Core hub - center */}
-      <circle cx="32" cy="32" r="10" fill="white" filter="url(#core-glow)" />
-      <circle cx="32" cy="32" r="6" fill="#d97706" />
-      {/* Connected nodes - representing team */}
-      <circle cx="20" cy="24" r="4" fill="white" opacity="0.9" />
-      <circle cx="44" cy="24" r="4" fill="white" opacity="0.9" />
-      <circle cx="20" cy="40" r="4" fill="white" opacity="0.9" />
-      <circle cx="44" cy="40" r="4" fill="white" opacity="0.9" />
-      {/* Connection lines */}
-      <line x1="24" y1="26" x2="28" y2="30" stroke="white" strokeWidth="2" opacity="0.7" />
-      <line x1="40" y1="26" x2="36" y2="30" stroke="white" strokeWidth="2" opacity="0.7" />
-      <line x1="24" y1="38" x2="28" y2="34" stroke="white" strokeWidth="2" opacity="0.7" />
-      <line x1="40" y1="38" x2="36" y2="34" stroke="white" strokeWidth="2" opacity="0.7" />
-    </svg>
-  ),
+export function isDisplayableBadge(badgeName: string | undefined): boolean {
+  return !!badgeName && badgeName.trim() !== '' && !HIDDEN_BADGES.has(badgeName);
+}
 
-  // LEAD - Compass/direction representing leadership and guiding the project
-  'Lead': (
-    <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+/**
+ * What the tooltip prints where the tier goes.
+ *
+ * Activity badges describe a status rather than an achievement, so giving them
+ * a rarity said that being new, or being quiet, was a common drop. They get the
+ * word Status instead. Everything else prints its rank as-is.
+ */
+export function getTierChip(config: BadgeConfigItem): { text: string; className: string } {
+  if (config.category === 'activity') {
+    return { text: 'Status', className: 'tier-status' };
+  }
+  const tier = config.tier || 'common';
+  return {
+    text: `${tier.charAt(0).toUpperCase()}${tier.slice(1)}`,
+    className: `tier-${tier}`
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* Shared geometry and helpers                                          */
+/* ------------------------------------------------------------------ */
+
+const SHIELD = 'M32 4L8 14V30C8 44 18 54 32 60C46 54 56 44 56 30V14L32 4Z';
+const SHIELD_INNER = 'M32 8L12 16V30C12 42 20 50 32 56C44 50 52 42 52 30V16L32 8Z';
+const STAR = 'M32 2L38 22L58 22L42 36L48 56L32 44L16 56L22 36L6 22L26 22L32 2Z';
+const HEX = 'M32 3L55.5 16.5V43.5L32 57L8.5 43.5V16.5Z';
+const OCTAGON = 'M22 6L42 6L58 22L58 42L42 58L22 58L6 42L6 22Z';
+
+// Numbers on a badge are read at 36px, so they need a UI face rather than the
+// document serif Vocs sets on the page.
+const NUM_FONT = 'system-ui, -apple-system, Segoe UI, sans-serif';
+
+function Grad({ id, from, to, mid }: { id: string; from: string; to: string; mid?: string }) {
+  return (
+    <linearGradient id={id} x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stopColor={from} />
+      {mid && <stop offset="50%" stopColor={mid} />}
+      <stop offset="100%" stopColor={to} />
+    </linearGradient>
+  );
+}
+
+function Sheen({ id }: { id: string }) {
+  return (
+    <linearGradient id={id} x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stopColor="white" stopOpacity="0.5" />
+      <stop offset="50%" stopColor="white" stopOpacity="0" />
+      <stop offset="100%" stopColor="white" stopOpacity="0.5" />
+    </linearGradient>
+  );
+}
+
+const Svg = ({ children }: { children: React.ReactNode }) => (
+  <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">{children}</svg>
+);
+
+const Squircle = ({ id }: { id: string }) => (
+  <rect x="4" y="4" width="56" height="56" rx="16" fill={`url(#${id})`} className="badge-main" />
+);
+
+/* A four-point spark, the "this was the first one" accent. */
+const Spark = ({ x, y, r, fill = '#fbbf24', opacity = 1 }: { x: number; y: number; r: number; fill?: string; opacity?: number }) => (
+  <path
+    d={`M${x} ${y - r}L${x + r * 0.32} ${y - r * 0.32}L${x + r} ${y}L${x + r * 0.32} ${y + r * 0.32}L${x} ${y + r}L${x - r * 0.32} ${y + r * 0.32}L${x - r} ${y}L${x - r * 0.32} ${y - r * 0.32}Z`}
+    fill={fill}
+    opacity={opacity}
+  />
+);
+
+/* ------------------------------------------------------------------ */
+/* Milestone ladder palettes                                            */
+/* ------------------------------------------------------------------ */
+
+type Level = 5 | 10 | 25;
+
+interface Metal { light: string; mid: string; dark: string; ribbon: string; ink: string }
+
+// Bronze at 5, silver at 10, gold at 25, matching the labels in BADGE_CONFIG.
+const METALS: Record<Level, Metal> = {
+  5: { light: '#f0a75e', mid: '#d9822b', dark: '#96501a', ribbon: '#8a4513', ink: '#ffffff' },
+  10: { light: '#f8fafc', mid: '#cbd5e1', dark: '#94a3b8', ribbon: '#64748b', ink: '#334155' },
+  25: { light: '#fde68a', mid: '#fbbf24', dark: '#d97706', ribbon: '#b45309', ink: '#7c2d12' }
+};
+
+const REVIEW_HUES: Record<number, [string, string, string]> = {
+  10: ['#a78bfa', '#6d28d9', '#5b21b6'],
+  25: ['#8b5cf6', '#4c1d95', '#3b0764']
+};
+
+const ISSUE_HUES: Record<Level, [string, string, string]> = {
+  5: ['#22d3ee', '#0891b2', '#0e7490'],
+  10: ['#38bdf8', '#0369a1', '#075985'],
+  25: ['#60a5fa', '#1d4ed8', '#1e40af']
+};
+
+/* ------------------------------------------------------------------ */
+/* Icon builders                                                        */
+/* ------------------------------------------------------------------ */
+
+/** Contribution medal: ribbon, metal disc, code brackets, the threshold. */
+const contributorMedal = (uid: string, level: Level) => {
+  const m = METALS[level];
+  return (
+    <Svg>
       <defs>
-        <linearGradient id="lead-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="#ec4899" />
-          <stop offset="100%" stopColor="#be185d" />
-        </linearGradient>
-        <linearGradient id="lead-inner" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="#f472b6" />
-          <stop offset="100%" stopColor="#ec4899" />
-        </linearGradient>
+        <Grad id={`${uid}-m`} from={m.light} mid={m.mid} to={m.dark} />
+        <Sheen id={`${uid}-s`} />
       </defs>
-      {/* Outer circle badge */}
-      <circle cx="32" cy="32" r="28" fill="url(#lead-grad)" className="badge-main" />
-      {/* Inner compass ring */}
-      <circle cx="32" cy="32" r="20" fill="white" opacity="0.95" />
-      <circle cx="32" cy="32" r="16" stroke="#be185d" strokeWidth="2" fill="none" opacity="0.3" />
-      {/* Compass needle - pointing up (North/direction) */}
-      <path d="M32 14L38 32L32 28L26 32L32 14Z" fill="#be185d" />
-      <path d="M32 50L26 32L32 36L38 32L32 50Z" fill="#f9a8d4" />
-      {/* Center dot */}
-      <circle cx="32" cy="32" r="4" fill="#be185d" />
+      <path d="M20 2L32 20L44 2L49 2L38 23L32 27L26 23L15 2Z" fill={m.ribbon} />
+      <circle cx="32" cy="41" r="21" fill={`url(#${uid}-m)`} className="badge-main" />
+      <circle cx="32" cy="41" r="21" fill={`url(#${uid}-s)`} />
+      <circle cx="32" cy="41" r="17.5" stroke="white" strokeWidth="1.5" opacity="0.45" />
+      <g stroke={m.ink} strokeWidth="2.6" strokeLinecap="round" strokeLinejoin="round" opacity="0.85">
+        <path d="M26.5 27.5L23 31L26.5 34.5" />
+        <path d="M37.5 27.5L41 31L37.5 34.5" />
+      </g>
+      <text x="32" y="52.5" fontSize="21" fontWeight="800" fill={m.ink} textAnchor="middle" fontFamily={NUM_FONT}>
+        {level}
+      </text>
+    </Svg>
+  );
+};
+
+/** Reviewer: an approved changelist, three lines, three checks. */
+const reviewerHex = (uid: string, level: 10 | 25) => {
+  const [from, to, ink] = REVIEW_HUES[level];
+  return (
+    <Svg>
+      <defs><Grad id={`${uid}-o`} from={from} to={to} /></defs>
+      <path d={HEX} fill={`url(#${uid}-o)`} className="badge-main" />
+      <path d="M32 8L51 19V41L32 52L13 41V19Z" stroke="white" strokeWidth="1.5" opacity="0.28" />
+      {[14, 23.5, 33].map((y, i) => (
+        <g key={y}>
+          <path
+            d={`M15 ${y + 4.5}L18.5 ${y + 8}L25 ${y + 1}`}
+            stroke="#34d399"
+            strokeWidth="3.4"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          <rect x="29" y={y + 3} width={i === 2 ? 12 : 20} height="3.6" rx="1.8" fill="white" opacity={0.9 - i * 0.16} />
+        </g>
+      ))}
+      <circle cx="32" cy="45" r="11.5" fill="white" />
+      <text x="32" y="50.2" fontSize="14.5" fontWeight="800" fill={ink} textAnchor="middle" fontFamily={NUM_FONT}>
+        {level}
+      </text>
+    </Svg>
+  );
+};
+
+/** Issue ladder: the octagon, the bug, the threshold. */
+const issueOctagon = (uid: string, level: Level) => {
+  const [from, to, ink] = ISSUE_HUES[level];
+  return (
+    <Svg>
+      <defs><Grad id={`${uid}-o`} from={from} to={to} /></defs>
+      <path d={OCTAGON} fill={`url(#${uid}-o)`} className="badge-main" />
+      <ellipse cx="32" cy="25" rx="10.5" ry="11.5" fill="white" />
+      <g stroke={to} strokeWidth="1.8" opacity="0.55">
+        <path d="M22 21H42M22 29H42" />
+      </g>
+      <circle cx="32" cy="13.5" r="6" fill="white" />
+      <circle cx="29.4" cy="12.8" r="1.9" fill={to} />
+      <circle cx="34.6" cy="12.8" r="1.9" fill={to} />
+      <g stroke="white" strokeWidth="3.2" strokeLinecap="round">
+        <path d="M28.2 9.2L25.5 5.5M35.8 9.2L38.5 5.5" />
+        <path d="M22 19.5L13.5 15.5M42 19.5L50.5 15.5M22 30.5L13.5 34.5M42 30.5L50.5 34.5" />
+      </g>
+      <circle cx="32" cy="46.5" r="11.5" fill="white" />
+      <text x="32" y="51.7" fontSize="14.5" fontWeight="800" fill={ink} textAnchor="middle" fontFamily={NUM_FONT}>
+        {level}
+      </text>
+    </Svg>
+  );
+};
+
+export const BADGE_ICONS: Record<string, (uid: string) => JSX.Element> = {
+  // LEAD - Compass: leadership is pointing the project somewhere.
+  'Lead': (uid: string) => (
+    <Svg>
+      <defs><Grad id={`${uid}-o`} from="#f472b6" to="#be185d" /></defs>
+      <circle cx="32" cy="32" r="28" fill={`url(#${uid}-o)`} className="badge-main" />
+      <circle cx="32" cy="32" r="21" fill="white" />
+      <circle cx="32" cy="32" r="16.5" stroke="#be185d" strokeWidth="2" opacity="0.22" />
+      <path d="M32 13L39.5 32L32 27.5L24.5 32Z" fill="#be185d" />
+      <path d="M32 51L24.5 32L32 36.5L39.5 32Z" fill="#f9a8d4" />
+      <circle cx="32" cy="32" r="4.8" fill="#be185d" />
       <circle cx="32" cy="32" r="2" fill="white" />
-      {/* Cardinal direction markers */}
-      <circle cx="32" cy="16" r="2" fill="#be185d" />
-      <circle cx="32" cy="48" r="2" fill="#be185d" opacity="0.5" />
-      <circle cx="16" cy="32" r="2" fill="#be185d" opacity="0.5" />
-      <circle cx="48" cy="32" r="2" fill="#be185d" opacity="0.5" />
-      {/* Star accent */}
-      <path d="M50 12L52 16L56 16L53 19L54 23L50 20L46 23L47 19L44 16L48 16L50 12Z" fill="#fbbf24" />
-    </svg>
+      <path d="M50 9L52.4 14.4L58 15L53.8 18.8L55 24.4L50 21.6L45 24.4L46.2 18.8L42 15L47.6 14.4Z" fill="#fbbf24" />
+    </Svg>
   ),
 
-  // CONTRIBUTOR-5 - Bronze medal with code brackets
-  'Contributor-5': (
-    <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  // FRAMEWORK STEWARD - Shield and gear, with the approval check at the hub.
+  'Framework-Steward': (uid: string) => (
+    <Svg>
       <defs>
-        <linearGradient id="bronze-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="#d97706" />
-          <stop offset="50%" stopColor="#b45309" />
-          <stop offset="100%" stopColor="#92400e" />
-        </linearGradient>
-        <linearGradient id="bronze-shine" x1="0%" y1="0%" x2="100%" y2="0%">
-          <stop offset="0%" stopColor="#fbbf24" stopOpacity="0.4" />
-          <stop offset="50%" stopColor="#fbbf24" stopOpacity="0" />
-          <stop offset="100%" stopColor="#fbbf24" stopOpacity="0.4" />
-        </linearGradient>
+        <Grad id={`${uid}-o`} from="#60a5fa" to="#1d4ed8" />
+        <Grad id={`${uid}-i`} from="#93c5fd" to="#3b82f6" />
       </defs>
-      {/* Ribbon */}
-      <path d="M24 4L32 16L40 4L44 4L38 20L32 24L26 20L20 4Z" fill="#c2410c" opacity="0.9" />
-      <path d="M28 4L32 12L36 4" stroke="#fbbf24" strokeWidth="1" opacity="0.5" />
-      {/* Medal circle */}
-      <circle cx="32" cy="38" r="20" fill="url(#bronze-grad)" className="badge-main" />
-      <circle cx="32" cy="38" r="20" fill="url(#bronze-shine)" />
-      <circle cx="32" cy="38" r="16" stroke="#fbbf24" strokeWidth="1" opacity="0.3" />
-      {/* Code brackets < > representing contributions */}
-      <path d="M24 32L18 38L24 44" stroke="white" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
-      <path d="M40 32L46 38L40 44" stroke="white" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
-      {/* Number 5 */}
-      <text x="32" y="43" fontSize="14" fill="white" fontWeight="bold" textAnchor="middle" fontFamily="sans-serif">5</text>
-    </svg>
+      <path d={SHIELD} fill={`url(#${uid}-o)`} className="badge-main" />
+      <path d={SHIELD_INNER} fill={`url(#${uid}-i)`} opacity="0.3" />
+      {[0, 45, 90, 135].map((a) => (
+        <rect key={a} x="28.5" y="15" width="7" height="34" rx="3.5" fill="white" transform={`rotate(${a} 32 32)`} />
+      ))}
+      <circle cx="32" cy="32" r="12.5" fill="white" />
+      <circle cx="32" cy="32" r="9" fill="#1d4ed8" />
+      <path d="M27.6 32.4L30.6 35.4L36.4 28.9" stroke="white" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
+    </Svg>
   ),
 
-  // CONTRIBUTOR-10 - Silver medal with merge icon
-  'Contributor-10': (
-    <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <defs>
-        <linearGradient id="silver-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="#e5e7eb" />
-          <stop offset="50%" stopColor="#9ca3af" />
-          <stop offset="100%" stopColor="#6b7280" />
-        </linearGradient>
-        <linearGradient id="silver-shine" x1="0%" y1="0%" x2="100%" y2="0%">
-          <stop offset="0%" stopColor="white" stopOpacity="0.5" />
-          <stop offset="50%" stopColor="white" stopOpacity="0" />
-          <stop offset="100%" stopColor="white" stopOpacity="0.5" />
-        </linearGradient>
-      </defs>
-      {/* Ribbon */}
-      <path d="M22 4L32 18L42 4L46 4L38 22L32 26L26 22L18 4Z" fill="#4b5563" opacity="0.9" />
-      <path d="M32 8L26 4M32 8L38 4" stroke="#9ca3af" strokeWidth="1" opacity="0.6" />
-      {/* Medal */}
-      <circle cx="32" cy="40" r="20" fill="url(#silver-grad)" className="badge-main" />
-      <circle cx="32" cy="40" r="20" fill="url(#silver-shine)" />
-      <circle cx="32" cy="40" r="16" stroke="white" strokeWidth="1" opacity="0.4" />
-      {/* Git merge icon */}
-      <circle cx="26" cy="34" r="3" fill="white" />
-      <circle cx="38" cy="34" r="3" fill="white" />
-      <circle cx="32" cy="48" r="3" fill="white" />
-      <path d="M26 37V42C26 45 28 48 32 48M38 37V40C38 43 36 46 32 48" stroke="white" strokeWidth="2" />
-      {/* Number */}
-      <text x="32" y="43" fontSize="10" fill="#4b5563" fontWeight="bold" textAnchor="middle">10</text>
-    </svg>
+  // CORE TEAM - The star, with a concentric core.
+  'Core-Contributor': (uid: string) => (
+    <Svg>
+      <defs><Grad id={`${uid}-o`} from="#fcd34d" to="#d97706" /></defs>
+      <path d={STAR} fill={`url(#${uid}-o)`} className="badge-main" />
+      <circle cx="32" cy="32" r="13.5" fill="white" />
+      <circle cx="32" cy="32" r="9.5" fill="#d97706" />
+      <circle cx="32" cy="32" r="4.5" fill="white" />
+    </Svg>
   ),
 
-  // CONTRIBUTOR-25 - Gold medal with diamond & pull request icon
-  'Contributor-25': (
-    <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <defs>
-        <linearGradient id="gold-medal-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="#fcd34d" />
-          <stop offset="50%" stopColor="#fbbf24" />
-          <stop offset="100%" stopColor="#d97706" />
-        </linearGradient>
-        <linearGradient id="gold-shine" x1="0%" y1="0%" x2="100%" y2="0%">
-          <stop offset="0%" stopColor="white" stopOpacity="0.6" />
-          <stop offset="50%" stopColor="white" stopOpacity="0" />
-          <stop offset="100%" stopColor="white" stopOpacity="0.6" />
-        </linearGradient>
-      </defs>
-      {/* Premium ribbon */}
-      <path d="M20 2L32 20L44 2L48 2L38 24L32 28L26 24L16 2Z" fill="#b45309" opacity="0.9" />
-      <path d="M24 4L32 16L40 4" stroke="#fcd34d" strokeWidth="1" opacity="0.7" />
-      {/* Stars on ribbon */}
-      <circle cx="24" cy="8" r="2" fill="#fcd34d" />
-      <circle cx="32" cy="6" r="2" fill="#fcd34d" />
-      <circle cx="40" cy="8" r="2" fill="#fcd34d" />
-      {/* Medal */}
-      <circle cx="32" cy="42" r="20" fill="url(#gold-medal-grad)" className="badge-main" />
-      <circle cx="32" cy="42" r="20" fill="url(#gold-shine)" />
-      <circle cx="32" cy="42" r="16" stroke="white" strokeWidth="1.5" opacity="0.5" />
-      {/* Diamond shape in center */}
-      <path d="M32 30L42 42L32 54L22 42Z" fill="white" opacity="0.95" />
-      <path d="M32 30L37 38H27L32 30Z" fill="#ec4899" opacity="0.8" />
-      <path d="M27 38L32 54L22 42L27 38ZM37 38L32 54L42 42L37 38Z" fill="#be185d" opacity="0.6" />
-      {/* Number */}
-      <text x="32" y="47" fontSize="12" fill="#be185d" fontWeight="bold" textAnchor="middle">25</text>
-    </svg>
+  'Contributor-5': (uid: string) => contributorMedal(uid, 5),
+  'Contributor-10': (uid: string) => contributorMedal(uid, 10),
+  'Contributor-25': (uid: string) => contributorMedal(uid, 25),
+
+  'Reviewer-10': (uid: string) => reviewerHex(uid, 10),
+  'Reviewer-25': (uid: string) => reviewerHex(uid, 25),
+
+  'Issue-Opener-5': (uid: string) => issueOctagon(uid, 5),
+  'Issue-Opener-10': (uid: string) => issueOctagon(uid, 10),
+  'Issue-Opener-25': (uid: string) => issueOctagon(uid, 25),
+
+  // EARLY CONTRIBUTOR - Here before the project had a shape.
+  'Early-Contributor': (uid: string) => (
+    <Svg>
+      <defs><Grad id={`${uid}-o`} from="#fbbf24" to="#b45309" /></defs>
+      <circle cx="32" cy="32" r="28" fill={`url(#${uid}-o)`} className="badge-main" />
+      <path d="M32 7C32 7 42 20 42 33C42 41 37.5 47 32 47C26.5 47 22 41 22 33C22 20 32 7 32 7Z" fill="white" />
+      <circle cx="32" cy="26" r="5.5" fill="#b45309" />
+      <path d="M22 37L13.5 46.5L22 48Z" fill="white" />
+      <path d="M42 37L50.5 46.5L42 48Z" fill="white" />
+      <path d="M26.5 47.5L32 60L37.5 47.5Z" fill="#ef4444" />
+      <path d="M29.3 47.5L32 55.5L34.7 47.5Z" fill="#fde68a" />
+    </Svg>
   ),
 
-  // REVIEWER-10 - Document with checkmarks
-  'Reviewer-10': (
-    <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <defs>
-        <linearGradient id="review10-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="#8b5cf6" />
-          <stop offset="100%" stopColor="#6d28d9" />
-        </linearGradient>
-      </defs>
-      {/* Hexagon badge */}
-      <path d="M32 4L54 18V46L32 60L10 46V18L32 4Z" fill="url(#review10-grad)" className="badge-main" />
-      {/* Document */}
-      <rect x="20" y="14" width="24" height="32" rx="2" fill="white" opacity="0.95" />
-      <path d="M40 14L44 18V14H40Z" fill="#6d28d9" opacity="0.3" />
-      {/* Code/text lines */}
-      <rect x="24" y="22" width="16" height="2" rx="1" fill="#6d28d9" opacity="0.3" />
-      <rect x="24" y="28" width="12" height="2" rx="1" fill="#6d28d9" opacity="0.3" />
-      <rect x="24" y="34" width="14" height="2" rx="1" fill="#6d28d9" opacity="0.3" />
-      {/* Checkmarks - reviewed */}
-      <circle cx="26" cy="23" r="4" fill="#10b981" />
-      <path d="M24 23L25.5 24.5L28 22" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-      <circle cx="26" cy="35" r="4" fill="#10b981" />
-      <path d="M24 35L25.5 36.5L28 34" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-      {/* Number badge */}
-      <circle cx="44" cy="48" r="10" fill="#fbbf24" />
-      <text x="44" y="52" fontSize="10" fill="white" fontWeight="bold" textAnchor="middle">10</text>
-    </svg>
+  // FIRST CONTRIBUTION - One date, one gold star.
+  'First-Contribution': (uid: string) => (
+    <Svg>
+      <defs><Grad id={`${uid}-o`} from="#a78bfa" mid="#7c3aed" to="#5b21b6" /></defs>
+      <path d={SHIELD} fill={`url(#${uid}-o)`} className="badge-main" />
+      <path d={SHIELD_INNER} fill="white" opacity="0.14" />
+      <rect x="15" y="17" width="34" height="32" rx="4.5" fill="white" />
+      <path d="M15 21.5A4.5 4.5 0 0 1 19.5 17h25A4.5 4.5 0 0 1 49 21.5V27H15Z" fill="#6d28d9" />
+      <rect x="21.5" y="12" width="4.5" height="10" rx="2.25" fill="white" />
+      <rect x="38" y="12" width="4.5" height="10" rx="2.25" fill="white" />
+      <path
+        d="M32 28.5L34.9 35.6L42.5 36.1L36.6 41L38.5 48.4L32 44.2L25.5 48.4L27.4 41L21.5 36.1L29.1 35.6Z"
+        fill="#fbbf24"
+      />
+    </Svg>
   ),
 
-  // REVIEWER-25 - Stack of reviewed documents with star
-  'Reviewer-25': (
-    <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <defs>
-        <linearGradient id="review25-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="#a855f7" />
-          <stop offset="100%" stopColor="#7c3aed" />
-        </linearGradient>
-      </defs>
-      {/* Star burst background */}
-      <path d="M32 2L38 20L56 24L42 36L46 54L32 44L18 54L22 36L8 24L26 20L32 2Z"
-        fill="url(#review25-grad)" className="badge-main" />
-      {/* Stacked documents */}
-      <rect x="22" y="22" width="20" height="26" rx="1" fill="white" opacity="0.6" transform="rotate(-5 32 35)" />
-      <rect x="22" y="20" width="20" height="26" rx="1" fill="white" opacity="0.8" transform="rotate(3 32 33)" />
-      <rect x="22" y="18" width="20" height="26" rx="1" fill="white" opacity="0.95" />
-      {/* Document lines */}
-      <rect x="25" y="24" width="14" height="2" rx="1" fill="#7c3aed" opacity="0.3" />
-      <rect x="25" y="29" width="10" height="2" rx="1" fill="#7c3aed" opacity="0.3" />
-      <rect x="25" y="34" width="12" height="2" rx="1" fill="#7c3aed" opacity="0.3" />
-      {/* Big checkmark */}
-      <path d="M26 32L30 36L38 26" stroke="#10b981" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
-      {/* Number badge */}
-      <circle cx="46" cy="46" r="10" fill="#fbbf24" />
-      <text x="46" y="50" fontSize="10" fill="white" fontWeight="bold" textAnchor="middle">25</text>
-    </svg>
+  // FIRST REVIEW - A review comment, not a document, so it cannot be mistaken
+  // for the Reviewer hexagon.
+  'First-Review': (uid: string) => (
+    <Svg>
+      <defs><Grad id={`${uid}-o`} from="#34d399" mid="#059669" to="#065f46" /></defs>
+      <path d={SHIELD} fill={`url(#${uid}-o)`} className="badge-main" />
+      <path d={SHIELD_INNER} fill="white" opacity="0.14" />
+      <path d="M18 16h28a4.5 4.5 0 0 1 4.5 4.5v15A4.5 4.5 0 0 1 46 40H34l-7.5 7.5V40H18a4.5 4.5 0 0 1-4.5-4.5v-15A4.5 4.5 0 0 1 18 16Z" fill="white" />
+      <path d="M23.5 28.5L28.5 33.5L39.5 22.5" stroke="#047857" strokeWidth="4.6" strokeLinecap="round" strokeLinejoin="round" />
+      <Spark x={45} y={46} r={7.5} />
+    </Svg>
   ),
 
-  // ISSUE-OPENER-5 - Bug with magnifying glass
-  'Issue-Opener-5': (
-    <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <defs>
-        <linearGradient id="issue5-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="#06b6d4" />
-          <stop offset="100%" stopColor="#0891b2" />
-        </linearGradient>
-      </defs>
-      {/* Octagon */}
-      <path d="M22 6L42 6L58 22L58 42L42 58L22 58L6 42L6 22L22 6Z" fill="url(#issue5-grad)" className="badge-main" />
-      {/* Bug body */}
-      <ellipse cx="32" cy="32" rx="12" ry="14" fill="white" opacity="0.95" />
-      {/* Bug segments */}
-      <line x1="20" y1="28" x2="44" y2="28" stroke="#0891b2" strokeWidth="1.5" />
-      <line x1="20" y1="36" x2="44" y2="36" stroke="#0891b2" strokeWidth="1.5" />
-      {/* Bug head */}
-      <circle cx="32" cy="20" r="6" fill="white" />
-      <circle cx="29" cy="19" r="2" fill="#0891b2" />
-      <circle cx="35" cy="19" r="2" fill="#0891b2" />
-      {/* Antennae */}
-      <path d="M28 14L24 8" stroke="white" strokeWidth="2" strokeLinecap="round" />
-      <path d="M36 14L40 8" stroke="white" strokeWidth="2" strokeLinecap="round" />
-      {/* Bug legs */}
-      <path d="M20 26L14 22" stroke="white" strokeWidth="2" strokeLinecap="round" />
-      <path d="M44 26L50 22" stroke="white" strokeWidth="2" strokeLinecap="round" />
-      <path d="M20 38L14 42" stroke="white" strokeWidth="2" strokeLinecap="round" />
-      <path d="M44 38L50 42" stroke="white" strokeWidth="2" strokeLinecap="round" />
-      {/* Number */}
-      <circle cx="46" cy="50" r="8" fill="#fbbf24" />
-      <text x="46" y="54" fontSize="10" fill="white" fontWeight="bold" textAnchor="middle">5</text>
-    </svg>
+  // ACTIVE-LAST-7D - Rounded square, glyph, duration as large white text.
+  'Active-Last-7d': (uid: string) => (
+    <Svg>
+      <defs><Grad id={`${uid}-active7-grad`} from="#34d399" to="#047857" /></defs>
+      <Squircle id={`${uid}-active7-grad`} />
+      <path d="M35 8L20.5 31H29L27 44L43.5 22H34.5Z" fill="white" />
+      <text x="32" y="56" fontSize="15" fontWeight="800" fill="white" textAnchor="middle" fontFamily={NUM_FONT}>7d</text>
+    </Svg>
   ),
 
-  // ISSUE-OPENER-10 - Alert/warning icon with exclamation
-  'Issue-Opener-10': (
-    <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <defs>
-        <linearGradient id="issue10-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="#0ea5e9" />
-          <stop offset="100%" stopColor="#0284c7" />
-        </linearGradient>
-      </defs>
-      {/* Circle */}
-      <circle cx="32" cy="32" r="28" fill="url(#issue10-grad)" className="badge-main" />
-      {/* Warning triangle */}
-      <path d="M32 12L52 48H12L32 12Z" fill="white" opacity="0.95" />
-      {/* Exclamation mark */}
-      <rect x="29" y="22" width="6" height="14" rx="2" fill="#0284c7" />
-      <circle cx="32" cy="42" r="3" fill="#0284c7" />
-      {/* Number badge */}
-      <circle cx="48" cy="18" r="10" fill="#fbbf24" />
-      <text x="48" y="22" fontSize="10" fill="white" fontWeight="bold" textAnchor="middle">10</text>
-    </svg>
-  ),
-
-  // ISSUE-OPENER-25 - Radar/scanner detecting issues
-  'Issue-Opener-25': (
-    <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <defs>
-        <linearGradient id="issue25-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="#3b82f6" />
-          <stop offset="100%" stopColor="#1d4ed8" />
-        </linearGradient>
-      </defs>
-      {/* Star badge */}
-      <path d="M32 2L40 22L60 26L46 40L50 60L32 48L14 60L18 40L4 26L24 22L32 2Z"
-        fill="url(#issue25-grad)" className="badge-main" />
-      {/* Radar circles */}
-      <circle cx="32" cy="34" r="16" stroke="white" strokeWidth="2" fill="none" opacity="0.3" />
-      <circle cx="32" cy="34" r="11" stroke="white" strokeWidth="2" fill="none" opacity="0.5" />
-      <circle cx="32" cy="34" r="6" stroke="white" strokeWidth="2" fill="none" opacity="0.7" />
-      {/* Radar sweep */}
-      <path d="M32 34L32 18" stroke="white" strokeWidth="2" strokeLinecap="round" />
-      <path d="M32 34L44 26" stroke="white" strokeWidth="2" strokeLinecap="round" opacity="0.5" />
-      {/* Detected dots (issues found) */}
-      <circle cx="38" cy="28" r="3" fill="#ef4444" />
-      <circle cx="26" cy="38" r="2" fill="#ef4444" opacity="0.8" />
-      <circle cx="40" cy="40" r="2" fill="#ef4444" opacity="0.6" />
-      {/* Center */}
-      <circle cx="32" cy="34" r="3" fill="white" />
-      {/* Number badge */}
-      <circle cx="50" cy="50" r="10" fill="#fbbf24" />
-      <text x="50" y="54" fontSize="10" fill="white" fontWeight="bold" textAnchor="middle">25</text>
-    </svg>
-  ),
-
-  // EARLY CONTRIBUTOR - Pioneer/rocket ship
-  'Early-Contributor': (
-    <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <defs>
-        <linearGradient id="early-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="#f59e0b" />
-          <stop offset="100%" stopColor="#b45309" />
-        </linearGradient>
-      </defs>
-      {/* Circle badge */}
-      <circle cx="32" cy="32" r="28" fill="url(#early-grad)" className="badge-main" />
-      {/* Rocket ship */}
-      <path d="M32 8C32 8 24 20 24 32C24 40 28 46 32 46C36 46 40 40 40 32C40 20 32 8 32 8Z"
-        fill="white" opacity="0.95" />
-      {/* Rocket window */}
-      <circle cx="32" cy="24" r="5" fill="#f59e0b" />
-      <circle cx="32" cy="24" r="3" fill="white" opacity="0.5" />
-      {/* Rocket fins */}
-      <path d="M24 36L18 42L24 44Z" fill="white" opacity="0.9" />
-      <path d="M40 36L46 42L40 44Z" fill="white" opacity="0.9" />
-      {/* Rocket flames */}
-      <path d="M28 46L32 56L36 46" fill="#ef4444" />
-      <path d="M30 46L32 52L34 46" fill="#fbbf24" />
-      {/* Stars */}
-      <circle cx="14" cy="16" r="2" fill="white" opacity="0.8" />
-      <circle cx="50" cy="20" r="1.5" fill="white" opacity="0.6" />
-      <circle cx="18" cy="48" r="1.5" fill="white" opacity="0.7" />
-      <circle cx="48" cy="44" r="2" fill="white" opacity="0.8" />
-      {/* #1 badge */}
-      <circle cx="48" cy="14" r="8" fill="white" />
-      <text x="48" y="18" fontSize="9" fill="#b45309" fontWeight="bold" textAnchor="middle">#1</text>
-    </svg>
-  ),
-
-  // FIRST CONTRIBUTION - Calendar with star marking the date
-  'First-Contribution': (
-    <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <defs>
-        <linearGradient id="first-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="#8b5cf6" />
-          <stop offset="50%" stopColor="#7c3aed" />
-          <stop offset="100%" stopColor="#6d28d9" />
-        </linearGradient>
-        <linearGradient id="first-shine" x1="0%" y1="0%" x2="0%" y2="100%">
-          <stop offset="0%" stopColor="white" stopOpacity="0.3" />
-          <stop offset="100%" stopColor="white" stopOpacity="0" />
-        </linearGradient>
-      </defs>
-      {/* Shield/badge background */}
-      <path d="M32 4L54 14V34C54 46 44 56 32 60C20 56 10 46 10 34V14L32 4Z"
-        fill="url(#first-grad)" className="badge-main" />
-      <path d="M32 4L54 14V34C54 46 44 56 32 60C20 56 10 46 10 34V14L32 4Z"
-        fill="url(#first-shine)" />
-      {/* Calendar body */}
-      <rect x="18" y="20" width="28" height="28" rx="3" fill="white" opacity="0.95" />
-      {/* Calendar header */}
-      <rect x="18" y="20" width="28" height="8" rx="3" fill="#7c3aed" />
-      <rect x="18" y="24" width="28" height="4" fill="#7c3aed" />
-      {/* Calendar rings */}
-      <circle cx="24" cy="20" r="2" fill="white" opacity="0.9" />
-      <circle cx="32" cy="20" r="2" fill="white" opacity="0.9" />
-      <circle cx="40" cy="20" r="2" fill="white" opacity="0.9" />
-      {/* Calendar grid dots (days) */}
-      <circle cx="24" cy="32" r="1.5" fill="#7c3aed" opacity="0.3" />
-      <circle cx="30" cy="32" r="1.5" fill="#7c3aed" opacity="0.3" />
-      <circle cx="36" cy="32" r="1.5" fill="#7c3aed" opacity="0.3" />
-      <circle cx="42" cy="32" r="1.5" fill="#7c3aed" opacity="0.3" />
-      <circle cx="24" cy="37" r="1.5" fill="#7c3aed" opacity="0.3" />
-      <circle cx="30" cy="37" r="1.5" fill="#7c3aed" opacity="0.3" />
-      <circle cx="36" cy="37" r="1.5" fill="#7c3aed" opacity="0.3" />
-      <circle cx="42" cy="37" r="1.5" fill="#7c3aed" opacity="0.3" />
-      <circle cx="24" cy="42" r="1.5" fill="#7c3aed" opacity="0.3" />
-      <circle cx="30" cy="42" r="1.5" fill="#7c3aed" opacity="0.3" />
-      {/* Highlighted date with star - THE FIRST CONTRIBUTION */}
-      <circle cx="36" cy="42" r="5" fill="#fbbf24" />
-      <path d="M36 39L37 41.5L39.5 41.5L37.5 43L38 45.5L36 44L34 45.5L34.5 43L32.5 41.5L35 41.5Z"
-        fill="white" />
-      {/* Confetti/sparkle effects */}
-      <circle cx="14" cy="16" r="1.5" fill="#fbbf24" opacity="0.8" />
-      <circle cx="50" cy="18" r="1.5" fill="#ec4899" opacity="0.8" />
-      <circle cx="12" cy="44" r="1" fill="#10b981" opacity="0.7" />
-      <circle cx="52" cy="46" r="1" fill="#3b82f6" opacity="0.7" />
-      {/* #1 badge in corner */}
-      <circle cx="48" cy="14" r="7" fill="#fbbf24" />
-      <text x="48" y="18" fontSize="8" fill="white" fontWeight="bold" textAnchor="middle">#1</text>
-    </svg>
-  ),
-
-  // FIRST REVIEW - Document with checkmark and calendar date
-  'First-Review': (
-    <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <defs>
-        <linearGradient id="first-review-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="#10b981" />
-          <stop offset="50%" stopColor="#059669" />
-          <stop offset="100%" stopColor="#047857" />
-        </linearGradient>
-        <linearGradient id="first-review-shine" x1="0%" y1="0%" x2="0%" y2="100%">
-          <stop offset="0%" stopColor="white" stopOpacity="0.3" />
-          <stop offset="100%" stopColor="white" stopOpacity="0" />
-        </linearGradient>
-      </defs>
-      {/* Shield/badge background */}
-      <path d="M32 4L54 14V34C54 46 44 56 32 60C20 56 10 46 10 34V14L32 4Z"
-        fill="url(#first-review-grad)" className="badge-main" />
-      <path d="M32 4L54 14V34C54 46 44 56 32 60C20 56 10 46 10 34V14L32 4Z"
-        fill="url(#first-review-shine)" />
-      {/* Document body */}
-      <rect x="18" y="16" width="28" height="36" rx="3" fill="white" opacity="0.95" />
-      {/* Document fold corner */}
-      <path d="M40 16L46 22H40V16Z" fill="#059669" opacity="0.3" />
-      {/* Document lines */}
-      <rect x="22" y="24" width="18" height="2" rx="1" fill="#059669" opacity="0.3" />
-      <rect x="22" y="30" width="14" height="2" rx="1" fill="#059669" opacity="0.3" />
-      <rect x="22" y="36" width="16" height="2" rx="1" fill="#059669" opacity="0.3" />
-      {/* Big checkmark - review approved */}
-      <circle cx="32" cy="44" r="8" fill="#10b981" />
-      <path d="M28 44L31 47L37 41" stroke="white" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
-      {/* Sparkle effects */}
-      <circle cx="14" cy="16" r="1.5" fill="#fbbf24" opacity="0.8" />
-      <circle cx="50" cy="18" r="1.5" fill="#ec4899" opacity="0.8" />
-      <circle cx="12" cy="44" r="1" fill="#8b5cf6" opacity="0.7" />
-      <circle cx="52" cy="46" r="1" fill="#3b82f6" opacity="0.7" />
-      {/* #1 badge in corner */}
-      <circle cx="48" cy="14" r="7" fill="#fbbf24" />
-      <text x="48" y="18" fontSize="8" fill="white" fontWeight="bold" textAnchor="middle">#1</text>
-    </svg>
-  ),
-
-  // ACTIVE-LAST-7D - Lightning bolt with calendar
-  'Active-Last-7d': (
-    <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <defs>
-        <linearGradient id="active30-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="#10b981" />
-          <stop offset="100%" stopColor="#047857" />
-        </linearGradient>
-      </defs>
-      {/* Circle */}
-      <circle cx="32" cy="32" r="28" fill="url(#active30-grad)" className="badge-main" />
-      {/* Lightning bolt - energy/activity */}
-      <path d="M36 8L22 32H30L28 56L42 28H34L36 8Z" fill="white" opacity="0.95" />
-      {/* Inner bolt highlight */}
-      <path d="M34 14L26 30H32L30 48L40 32H34L34 14Z" fill="#10b981" opacity="0.3" />
-      {/* Pulse rings */}
-      <circle cx="32" cy="32" r="24" stroke="white" strokeWidth="1" opacity="0.2" />
-      <circle cx="32" cy="32" r="20" stroke="white" strokeWidth="1" opacity="0.3" />
-      {/* 7d indicator */}
-      <rect x="42" y="44" width="18" height="14" rx="2" fill="white" />
-      <text x="51" y="54" fontSize="8" fill="#047857" fontWeight="bold" textAnchor="middle">7d</text>
-    </svg>
-  ),
-
-  // ACTIVE-LAST-90D - Activity chart
-  'Active-Last-30d': (
-    <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <defs>
-        <linearGradient id="active90-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="#14b8a6" />
-          <stop offset="100%" stopColor="#0d9488" />
-        </linearGradient>
-      </defs>
-      {/* Rounded square */}
-      <rect x="4" y="4" width="56" height="56" rx="14" fill="url(#active90-grad)" className="badge-main" />
-      {/* Activity pulse line */}
-      <path d="M10 36L18 36L22 28L28 44L34 20L40 38L46 32L54 32"
-        stroke="white" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" fill="none" />
-      {/* Activity dots */}
-      <circle cx="22" cy="28" r="3" fill="white" />
-      <circle cx="28" cy="44" r="3" fill="white" />
-      <circle cx="34" cy="20" r="3" fill="white" />
-      <circle cx="40" cy="38" r="3" fill="white" />
-      {/* 30d label */}
-      <rect x="20" y="48" width="24" height="10" rx="2" fill="white" opacity="0.95" />
-      <text x="32" y="56" fontSize="8" fill="#0d9488" fontWeight="bold" textAnchor="middle">30 DAYS</text>
-    </svg>
+  // ACTIVE-LAST-30D - Same frame, activity trace instead of the bolt.
+  'Active-Last-30d': (uid: string) => (
+    <Svg>
+      <defs><Grad id={`${uid}-active30-grad`} from="#2dd4bf" to="#0f766e" /></defs>
+      <Squircle id={`${uid}-active30-grad`} />
+      <path
+        d="M11 30H19L24 18L31 41L37 25L42 33H53"
+        stroke="white"
+        strokeWidth="4.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <text x="32" y="56" fontSize="15" fontWeight="800" fill="white" textAnchor="middle" fontFamily={NUM_FONT}>30d</text>
+    </Svg>
   ),
 
   // NEW JOINER - Welcome with sparkles
-  'New-Joiner': (
+  'New-Joiner': (uid: string) => (
     <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
       <defs>
-        <linearGradient id="newbie-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+        <linearGradient id={`${uid}-newbie-grad`} x1="0%" y1="0%" x2="100%" y2="100%">
           <stop offset="0%" stopColor="#fde047" />
           <stop offset="100%" stopColor="#eab308" />
         </linearGradient>
       </defs>
       {/* Starburst */}
       <path d="M32 0L36 24L60 20L40 32L60 44L36 40L32 64L28 40L4 44L24 32L4 20L28 24L32 0Z"
-        fill="url(#newbie-grad)" className="badge-main" />
+        fill={`url(#${uid}-newbie-grad)`} className="badge-main" />
       {/* Welcome hand wave */}
       <circle cx="32" cy="32" r="14" fill="white" opacity="0.95" />
       <text x="32" y="38" fontSize="20" textAnchor="middle">👋</text>
@@ -707,45 +504,54 @@ export const BADGE_ICONS: Record<string, JSX.Element> = {
   ),
 
   // DORMANT-90D+ - Sleeping moon
-  'Dormant-90d+': (
+  'Dormant-90d+': (uid: string) => (
     <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
       <defs>
-        <linearGradient id="dormant-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+        <linearGradient id={`${uid}-dormant-grad`} x1="0%" y1="0%" x2="100%" y2="100%">
           <stop offset="0%" stopColor="#6b7280" />
           <stop offset="100%" stopColor="#374151" />
         </linearGradient>
+        {/* The crescent is cut out of a disc rather than drawn as two arcs. The
+            arc form needs a radius of at least half the distance between its
+            endpoints; ask for less and SVG silently scales it up, which turns
+            the crescent back into the full disc it was cut from. */}
+        <mask id={`${uid}-dormant-moon`}>
+          <rect width="64" height="64" fill="black" />
+          <circle cx="29" cy="34" r="21" fill="white" />
+          <circle cx="49" cy="24" r="18" fill="black" />
+        </mask>
       </defs>
       {/* Circle */}
-      <circle cx="32" cy="32" r="28" fill="url(#dormant-grad)" className="badge-main" />
+      <circle cx="32" cy="32" r="28" fill={`url(#${uid}-dormant-grad)`} className="badge-main" />
+      {/* Stars, in the night sky the crescent leaves open */}
+      <circle cx="45" cy="36" r="2" fill="white" opacity="0.5" />
+      <circle cx="52" cy="27" r="1.5" fill="white" opacity="0.45" />
+      <circle cx="49" cy="45" r="1.5" fill="white" opacity="0.5" />
       {/* Moon crescent */}
-      <path d="M38 14A18 18 0 1 1 38 50A14 14 0 1 0 38 14Z" fill="white" opacity="0.9" />
-      {/* Sleeping face on moon */}
-      <path d="M26 30C26 30 28 32 30 30" stroke="#374151" strokeWidth="1.5" strokeLinecap="round" />
-      <path d="M34 30C34 30 36 32 38 30" stroke="#374151" strokeWidth="1.5" strokeLinecap="round" />
-      <path d="M30 38C30 38 32 40 34 38" stroke="#374151" strokeWidth="1.5" strokeLinecap="round" />
+      <rect width="64" height="64" fill="white" opacity="0.95" mask={`url(#${uid}-dormant-moon)`} />
+      {/* Sleeping face on the lit side of the moon */}
+      <g stroke="#374151" strokeWidth="3" strokeLinecap="round" fill="none">
+        <path d="M11 31.5Q14.5 36 18 31.5" />
+        <path d="M22 31.5Q25.5 36 29 31.5" />
+        <path d="M16 41Q20 45.5 24 41" />
+      </g>
       {/* ZZZ */}
-      <text x="48" y="20" fontSize="10" fill="white" opacity="0.9" fontFamily="serif" fontStyle="italic" fontWeight="bold">Z</text>
-      <text x="52" y="14" fontSize="8" fill="white" opacity="0.7" fontFamily="serif" fontStyle="italic" fontWeight="bold">z</text>
-      <text x="55" y="10" fontSize="6" fill="white" opacity="0.5" fontFamily="serif" fontStyle="italic" fontWeight="bold">z</text>
-      {/* Stars */}
-      <circle cx="14" cy="18" r="1.5" fill="white" opacity="0.6" />
-      <circle cx="20" cy="12" r="1" fill="white" opacity="0.5" />
-      <circle cx="10" cy="26" r="1" fill="white" opacity="0.4" />
-      <circle cx="16" cy="48" r="1.5" fill="white" opacity="0.5" />
+      <text x="38" y="26" fontSize="16" fill="white" opacity="0.95" fontFamily="serif" fontStyle="italic" fontWeight="bold">Z</text>
+      <text x="45" y="18" fontSize="10.5" fill="white" opacity="0.7" fontFamily="serif" fontStyle="italic" fontWeight="bold">z</text>
     </svg>
   ),
 
   // DEFAULT - Generic achievement badge
-  'default': (
+  'default': (uid: string) => (
     <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
       <defs>
-        <linearGradient id="default-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+        <linearGradient id={`${uid}-default-grad`} x1="0%" y1="0%" x2="100%" y2="100%">
           <stop offset="0%" stopColor="#6366f1" />
           <stop offset="100%" stopColor="#4338ca" />
         </linearGradient>
       </defs>
       {/* Hexagon */}
-      <path d="M32 4L56 18V46L32 60L8 46V18L32 4Z" fill="url(#default-grad)" className="badge-main" />
+      <path d="M32 4L56 18V46L32 60L8 46V18L32 4Z" fill={`url(#${uid}-default-grad)`} className="badge-main" />
       {/* Inner hexagon */}
       <path d="M32 12L48 22V42L32 52L16 42V22L32 12Z" stroke="white" strokeWidth="2" fill="none" opacity="0.3" />
       {/* Star */}
@@ -754,15 +560,27 @@ export const BADGE_ICONS: Record<string, JSX.Element> = {
   )
 };
 
+export function badgeIconUid(...parts: (string | number | undefined)[]): string {
+  return parts
+    .filter((part) => part !== undefined && part !== '')
+    .join('-')
+    .replace(/[^A-Za-z0-9_-]/g, '-');
+}
+
+export function renderBadgeIcon(name: string, uid: string): JSX.Element {
+  return (BADGE_ICONS[name] || BADGE_ICONS['default'])(uid);
+}
+
 interface BadgeIconProps {
   name: string;
   isNew: boolean;
+  uid: string;
 }
 
-export function BadgeIcon({ name, isNew }: BadgeIconProps) {
+export function BadgeIcon({ name, isNew, uid }: BadgeIconProps) {
   return (
     <div className={`badge-icon-container ${isNew ? 'badge-new' : ''}`}>
-      {BADGE_ICONS[name] || BADGE_ICONS['default']}
+      {renderBadgeIcon(name, uid)}
     </div>
   );
 }

--- a/docs/pages/contribute/spotlight-zone.mdx
+++ b/docs/pages/contribute/spotlight-zone.mdx
@@ -8,11 +8,9 @@ import { Contributors, BadgeLegend, ContributeFooter } from '../../../components
 
 This is the current list of individuals who have made substantial contributions to the project and deserve recognition.
 
-To understand what each badge represents, refer to the [Badge Legend](#badge-legend) at the bottom of this page.
+<BadgeLegend />
 
 <Contributors />
-
-<BadgeLegend />
 
 ---
 


### PR DESCRIPTION
<!--
Thanks for contributing! New here? Skim the contributor guide first:
https://frameworks.securityalliance.dev/contribute/contributing
-->

### What does this PR change?
<!-- A short summary: what you changed and why. -->
<!-- Opened an issue first, or completing one? Add "Closes #123" here so the issue auto-closes when this PR merges. -->
## Spotlight Zone: badge icons and legend rework
- Moved the legend above the contributor list as a collapsible panel, and added a Tiers section explaining each rank.
- Sort contributors by earned badges first, then activity status, then recency, using the most recent activity date rather than the first found.
- Renamed the medal tiers to Bronze / Silver / Gold (25 was "Diamond"), reviewers to Trusted / Senior, issue rungs to Reporter / Observer / Investigator, and promoted `Lead` to legendary.
- Activity badges show "Status" on the tooltip instead of a rarity.
- Fixed badge dates shifting a day by timezone, gave badge cards a proper `role="img"` label, and removed the unused intersection observer hook.
- Rebuilt badge icons on shared SVG primitives, with per-render unique gradient ids so badges no longer collide when the same one appears on several cards.

have a look at it here -> https://chore-spotlight-zone.frameworks-573.pages.dev/contribute/spotlight-zone

### Type of change
- [ ] New content
- [ ] Edit to existing content
- [ ] Outline / structure change
- [ ] Typo or formatting fix
- [x] Tooling / config

### If applicable
- [ ] Editing existing content: tagged the current contributors from the attribution list
- [ ] Framework has a steward: asked them to review
- [ ] Outline change: updated `vocs.config.ts` with the `dev: true` parameter
- [ ] Want community feedback: shared this PR in our Discord

Stuck on anything? Just write it here and we're happy to help.
