### PR TITLE
Chore: Remove dev:true from "Policy as Code" section

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -133,13 +133,12 @@ const config = {
             { text: 'Integrated Development Environments', link: '/devsecops/integrated-development-environments' },
             {
               text: 'Policy as Code',
-              collapsed: true,
-              dev: true,
+              collapsed: false,
               items: [
-                { text: 'Overview', link: '/devsecops/policy-as-code/overview', dev: true },
-                { text: 'Policy in the CI Pipeline', link: '/devsecops/policy-as-code/ci-pipeline', dev: true },
-                { text: 'Policy in Release and Runtime', link: '/devsecops/policy-as-code/release-and-runtime', dev: true },
-                { text: 'Governing the Policy Set', link: '/devsecops/policy-as-code/governance', dev: true },
+                { text: 'Overview', link: '/devsecops/policy-as-code/overview' },
+                { text: 'Policy in the CI Pipeline', link: '/devsecops/policy-as-code/ci-pipeline' },
+                { text: 'Policy in Release and Runtime', link: '/devsecops/policy-as-code/release-and-runtime' },
+                { text: 'Governing the Policy Set', link: '/devsecops/policy-as-code/governance' },
               ]
             },
             { text: 'Repository Hardening', link: '/devsecops/repository-hardening' },


### PR DESCRIPTION
<!--
Thanks for contributing! New here? Skim the contributor guide first:
https://frameworks.securityalliance.dev/contribute/contributing
-->

### What does this PR change?
<!-- A short summary: what you changed and why. -->
<!-- Opened an issue first, or completing one? Add "Closes #123" here so the issue auto-closes when this PR merges. -->
Remove dev:true from "Policy as Code" section

### Type of change
- [ ] New content
- [ ] Edit to existing content
- [ ] Outline / structure change
- [ ] Typo or formatting fix
- [ ] Tooling / config

### If applicable
- [ ] Editing existing content: tagged the current contributors from the attribution list
- [ ] Framework has a steward: asked them to review
- [ ] Outline change: updated `vocs.config.ts` with the `dev: true` parameter
- [ ] Want community feedback: shared this PR in our Discord

Stuck on anything? Just write it here and we're happy to help.
